### PR TITLE
Improvements in the documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -78,7 +78,7 @@ The following parameters and definitions are only needed if load_cost_forecast_m
 - set_nodischarge_to_grid: Set this to true if you want to forbidden to discharge the battery power to the grid.
 - set_battery_dynamic: Set a power dynamic limiting condition to the battery power. This is an additional constraint on the battery dynamic in power per unit of time, which allows you to set a percentage of the battery nominal full power as the maximum power allowed for (dis)charge.
 - battery_dynamic_max: The maximum positive (for discharge) battery power dynamic. This is the allowed power variation (in percentage) of battery maximum power per unit of time.
-- battery_dynamic_min: The minimum negative (for charge) battery power dynamic. This is the allowed power variation (in percentage) of battery maximum power per unit of time.
+- battery_dynamic_min: The maximum negative (for charge) battery power dynamic. This is the allowed power variation (in percentage) of battery maximum power per unit of time.
 
 ## System configuration parameters
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -76,9 +76,9 @@ The following parameters and definitions are only needed if load_cost_forecast_m
 - lp_solver_path: Set the path to the LP solver. Defaults to '/usr/bin/cbc'. 
 - set_nocharge_from_grid: Set this to true if you want to forbidden to charge the battery from the grid. The battery will only be charged from excess PV.
 - set_nodischarge_to_grid: Set this to true if you want to forbidden to discharge the battery power to the grid.
-- set_battery_dynamic: Set a power dynamic limiting condition to the battery power. This is an additional constraint on the battery dynamic in power per unit of time.
-- battery_dynamic_max: The maximum positive battery power dynamic. This is the power variation in percentage of battery maximum power.
-- battery_dynamic_min: The minimum negative battery power dynamic. This is the power variation in percentage of battery maximum power.
+- set_battery_dynamic: Set a power dynamic limiting condition to the battery power. This is an additional constraint on the battery dynamic in power per unit of time, which allows you to set a percentage of the battery nominal full power as the maximum power allowed for (dis)charge.
+- battery_dynamic_max: The maximum positive (for charge) battery power dynamic. This is the allowed power variation (in percentage) of battery maximum power per unit of time.
+- battery_dynamic_min: The minimum negative (for discharge) battery power dynamic. This is the allowed power variation (in percentage) of battery maximum power per unit of time.
 
 ## System configuration parameters
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -49,7 +49,7 @@ These are the parameters needed to properly define the optimization problem.
 - def_total_hours: The total number of hours that each deferrable load should operate. For example:
 	- 5
 	- 8
-- treat_def_as_semi_cont: Define if we should treat each deferrable load as a semi-continuous variable. Semi-continuous variables are variables that must take a value between their minimum and maximum or zero. For example:
+- treat_def_as_semi_cont: Define if we should treat each deferrable load as a semi-continuous variable. Semi-continuous variables (`True`) are variables that must take a value that can be either their maximum or minimum/zero (for example On = Maximum load, Off = 0 W). Non semi-continuous (which means continuous) variables (`False`) can take any values between their maximum and minimum. For example:
 	- True
 	- True
 - set_def_constant: Define if we should set each deferrable load as a constant fixed value variable with just one startup for each optimization task. For example:

--- a/docs/config.md
+++ b/docs/config.md
@@ -77,8 +77,8 @@ The following parameters and definitions are only needed if load_cost_forecast_m
 - set_nocharge_from_grid: Set this to true if you want to forbidden to charge the battery from the grid. The battery will only be charged from excess PV.
 - set_nodischarge_to_grid: Set this to true if you want to forbidden to discharge the battery power to the grid.
 - set_battery_dynamic: Set a power dynamic limiting condition to the battery power. This is an additional constraint on the battery dynamic in power per unit of time, which allows you to set a percentage of the battery nominal full power as the maximum power allowed for (dis)charge.
-- battery_dynamic_max: The maximum positive (for charge) battery power dynamic. This is the allowed power variation (in percentage) of battery maximum power per unit of time.
-- battery_dynamic_min: The minimum negative (for discharge) battery power dynamic. This is the allowed power variation (in percentage) of battery maximum power per unit of time.
+- battery_dynamic_max: The maximum positive (for discharge) battery power dynamic. This is the allowed power variation (in percentage) of battery maximum power per unit of time.
+- battery_dynamic_min: The minimum negative (for charge) battery power dynamic. This is the allowed power variation (in percentage) of battery maximum power per unit of time.
 
 ## System configuration parameters
 

--- a/docs/lpems.md
+++ b/docs/lpems.md
@@ -180,7 +180,7 @@ This type of controller performs the following actions:
 - Apply the first element of the obtained optimized control variables.
 - Repeat at a relatively high frequency, ex: 5 min.
 
-On the example diagram presented before, the MPC is performed on 6h intervals at 6h, 12h and 18h. The prediction horizon is redecing to keep the one-day energy optimization notion. This type of optimization is used to take advantage of actualized forecast values during throughout the day. The user can of course choose higher implementation intervals.
+On the example diagram presented before, the MPC is performed on 6h intervals at 6h, 12h and 18h. The prediction horizon is progressively reducing during the day to keep the one-day energy optimization notion (it should not just be a fixed rolling window as, for example, you would like to know when you want to reach the desired `soc_final`). This type of optimization is used to take advantage of actualized forecast values during throughout the day. The user can of course choose higher/lower implementation intervals, keeping in mind the contraints below on the `prediction_horizon`.
 
 When applying this controller, the following `runtimeparams` should be defined:
 


### PR DESCRIPTION
I would ask you to review the definitions of the battery_dynamics, as a bit unclear to me in regards to an explanation you gave in a post of the component thread. If I correctly understood we are just putting a constraint in the maximum allowed (dis)charge power of the battery (and not a constraint on the minimum allowed (dis)charge power), the use of the word "min" in the name of the parameter is a bit misleading.
Your input is welcome on this.

I also fixed what I think is a typo and expanded the section that explain the idea behind the reducing horizon in MPC.