### PR TITLE
Update optimization.py

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -204,10 +204,10 @@ class optimization:
                                       for i in set_I)
         elif self.costfun == 'cost':
             if self.optim_conf['set_total_pv_sell']:
-                objective = plp.lpSum(-0.001*self.timeStep*unit_load_cost[i]*P_grid_pos[i]
+                objective = plp.lpSum(-0.001*self.timeStep*unit_load_cost[i]*(P_load[i] + P_def_sum[i])
                                       for i in set_I)
             else:
-                objective = plp.lpSum(-0.001*self.timeStep*unit_load_cost[i]*(P_load[i] + P_def_sum[i])
+                objective = plp.lpSum(-0.001*self.timeStep*unit_load_cost[i]*P_grid_pos[i]
                                       for i in set_I)
         elif self.costfun == 'self-consumption':
             if type_self_conso == 'bigm':

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -450,7 +450,10 @@ class optimization:
                 opt_tp["cost_fun_profit"] = [-0.001*self.timeStep*(unit_load_cost[i]*P_grid_pos[i].varValue + \
                     unit_prod_price[i]*P_grid_neg[i].varValue) for i in set_I]
         elif self.costfun == 'cost':
-            opt_tp["cost_fun_cost"] = [-0.001*self.timeStep*unit_load_cost[i]*(P_load[i] + P_def_sum_tp[i]) for i in set_I]
+            if self.optim_conf['set_total_pv_sell']:
+                opt_tp["cost_fun_cost"] = [-0.001*self.timeStep*unit_load_cost[i]*(P_load[i] + P_def_sum_tp[i]) for i in set_I]
+            else:
+                opt_tp["cost_fun_cost"] = [-0.001*self.timeStep*unit_load_cost[i]*P_grid_pos[i].varValue for i in set_I]
         elif self.costfun == 'self-consumption':
             if type_self_conso == 'maxmin':
                 opt_tp["cost_fun_selfcons"] = [-0.001*self.timeStep*unit_load_cost[i]*SC[i].varValue for i in set_I]


### PR DESCRIPTION
# Implemented changes: 

- Inverted the objective formulas in the case of "grid cost" cost function
- Changed the cost calculation to be consistent with the objective formula, in case of "grid cost" cost function (the cost calculation didn't distinguish between set_total_pv_sell = TRUE vs FALSE, whereas the objective function did).

# To resolve following issue:
While looking at the code in order to understand the functioning of EMHASS, I noticed an inconsistency in the objective formulas.
The profit cost function shows this:
https://github.com/davidusb-geek/emhass/blob/bec6f76f1d7795a1ab8730fb0a61f883e75caf0c/src/emhass/optimization.py#L196-L204
which looks correct, and is consistent with the EMHASS documentation:

- In the case of an energy contract where the totality of the PV produced energy is injected into the grid, the grid offtake volume equals = P_load + P_deferrable_sum
- Else (only the excess of PV produced energy is injected), the grid offtake equals = P_grid_pos

However, the "grid cost" cost function seems to have the formulas inverted, which is unexpected:
https://github.com/davidusb-geek/emhass/blob/bec6f76f1d7795a1ab8730fb0a61f883e75caf0c/src/emhass/optimization.py#L205-L211

Therefore, I wonder if the objective formulas in "Grid cost" cost function shouldn't be inverted.