### PR TITLE
Add devcontainer and pave the way for ingress access

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.8-buster
+
+# copy the requirements file into the image
+COPY requirements.txt requirements.txt
+COPY requirements_webserver.txt requirements_webserver.txt
+
+# Setup
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        coinor-cbc \
+        coinor-libcbc-dev \
+        gcc \
+        gfortran \
+        libhdf5-dev \
+        libhdf5-serial-dev \
+        libnetcdf-dev \
+        netcdf-bin \
+    && ln -s /usr/include/hdf5/serial /usr/include/hdf5/include \
+    && export HDF5_DIR=/usr/include/hdf5 \
+    && pip install netCDF4 \
+    && apt-get purge -y --auto-remove \
+        gcc \
+        libhdf5-dev \
+        libhdf5-serial-dev \
+        netcdf-bin \
+        libnetcdf-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install -r requirements_webserver.txt

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,29 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/python:1-3.8-buster
 
-# copy the requirements file into the image
-COPY requirements.txt requirements.txt
-COPY requirements_webserver.txt requirements_webserver.txt
-
-# Setup
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        coinor-cbc \
-        coinor-libcbc-dev \
-        gcc \
-        gfortran \
-        libhdf5-dev \
-        libhdf5-serial-dev \
-        libnetcdf-dev \
-        netcdf-bin \
-    && ln -s /usr/include/hdf5/serial /usr/include/hdf5/include \
-    && export HDF5_DIR=/usr/include/hdf5 \
-    && pip install netCDF4 \
-    && apt-get purge -y --auto-remove \
-        gcc \
-        libhdf5-dev \
-        libhdf5-serial-dev \
-        netcdf-bin \
-        libnetcdf-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip install -r requirements_webserver.txt
+COPY .devcontainer/setup.sh requirements.txt requirements_webserver.txt ./
+RUN ./setup.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "EMHASS",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	}
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,9 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": ".."
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
 	}
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+main() {
+    set -x
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        coinor-cbc \
+        coinor-libcbc-dev \
+        gcc \
+        gfortran \
+        libhdf5-dev \
+        libhdf5-serial-dev \
+        libnetcdf-dev \
+        netcdf-bin
+
+    ln -s /usr/include/hdf5/serial /usr/include/hdf5/include
+    export HDF5_DIR=/usr/include/hdf5
+    pip install netCDF4
+
+    pip install -r requirements_webserver.txt
+
+    rm -rf "$0"
+}
+
+main

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3.8-slim-buster
 WORKDIR /app
 
 # copy the requirements file into the image
+COPY requirements.txt requirements.txt
 COPY requirements_webserver.txt requirements_webserver.txt
 COPY setup.py setup.py
 COPY README.md README.md

--- a/requirements_webserver.txt
+++ b/requirements_webserver.txt
@@ -1,16 +1,4 @@
-wheel
-numpy==1.22.2
-pandas==1.4.1
-scipy<1.9.0
-pvlib>=0.10.1
-protobuf>=3.0.0
-pytz>=2021.1
-requests>=2.25.1
-beautifulsoup4>=4.9.3
-pulp>=2.4
-pyyaml>=5.4.1
-tables==3.7.0
-skforecast==0.9.1
+-r requirements.txt
 flask>=2.0.3
 waitress>=2.1.1
 plotly>=5.6.0

--- a/src/emhass/templates/index.html
+++ b/src/emhass/templates/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
         <title>EMHASS: Energy Management Optimization for Home Assistant</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="stylesheet" type="text/css" href="../static/style.css">
+        <link rel="stylesheet" type="text/css" href="{{ basename }}/static/style.css">
     </head>
     <body>
         <center>
@@ -14,8 +13,8 @@
             <div align="center" class="form">
                 <form action="" method="get">
                     <h4 style="font-family: Helvetica;color: darkblue;">Use the buttons below to manually  launch different optimization tasks</h4>
-                    <button type="button" id="perfect-optimization" class="button button1" >Perfect Optimization</button>
-                    <button type="button" id="dayahead-optimization" class="button button2" >Day-ahead Optimization</button>
+                    <button type="button" id="perfect-optim" class="button button1" >Perfect Optimization</button>
+                    <button type="button" id="dayahead-optim" class="button button2" >Day-ahead Optimization</button>
                     <h4 style="font-family: Helvetica;color: darkblue;">Use the button below to publish the optimized variables at the current timestamp</h4>
                     <button type="button" id="publish-data" class="button button1" >Publish Optimization Results</button>
                     <h4 style="font-family: Helvetica;color: darkblue;">Use the buttons below to fit, predict and tune a machine learning model for testing</h4>
@@ -43,118 +42,23 @@
         </footer>
     </body>
     <script>
-        document.getElementById('perfect-optimization').addEventListener('click', function() {
-            var url = "/action/perfect-optim"
-            var settings = {
-            "async": true,
-            "crossDomain": true,
-            "url": url,
-            "method": "POST",
-            "headers": {
-                'Content-Type':'application/json'
-            },
-            "dataType": 'json',
-            "data": '{}'
-            }
-            $.ajax(settings).done(function (response) {
+        async function performAction(action) {
+            await fetch(`{{ basename }}/action/${action}`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: "{}",
             });
-        });
-        document.getElementById('dayahead-optimization').addEventListener('click', function() {
-            var url = "/action/dayahead-optim"
-            var settings = {
-            "async": true,
-            "crossDomain": true,
-            "url": url,
-            "method": "POST",
-            "headers": {
-                'Content-Type':'application/json'
-            },
-            "dataType": 'json',
-            "data": '{}'
-            }
-            $.ajax(settings).done(function (response) {
-            });
-        });
-        document.getElementById('publish-data').addEventListener('click', function() {
-            var url = "/action/publish-data"
-            var settings = {
-            "async": true,
-            "crossDomain": true,
-            "url": url,
-            "method": "POST",
-            "headers": {
-                'Content-Type':'application/json'
-            },
-            "dataType": 'json',
-            "data": '{}'
-            }
-            $.ajax(settings).done(function (response) {
-            });
-        });
-        // document.getElementById('forecast-model-fit').addEventListener('click', function() {
-        //     var formData = $("runtimeparams").serialize();
-        //     // send ajax
-        //     $.ajax({
-        //         url: "/action/forecast-model-fit",
-        //         type : "POST",
-        //         contentType : "application/json;charset=UTF-8",
-        //         dataType : 'json',
-        //         data : formData,
-        //         success : function(result) {
-        //             console.log(result);
-        //         },
-        //         error: function(xhr, resp, text) {
-        //             console.log(xhr, resp, text);
-        //         }
-        //     })
-        // });
-        document.getElementById('forecast-model-fit').addEventListener('click', function() {
-            var url = "/action/forecast-model-fit"
-            var settings = {
-            "async": true,
-            "crossDomain": true,
-            "url": url,
-            "method": "POST",
-            "headers": {
-                'Content-Type':'application/json'
-            },
-            "dataType": 'json',
-            "data": '{}'
-            }
-            $.ajax(settings).done(function (response) {
-            });
-        });
-        document.getElementById('forecast-model-predict').addEventListener('click', function() {
-            var url = "/action/forecast-model-predict"
-            var settings = {
-            "async": true,
-            "crossDomain": true,
-            "url": url,
-            "method": "POST",
-            "headers": {
-                'Content-Type':'application/json'
-            },
-            "dataType": 'json',
-            "data": '{}'
-            }
-            $.ajax(settings).done(function (response) {
-            });
-        });
-        document.getElementById('forecast-model-tune').addEventListener('click', function() {
-            var url = "/action/forecast-model-tune"
-            var settings = {
-            "async": true,
-            "crossDomain": true,
-            "url": url,
-            "method": "POST",
-            "headers": {
-                'Content-Type':'application/json'
-            },
-            "dataType": 'json',
-            "data": '{}'
-            }
-            $.ajax(settings).done(function (response) {
-            });
-        });
+        }
+
+        [
+            "dayahead-optim",
+            "forecast-model-fit",
+            "forecast-model-predict",
+            "forecast-model-tune",
+            "perfect-optim",
+            "publish-data",
+        ].forEach((id) => document.getElementById(id).addEventListener('click', () => performAction(id)));
     </script>
 </html>

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -166,7 +166,8 @@ def index():
     else:
         app.logger.warning("The data container dictionary is empty... Please launch an optimization task")
         injection_dict={}
-    return make_response(template.render(injection_dict=injection_dict))
+    basename = request.headers.get("X-Ingress-Path", "")
+    return make_response(template.render(injection_dict=injection_dict, basename=basename))
 
 @app.route('/action/<action_name>', methods=['POST'])
 def action_call(action_name):


### PR DESCRIPTION
Closes: #22 

![image](https://github.com/davidusb-geek/emhass/assets/16530283/9d0c4fc6-d7aa-4959-aabb-c30c8b1bfde0)

The only way to see that it's working in this image is because the styles are loaded. But trust me, the buttons are working too.

---

This PR enables support for the Home Assistant ingress by reading the contents of the standard `X-Ingress-Path` header. This header is also used by many other reverse proxies, so this will allow them to function correctly on sub paths as well.
If there's no reverse proxy in front of emhass, it will work like before, so this won't break the non-addon setup.

There are also two other changes in this PR:

- I added a devcontainer that allows new contributors to get into the project more quickly. It's very bare-bones at the moment, but it can run the emhass web server without problems (which is how I was working on this project).
- Removed duplication from the "requirements*.txt" files by referencing the main dependencies in the web server one.

I'm of course happy to remove these changes from this PR if you wish.

There will be a separate PR over at [davidusb-geek/emhass-add-on](https://github.com/davidusb-geek/emhass-add-on) that's required before the ingress actually works.