### PR TITLE
Dynamic paths with emhass config dict, some mlforcaster error suppression

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -23,21 +23,19 @@ from emhass.optimization import Optimization
 from emhass import utils
 
 
-def set_input_data_dict(config_path: pathlib.Path, base_path: str, costfun: str, 
+def set_input_data_dict(emhass_conf: dict, costfun: str, 
     params: str, runtimeparams: str, set_type: str, logger: logging.Logger,
     get_data_from_file: Optional[bool] = False) -> dict:
     """
     Set up some of the data needed for the different actions.
     
-    :param config_path: The complete absolute path where the config.yaml file is located
-    :type config_path: pathlib.Path
-    :param base_path: The parent folder of the config_path
-    :type base_path: str
+    :param emhass_conf: Dictionary containing the needed emhass paths
+    :type emhass_conf: dict
     :param costfun: The type of cost function to use for optimization problem
     :type costfun: str
     :param params: Configuration parameters passed from data/options.json
     :type params: str
-    :param runtimeparams: Runtime optimization parameters passed as a dictionnary
+    :param runtimeparams: Runtime optimization parameters passed as a dictionary
     :type runtimeparams: str
     :param set_type: Set the type of setup based on following type of optimization
     :type set_type: str
@@ -52,7 +50,7 @@ def set_input_data_dict(config_path: pathlib.Path, base_path: str, costfun: str,
     logger.info("Setting up needed data")
     # Parsing yaml
     retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(
-        config_path, use_secrets=not(get_data_from_file), params=params)
+        emhass_conf['config_path'], use_secrets=not(get_data_from_file), params=params)
     # Treat runtimeparams
     params, retrieve_hass_conf, optim_conf, plant_conf = utils.treat_runtimeparams(
         runtimeparams, params, retrieve_hass_conf, 
@@ -60,17 +58,17 @@ def set_input_data_dict(config_path: pathlib.Path, base_path: str, costfun: str,
     # Define main objects
     rh = RetrieveHass(retrieve_hass_conf['hass_url'], retrieve_hass_conf['long_lived_token'], 
                       retrieve_hass_conf['freq'], retrieve_hass_conf['time_zone'], 
-                      params, base_path, logger, get_data_from_file=get_data_from_file)
+                      params, emhass_conf, logger, get_data_from_file=get_data_from_file)
     fcst = Forecast(retrieve_hass_conf, optim_conf, plant_conf,
-                    params, base_path, logger, get_data_from_file=get_data_from_file)
+                    params, emhass_conf, logger, get_data_from_file=get_data_from_file)
     opt = Optimization(retrieve_hass_conf, optim_conf, plant_conf, 
                        fcst.var_load_cost, fcst.var_prod_price, 
-                       costfun, base_path, logger)
+                       costfun, emhass_conf, logger)
     # Perform setup based on type of action
     if set_type == "perfect-optim":
         # Retrieve data from hass
         if get_data_from_file:
-            with open(pathlib.Path(base_path) / 'data' / 'test_df_final.pkl', 'rb') as inp:
+            with open(emhass_conf['data_path'] / 'test_df_final.pkl', 'rb') as inp:
                 rh.df_final, days_list, var_list = pickle.load(inp)
         else:
             days_list = utils.get_days_list(retrieve_hass_conf['days_to_retrieve'])
@@ -107,7 +105,7 @@ def set_input_data_dict(config_path: pathlib.Path, base_path: str, costfun: str,
     elif set_type == "naive-mpc-optim":
         # Retrieve data from hass
         if get_data_from_file:
-            with open(pathlib.Path(base_path) / 'data' / 'test_df_final.pkl', 'rb') as inp:
+            with open(emhass_conf['data_path'] / 'test_df_final.pkl', 'rb') as inp:
                 rh.df_final, days_list, var_list = pickle.load(inp)
         else:
             days_list = utils.get_days_list(1)
@@ -125,6 +123,9 @@ def set_input_data_dict(config_path: pathlib.Path, base_path: str, costfun: str,
         df_weather = fcst.get_weather_forecast(method=optim_conf['weather_forecast_method'])
         P_PV_forecast = fcst.get_power_from_weather(df_weather, set_mix_forecast=True, df_now=df_input_data)
         P_load_forecast = fcst.get_load_forecast(method=optim_conf['load_forecast_method'], set_mix_forecast=True, df_now=df_input_data)
+        if isinstance(P_load_forecast,bool) and not P_load_forecast:
+            logger.error("Unable to get sensor power photovoltaics, or sensor power load no var loads. Check HA sensors and their daily data")
+            return False
         df_input_data_dayahead = pd.concat([P_PV_forecast, P_load_forecast], axis=1)
         df_input_data_dayahead = utils.set_df_index_freq(df_input_data_dayahead)
         df_input_data_dayahead.columns = ['P_PV_forecast', 'P_load_forecast']
@@ -143,7 +144,7 @@ def set_input_data_dict(config_path: pathlib.Path, base_path: str, costfun: str,
         if get_data_from_file:
             days_list = None
             filename = 'data_train_'+model_type+'.pkl'
-            data_path = pathlib.Path(base_path) / 'data' / filename
+            data_path = emhass_conf['data_path'] / filename
             with open(data_path, 'rb') as inp:
                 df_input_data, _ = pickle.load(inp)
             df_input_data = df_input_data[df_input_data.index[-1] - pd.offsets.Day(days_to_retrieve):]
@@ -163,9 +164,9 @@ def set_input_data_dict(config_path: pathlib.Path, base_path: str, costfun: str,
         P_PV_forecast, P_load_forecast = None, None
         days_list = None
 
-    # The input data dictionnary to return
+    # The input data dictionary to return
     input_data_dict = {
-        'root': base_path,
+        'emhass_conf': emhass_conf,
         'retrieve_hass_conf': retrieve_hass_conf,
         'rh': rh,
         'opt': opt,
@@ -211,7 +212,7 @@ def perfect_forecast_optim(input_data_dict: dict, logger: logging.Logger,
     else: # Just save the latest optimization results
         filename = 'opt_res_latest.csv'
     if not debug:
-        opt_res.to_csv(pathlib.Path(input_data_dict['root']) / filename, index_label='timestamp')
+        opt_res.to_csv(pathlib.Path(input_data_dict['emhass_conf']['data_path']) / filename, index_label='timestamp')
     return opt_res
     
 def dayahead_forecast_optim(input_data_dict: dict, logger: logging.Logger,
@@ -248,7 +249,7 @@ def dayahead_forecast_optim(input_data_dict: dict, logger: logging.Logger,
     else: # Just save the latest optimization results
         filename = 'opt_res_latest.csv'
     if not debug:
-        opt_res_dayahead.to_csv(pathlib.Path(input_data_dict['root']) / filename, index_label='timestamp')
+        opt_res_dayahead.to_csv(pathlib.Path(input_data_dict['emhass_conf']['data_path']) / filename, index_label='timestamp')
     return opt_res_dayahead
 
 def naive_mpc_optim(input_data_dict: dict, logger: logging.Logger,
@@ -292,7 +293,7 @@ def naive_mpc_optim(input_data_dict: dict, logger: logging.Logger,
     else: # Just save the latest optimization results
         filename = 'opt_res_latest.csv'
     if not debug:
-        opt_res_naive_mpc.to_csv(pathlib.Path(input_data_dict['root']) / filename, index_label='timestamp')
+        opt_res_naive_mpc.to_csv(pathlib.Path(input_data_dict['emhass_conf']['data_path']) / filename, index_label='timestamp')
     return opt_res_naive_mpc
 
 def forecast_model_fit(input_data_dict: dict, logger: logging.Logger,
@@ -315,16 +316,16 @@ def forecast_model_fit(input_data_dict: dict, logger: logging.Logger,
     num_lags = input_data_dict['params']['passed_data']['num_lags']
     split_date_delta = input_data_dict['params']['passed_data']['split_date_delta']
     perform_backtest = input_data_dict['params']['passed_data']['perform_backtest']
-    root = input_data_dict['root']
+    data_path = input_data_dict['emhass_conf']['data_path']
     # The ML forecaster object
-    mlf = MLForecaster(data, model_type, var_model, sklearn_model, num_lags, root, logger)
+    mlf = MLForecaster(data, model_type, var_model, sklearn_model, num_lags, input_data_dict['emhass_conf'], logger)
     # Fit the ML model
     df_pred, df_pred_backtest = mlf.fit(split_date_delta=split_date_delta, 
                                         perform_backtest=perform_backtest)
     # Save model
     if not debug:
         filename = model_type+'_mlf.pkl'
-        with open(pathlib.Path(root) / filename, 'wb') as outp:
+        with open(pathlib.Path(data_path) / filename, 'wb') as outp:
             pickle.dump(mlf, outp, pickle.HIGHEST_PROTOCOL)
     return df_pred, df_pred_backtest, mlf
 
@@ -353,9 +354,9 @@ def forecast_model_predict(input_data_dict: dict, logger: logging.Logger,
     """
     # Load model
     model_type = input_data_dict['params']['passed_data']['model_type']
-    root = input_data_dict['root']
+    data_path = input_data_dict['emhass_conf']['data_path']
     filename = model_type+'_mlf.pkl'
-    filename_path = pathlib.Path(root) / filename
+    filename_path = pathlib.Path(data_path) / filename
     if not debug:
         if filename_path.is_file():
             with open(filename_path, 'rb') as inp:
@@ -414,9 +415,9 @@ def forecast_model_tune(input_data_dict: dict, logger: logging.Logger,
     """
     # Load model
     model_type = input_data_dict['params']['passed_data']['model_type']
-    root = input_data_dict['root']
+    data_path = input_data_dict['emhass_conf']['data_path']
     filename = model_type+'_mlf.pkl'
-    filename_path = pathlib.Path(root) / filename
+    filename_path = pathlib.Path(data_path) / filename
     if not debug:
         if filename_path.is_file():
             with open(filename_path, 'rb') as inp:
@@ -429,7 +430,7 @@ def forecast_model_tune(input_data_dict: dict, logger: logging.Logger,
     # Save model
     if not debug:
         filename = model_type+'_mlf.pkl'
-        with open(pathlib.Path(root) / filename, 'wb') as outp:
+        with open(pathlib.Path(data_path) / filename, 'wb') as outp:
             pickle.dump(mlf, outp, pickle.HIGHEST_PROTOCOL)
     return df_pred_optim, mlf
 
@@ -457,11 +458,11 @@ def publish_data(input_data_dict: dict, logger: logging.Logger,
     else:
         filename = 'opt_res_latest.csv'
     if opt_res_latest is None:
-        if not os.path.isfile(pathlib.Path(input_data_dict['root']) / filename):
+        if not os.path.isfile(pathlib.Path(input_data_dict['emhass_conf']['data_path']) / filename):
             logger.error("File not found error, run an optimization task first.")
             return
         else:
-            opt_res_latest = pd.read_csv(pathlib.Path(input_data_dict['root']) / filename, index_col='timestamp')
+            opt_res_latest = pd.read_csv(pathlib.Path(input_data_dict['emhass_conf']['data_path']) / filename, index_col='timestamp')
             opt_res_latest.index = pd.to_datetime(opt_res_latest.index)
             opt_res_latest.index.freq = input_data_dict['retrieve_hass_conf']['freq']
     # Estimate the current index
@@ -614,10 +615,18 @@ def main():
     parser.add_argument('--debug', type=strtobool, default='False', help='Use True for testing purposes')
     args = parser.parse_args()
     # The path to the configuration files
-    config_path = pathlib.Path(args.config)
-    base_path = str(config_path.parent)
+    if args.config is not None:
+        config_path = pathlib.Path(args.config)
+    else:
+        config_path = pathlib.Path(str(utils.get_root(__file__, num_parent=2) / 'config_emhass.yaml' ))
+    root_path = config_path.parent
+    data_path = (config_path.parent / 'data/')
+    emhass_conf = {}
+    emhass_conf['config_path'] = config_path
+    emhass_conf['data_path'] = data_path
+    emhass_conf['root_path'] = root_path
     # create logger
-    logger, ch = utils.get_logger(__name__, base_path, save_to_file=bool(args.log2file))
+    logger, ch = utils.get_logger(__name__, emhass_conf['data_path'], save_to_file=bool(args.log2file))
     # Additionnal argument
     try:
         parser.add_argument('--version', action='version', version='%(prog)s '+version('emhass'))
@@ -625,7 +634,7 @@ def main():
     except Exception:
         logger.info("Version not found for emhass package. Or importlib exited with PackageNotFoundError.")
     # Setup parameters
-    input_data_dict = set_input_data_dict(config_path, base_path, 
+    input_data_dict = set_input_data_dict(emhass_conf, 
                                           args.costfun, args.params, args.runtimeparams, args.action, 
                                           logger, args.debug)
     # Perform selected action
@@ -670,6 +679,8 @@ def main():
         return df_pred
     elif args.action == 'forecast-model-tune':
         return df_pred_optim, mlf
+    else: 
+        return opt_res
 
 if __name__ == '__main__':
     main()

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pathlib
+import os
 import pickle
 import copy
 import logging
@@ -98,25 +99,25 @@ class Forecast(object):
     """
 
     def __init__(self, retrieve_hass_conf: dict, optim_conf: dict, plant_conf: dict, 
-                 params: str, base_path: str, logger: logging.Logger, 
+                 params: str, emhass_conf: dict, logger: logging.Logger, 
                  opt_time_delta: Optional[int] = 24,
                  get_data_from_file: Optional[bool] = False) -> None:
         """
         Define constructor for the forecast class.
         
-        :param retrieve_hass_conf: Dictionnary containing the needed configuration
+        :param retrieve_hass_conf: Dictionary containing the needed configuration
             data from the configuration file, specific to retrieve data from HASS
         :type retrieve_hass_conf: dict
-        :param optim_conf: Dictionnary containing the needed configuration
+        :param optim_conf: Dictionary containing the needed configuration
             data from the configuration file, specific for the optimization task
         :type optim_conf: dict
-        :param plant_conf: Dictionnary containing the needed configuration
+        :param plant_conf: Dictionary containing the needed configuration
             data from the configuration file, specific for the modeling of the PV plant
         :type plant_conf: dict
         :param params: Configuration parameters passed from data/options.json
         :type params: str
-        :param base_path: The path to the yaml configuration file
-        :type base_path: str
+        :param emhass_conf: Dictionary containing the needed emhass paths
+        :type emhass_conf: dict
         :param logger: The passed logger object
         :type logger: logging object
         :param opt_time_delta: The time delta in hours used to generate forecasts, 
@@ -141,7 +142,7 @@ class Forecast(object):
         self.var_load_new = self.var_load+'_positive'
         self.lat = self.retrieve_hass_conf['lat'] 
         self.lon = self.retrieve_hass_conf['lon']
-        self.root = base_path
+        self.emhass_conf = emhass_conf
         self.logger = logger
         self.get_data_from_file = get_data_from_file
         self.var_load_cost = 'unit_load_cost'
@@ -169,7 +170,7 @@ class Forecast(object):
         
         
     def get_weather_forecast(self, method: Optional[str] = 'scrapper',
-                             csv_path: Optional[str] = "/data/data_weather_forecast.csv") -> pd.DataFrame:
+                             csv_path: Optional[str] = "data_weather_forecast.csv") -> pd.DataFrame:
         r"""
         Get and generate weather forecast data.
         
@@ -180,6 +181,8 @@ class Forecast(object):
         :rtype: pd.DataFrame
         
         """
+        csv_path  = self.emhass_conf['data_path'] / csv_path
+
         self.logger.info("Retrieving weather forecast data using method = "+method)
         self.weather_forecast_method = method # Saving this attribute for later use to identify csv method usage
         if method == 'scrapper':
@@ -292,7 +295,7 @@ class Forecast(object):
                 else:
                     data = data + data_tmp
         elif method == 'csv': # reading from a csv file
-            weather_csv_file_path = self.root + csv_path
+            weather_csv_file_path = csv_path
             # Loading the csv file, we will consider that this is the PV power in W
             data = pd.read_csv(weather_csv_file_path, header=None, names=['ts', 'yhat'])
             # Check if the passed data has the correct length       
@@ -424,9 +427,9 @@ class Forecast(object):
                 # cec_inverters = pvlib.pvsystem.retrieve_sam(path=self.root + '/data/CEC Inverters.csv')
                 # with bz2.BZ2File(self.root + '/data/cec_inverters.pbz2', "w") as f: 
                 #     cPickle.dump(cec_inverters, f)
-                cec_modules = bz2.BZ2File(str(pathlib.Path(self.root+'/data/cec_modules.pbz2')), "rb")
+                cec_modules = bz2.BZ2File(str(pathlib.Path(self.emhass_conf['data_path'] / 'cec_modules.pbz2')), "rb")
                 cec_modules = cPickle.load(cec_modules)
-                cec_inverters = bz2.BZ2File(str(pathlib.Path(self.root+'/data/cec_inverters.pbz2')), "rb")
+                cec_inverters = bz2.BZ2File(str(pathlib.Path(self.emhass_conf['data_path'] / 'cec_inverters.pbz2')), "rb")
                 cec_inverters = cPickle.load(cec_inverters)
                 if type(self.plant_conf['module_model']) == list:
                     P_PV_forecast = pd.Series(0, index=df_weather.index)
@@ -523,7 +526,9 @@ class Forecast(object):
             df_csv.index = forecast_dates_csv
             df_csv.drop(['ts'], axis=1, inplace=True)
         else:
-            load_csv_file_path = self.root + csv_path
+            load_csv_file_path = csv_path
+            if not os.path.exists(csv_path):
+                csv_path = self.emhass_conf['data_path'] / csv_path
             df_csv = pd.read_csv(load_csv_file_path, header=None, names=['ts', 'yhat'])
             df_csv.index = forecast_dates_csv
             df_csv.drop(['ts'], axis=1, inplace=True)
@@ -548,7 +553,7 @@ class Forecast(object):
         return forecast_out
     
     def get_load_forecast(self, days_min_load_forecast: Optional[int] = 3, method: Optional[str] = 'naive',
-                          csv_path: Optional[str] = "/data/data_load_forecast.csv",
+                          csv_path: Optional[str] = "data_load_forecast.csv",
                           set_mix_forecast:Optional[bool] = False, df_now:Optional[pd.DataFrame] = pd.DataFrame(),
                           use_last_window: Optional[bool] = True, mlf: Optional[MLForecaster] = None,
                           debug: Optional[bool] = False) -> pd.Series:
@@ -586,6 +591,8 @@ class Forecast(object):
         :rtype: pd.DataFrame
 
         """
+        csv_path  = self.emhass_conf['data_path'] / csv_path
+        
         if method == 'naive' or method == 'mlforecaster': # retrieving needed data for these methods
             self.logger.info("Retrieving data from hass for load forecast using method = "+method)
             var_list = [self.var_load]
@@ -594,9 +601,9 @@ class Forecast(object):
             time_zone_load_foreacast = None
             # We will need to retrieve a new set of load data according to the days_min_load_forecast parameter
             rh = RetrieveHass(self.retrieve_hass_conf['hass_url'], self.retrieve_hass_conf['long_lived_token'], 
-                               self.freq, time_zone_load_foreacast, self.params, self.root, self.logger)
+                               self.freq, time_zone_load_foreacast, self.params, self.emhass_conf, self.logger)
             if self.get_data_from_file:
-                with open(pathlib.Path(self.root) / 'data' / 'test_df_final.pkl', 'rb') as inp:
+                with open(pathlib.Path(self.emhass_conf['data_path']) / 'test_df_final.pkl', 'rb') as inp:
                     rh.df_final, days_list, _ = pickle.load(inp)
             else:
                 days_list = get_days_list(days_min_load_forecast) 
@@ -619,13 +626,14 @@ class Forecast(object):
             # Load model
             model_type = self.params['passed_data']['model_type']
             filename = model_type+'_mlf.pkl'
-            filename_path = pathlib.Path(self.root) / filename
+            filename_path = pathlib.Path(self.emhass_conf['data_path']) / filename
             if not debug:
                 if filename_path.is_file():
                     with open(filename_path, 'rb') as inp:
                         mlf = pickle.load(inp)
                 else:
                     self.logger.error("The ML forecaster file was not found, please run a model fit method before this predict method")
+                    return False
             # Make predictions
             if use_last_window:
                 data_last_window = copy.deepcopy(df)
@@ -633,8 +641,12 @@ class Forecast(object):
             else:
                 data_last_window = None
             forecast_out = mlf.predict(data_last_window)
-            # Force forecast_out length to avoid mismatches
-            forecast_out = forecast_out.iloc[0:len(self.forecast_dates)]
+            # Force forecast length to avoid mismatches
+            if len(self.forecast_dates) < len(forecast_out.index):
+                forecast_out = forecast_out.iloc[0:len(self.forecast_dates)]
+            elif len(self.forecast_dates) > len(forecast_out.index):
+                self.logger.error("sensor: power load no var loads missing data within the " + str(len(self.forecast_dates)) + " days")
+                return False
             # Define DataFrame
             data_dict = {'ts':self.forecast_dates, 'yhat':forecast_out.values.tolist()}
             data = pd.DataFrame.from_dict(data_dict)
@@ -642,7 +654,7 @@ class Forecast(object):
             data.set_index('ts', inplace=True)
             forecast_out = data.copy().loc[self.forecast_dates]
         elif method == 'csv': # reading from a csv file
-            load_csv_file_path = self.root + csv_path
+            load_csv_file_path = csv_path
             df_csv = pd.read_csv(load_csv_file_path, header=None, names=['ts', 'yhat'])
             if len(df_csv) < len(self.forecast_dates):
                 self.logger.error("Passed data from CSV is not long enough")
@@ -659,6 +671,7 @@ class Forecast(object):
             # Check if the passed data has the correct length
             if len(data_list) < len(self.forecast_dates) and self.params['passed_data']['prediction_horizon'] is None:
                 self.logger.error("Passed data from passed list is not long enough")
+                return False
             else:
                 # Ensure correct length
                 data_list = data_list[0:len(self.forecast_dates)]
@@ -670,6 +683,7 @@ class Forecast(object):
                 forecast_out = data.copy().loc[self.forecast_dates]
         else:
             self.logger.error("Passed method is not valid")
+            return False
         P_Load_forecast = copy.deepcopy(forecast_out['yhat'])
         if set_mix_forecast:
             P_Load_forecast = Forecast.get_mix_forecast(
@@ -698,6 +712,8 @@ class Forecast(object):
         :rtype: pd.DataFrame
 
         """
+        csv_path  = self.emhass_conf['data_path'] / csv_path
+
         if method == 'hp_hc_periods':
             df_final[self.var_load_cost] = self.optim_conf['load_cost_hc']
             list_df_hp = []
@@ -717,6 +733,7 @@ class Forecast(object):
             # Check if the passed data has the correct length
             if len(data_list) < len(self.forecast_dates) and self.params['passed_data']['prediction_horizon'] is None:
                 self.logger.error("Passed data from passed list is not long enough")
+                return False
             else:
                 # Ensure correct length
                 data_list = data_list[0:len(self.forecast_dates)]
@@ -728,11 +745,12 @@ class Forecast(object):
                 df_final[self.var_load_cost] = forecast_out
         else:
             self.logger.error("Passed method is not valid")
+            return False
             
         return df_final
     
     def get_prod_price_forecast(self, df_final: pd.DataFrame, method: Optional[str] = 'constant',
-                               csv_path: Optional[str] = "/data/data_prod_price_forecast.csv") -> pd.DataFrame:
+                               csv_path: Optional[str] = "'data_prod_price_forecast.csv") -> pd.DataFrame:
         r"""
         Get the unit power production price for the energy injected to the grid.\
         This is the price of the energy injected to the utility in a vector \
@@ -753,6 +771,9 @@ class Forecast(object):
         :rtype: pd.DataFrame
 
         """
+
+        csv_path  = self.emhass_conf['data_path'] / csv_path
+
         if method == 'constant':
             df_final[self.var_prod_price] = self.optim_conf['prod_sell_price']
         elif method == 'csv':
@@ -767,6 +788,7 @@ class Forecast(object):
             # Check if the passed data has the correct length
             if len(data_list) < len(self.forecast_dates) and self.params['passed_data']['prediction_horizon'] is None:
                 self.logger.error("Passed data from passed list is not long enough")
+                return False
             else:
                 # Ensure correct length
                 data_list = data_list[0:len(self.forecast_dates)]
@@ -778,6 +800,7 @@ class Forecast(object):
                 df_final[self.var_prod_price] = forecast_out
         else:
             self.logger.error("Passed method is not valid")
+            return False
             
         return df_final
     

--- a/src/emhass/machine_learning_forecaster.py
+++ b/src/emhass/machine_learning_forecaster.py
@@ -38,7 +38,7 @@ class MLForecaster:
     """
 
     def __init__(self, data: pd.DataFrame, model_type: str, var_model: str, sklearn_model: str,
-                 num_lags: int, root: str, logger: logging.Logger) -> None:
+                 num_lags: int, emhass_conf: dict, logger: logging.Logger) -> None:
         r"""Define constructor for the forecast class.
 
         :param data: The data that will be used for train/test
@@ -56,8 +56,8 @@ class MLForecaster:
             is to fix this as one day. For example if your time step is 30 minutes, then fix this \
             to 48, if the time step is 1 hour the fix this to 24 and so on.
         :type num_lags: int
-        :param root: The parent folder of the path where the config.yaml file is located
-        :type root: str
+        :param emhass_conf: Dictionary containing the needed emhass paths
+        :type emhass_conf: dict
         :param logger: The passed logger object
         :type logger: logging.Logger
         """
@@ -66,7 +66,7 @@ class MLForecaster:
         self.var_model = var_model
         self.sklearn_model = sklearn_model
         self.num_lags = num_lags
-        self.root = root
+        self.emhass_conf = emhass_conf
         self.logger = logger
         self.is_tuned = False
         # A quick data preparation

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -31,7 +31,7 @@ class Optimization:
 
     def __init__(self, retrieve_hass_conf: dict, optim_conf: dict, plant_conf: dict, 
                  var_load_cost: str, var_prod_price: str, 
-                 costfun: str, base_path: str, logger: logging.Logger, 
+                 costfun: str, emhass_conf: dict, logger: logging.Logger, 
                  opt_time_delta: Optional[int] = 24) -> None:
         r"""
         Define constructor for Optimization class.
@@ -50,8 +50,8 @@ class Optimization:
         :type var_prod_price: str
         :param costfun: The type of cost function to use for optimization problem
         :type costfun: str
-        :param base_path: The path to the yaml configuration file
-        :type base_path: str
+        :param emhass_conf: Dictionary containing the needed emhass paths
+        :type emhass_conf: dict
         :param logger: The passed logger object
         :type logger: logging object
         :param opt_time_delta: The number of hours to optimize. If days_list has \
@@ -71,6 +71,7 @@ class Optimization:
         self.var_load = self.retrieve_hass_conf['var_load']
         self.var_load_new = self.var_load+'_positive'
         self.costfun = costfun
+        # self.emhass_conf = emhass_conf
         self.logger = logger
         self.var_load_cost = var_load_cost
         self.var_prod_price = var_prod_price

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -31,7 +31,7 @@ class RetrieveHass:
     """
 
     def __init__(self, hass_url: str, long_lived_token: str, freq: pd.Timedelta, 
-                 time_zone: datetime.timezone, params: str, base_path: str, logger: logging.Logger,
+                 time_zone: datetime.timezone, params: str, emhass_conf: dict, logger: logging.Logger,
                  get_data_from_file: Optional[bool] = False) -> None:
         """
         Define constructor for RetrieveHass class.
@@ -46,8 +46,8 @@ class RetrieveHass:
         :type time_zone: datetime.timezone
         :param params: Configuration parameters passed from data/options.json
         :type params: str
-        :param base_path: The path to the yaml configuration file
-        :type base_path: str
+        :param emhass_conf: Dictionary containing the needed emhass paths
+        :type emhass_conf: dict
         :param logger: The passed logger object
         :type logger: logging object
         :param get_data_from_file: Select if data should be retrieved from a 
@@ -61,7 +61,7 @@ class RetrieveHass:
         self.freq = freq
         self.time_zone = time_zone
         self.params = params
-        self.base_path = base_path
+        # self.emhass_conf = emhass_conf
         self.logger = logger
         self.get_data_from_file = get_data_from_file
 
@@ -134,17 +134,21 @@ class RetrieveHass:
                     data = response.json()[0]
                 except IndexError:
                     if x == 0:
-                        self.logger.error("The retrieved JSON is empty, A sensor:" + var + " may have 0 days of history or passed sensor may not be correct")
+                        self.logger.error("The retrieved JSON is empty, A sensor:" + var + " may have 0 days of history, passed sensor may not be correct, or retrieve days set too heigh")
                     else:
                         self.logger.error("The retrieved JSON is empty for day:"+ str(day) +", days_to_retrieve may be larger than the recorded history of sensor:" + var + " (check your recorder settings)")
                     return False
                 df_raw = pd.DataFrame.from_dict(data)
+                # self.logger.info(str(df_raw))
                 if len(df_raw) == 0:
                     if x == 0:
                         self.logger.error("The retrieved Dataframe is empty, A sensor:" + var + " may have 0 days of history or passed sensor may not be correct")
                     else:
                         self.logger.error("Retrieved empty Dataframe for day:"+ str(day) +", days_to_retrieve may be larger than the recorded history of sensor:" + var + " (check your recorder settings)")
                     return False
+                # self.logger.info(self.freq.seconds)
+                if len(df_raw) < ((60 / (self.freq.seconds / 60)) * 24) and x != len(days_list) -1: #check if there is enough Dataframes for passed frequency per day (not inc current day)
+                    self.logger.warning("sensor:"  + var + " retrieved Dataframe count: " + str(len(df_raw))  + ", on day: " + str(day) + ", is less than freq value passed: " + str(self.freq))
                 if i == 0: # Defining the DataFrame container
                     from_date = pd.to_datetime(df_raw['last_changed'], format="ISO8601").min()
                     to_date = pd.to_datetime(df_raw['last_changed'], format="ISO8601").max()
@@ -158,14 +162,14 @@ class RetrieveHass:
                 df_tp.set_index(pd.to_datetime(df_raw['last_changed'], format="ISO8601"), inplace=True)
                 df_tp = df_tp.resample(self.freq).mean()
                 df_day = pd.concat([df_day, df_tp], axis=1)
-            
-            x += 1
             self.df_final = pd.concat([self.df_final, df_day], axis=0)
+            x += 1 
         self.df_final = set_df_index_freq(self.df_final)
         if self.df_final.index.freq != self.freq:
-            self.logger.error("The inferred freq from data is not equal to the defined freq in passed parameters")
+            self.logger.error("The inferred freq:" + str(self.df_final.index.freq) + " from data is not equal to the defined freq in passed:" + str(self.freq))
             return False
         return True
+           
     
     def prepare_data(self, var_load: str, load_negative: Optional[bool] = False, set_zero_min: Optional[bool] = True,
                      var_replace_zero: Optional[list] = None, var_interp: Optional[list] = None) -> None:

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -97,7 +97,7 @@ def template_action(action_name):
 @app.route('/action/<action_name>', methods=['POST'])
 def action_call(action_name):
     with open(str(data_path / 'params.pkl'), "rb") as fid:
-        config_path, params = pickle.load(fid)
+        emhass_conf['config_path'], params = pickle.load(fid)
     runtimeparams = request.get_json(force=True)
     params = json.dumps(params)
     if runtimeparams is not None and runtimeparams != '{}':
@@ -105,7 +105,7 @@ def action_call(action_name):
     runtimeparams = json.dumps(runtimeparams)
     ActionStr = " >> Setting input data dict"
     app.logger.info(ActionStr)
-    input_data_dict = set_input_data_dict(config_path, str(data_path), costfun, 
+    input_data_dict = set_input_data_dict(emhass_conf, costfun, 
         params, runtimeparams, action_name, app.logger)
     if not input_data_dict:
         return make_response(grabLog(ActionStr), 400)
@@ -255,6 +255,12 @@ if __name__ == "__main__":
 
     config_path = Path(CONFIG_PATH)
     data_path = Path(DATA_PATH)
+
+    #save paths to dictionary
+    emhass_conf = {}
+    emhass_conf['config_path'] = config_path
+    emhass_conf['data_path'] = data_path
+    emhass_conf['root_path'] = Path(config_path).parent
     
     # Read the example default config file
     if config_path.exists():
@@ -388,7 +394,7 @@ if __name__ == "__main__":
         with open(str(data_path / 'params.pkl'), "wb") as fid:
             pickle.dump((config_path, params), fid)
     else: 
-        raise Exception("missing: " + str(data_path))        
+        raise Exception("missing: " + str(data_path))   
 
     # Define logger
     #stream logger

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -13,16 +13,21 @@ from emhass.command_line import publish_data
 from emhass.command_line import main
 from emhass import utils
 
-# the root folder
+# create paths
 root = str(utils.get_root(__file__, num_parent=2))
+emhass_conf = {}
+emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
+emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
+emhass_conf['root_path'] = pathlib.Path(root)
+
 # create logger
-logger, ch = utils.get_logger(__name__, root, save_to_file=False)
+logger, ch = utils.get_logger(__name__, emhass_conf['root_path'], save_to_file=False)
 
 class TestCommandLineUtils(unittest.TestCase):
     
     @staticmethod
     def get_test_params():
-        with open(root+'/config_emhass.yaml', 'r') as file:
+        with open(emhass_conf['config_path'], 'r') as file:
             params = yaml.load(file, Loader=yaml.FullLoader)
         params.update({
             'params_secrets': {
@@ -49,11 +54,9 @@ class TestCommandLineUtils(unittest.TestCase):
         self.params_json = json.dumps(params)
         
     def test_set_input_data_dict(self):
-        config_path = pathlib.Path(root+'/config_emhass.yaml')
-        base_path = str(config_path.parent)
         costfun = 'profit'
         action = 'dayahead-optim'
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, self.params_json, self.runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, self.params_json, self.runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         self.assertIsInstance(input_data_dict, dict)
         self.assertTrue(input_data_dict['df_input_data'] == None)
@@ -65,14 +68,14 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertTrue(input_data_dict['fcst'].optim_conf['load_cost_forecast_method']=='list')
         self.assertTrue(input_data_dict['fcst'].optim_conf['prod_price_forecast_method']=='list')
         action = 'publish-data'
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, self.params_json, self.runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, self.params_json, self.runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         self.assertTrue(input_data_dict['df_input_data'] == None)
         self.assertTrue(input_data_dict['df_input_data_dayahead'] == None)
         self.assertTrue(input_data_dict['P_PV_forecast'] == None)
         self.assertTrue(input_data_dict['P_load_forecast'] == None)
         action = 'naive-mpc-optim'
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, self.params_json, self.runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, self.params_json, self.runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         self.assertIsInstance(input_data_dict, dict)
         self.assertIsInstance(input_data_dict['df_input_data_dayahead'], pd.DataFrame)
@@ -89,7 +92,7 @@ class TestCommandLineUtils(unittest.TestCase):
         params = copy.deepcopy(json.loads(self.params_json))
         params['passed_data'] = runtimeparams
         params_json = json.dumps(params)
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         self.assertIsInstance(input_data_dict, dict)
         self.assertIsInstance(input_data_dict['df_input_data_dayahead'], pd.DataFrame)
@@ -102,7 +105,7 @@ class TestCommandLineUtils(unittest.TestCase):
         params = copy.deepcopy(json.loads(self.params_json))
         params['passed_data'] = runtimeparams
         params_json = json.dumps(params)
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         self.assertIsInstance(input_data_dict, dict)
         self.assertIsInstance(input_data_dict['df_input_data_dayahead'], pd.DataFrame)
@@ -119,18 +122,16 @@ class TestCommandLineUtils(unittest.TestCase):
         runtimeparams_json = json.dumps(runtimeparams)
         params['passed_data'] = runtimeparams
         params_json = json.dumps(params)
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         self.assertTrue(input_data_dict['fcst'].optim_conf['load_cost_forecast_method']=='list')
         self.assertTrue(input_data_dict['fcst'].optim_conf['prod_price_forecast_method']=='list')
     
     def test_webserver_get_injection_dict(self):
         # First perform a day-ahead optimization
-        config_path = pathlib.Path(root+'/config_emhass.yaml')
-        base_path = str(config_path.parent)
         costfun = 'profit'
         action = 'dayahead-optim'
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, self.params_json, self.runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, self.params_json, self.runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         opt_res = dayahead_forecast_optim(input_data_dict, logger, debug=True)
         injection_dict = utils.get_injection_dict(opt_res)
@@ -139,12 +140,10 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertIsInstance(injection_dict['table2'], str)
     
     def test_dayahead_forecast_optim(self):
-        config_path = pathlib.Path(root+'/config_emhass.yaml')
-        base_path = str(config_path.parent)
         costfun = 'profit'
         action = 'dayahead-optim'
         params = copy.deepcopy(json.loads(self.params_json))
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, self.params_json, self.runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, self.params_json, self.runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         opt_res = dayahead_forecast_optim(input_data_dict, logger, debug=True)
         self.assertIsInstance(opt_res, pd.DataFrame)
@@ -160,7 +159,7 @@ class TestCommandLineUtils(unittest.TestCase):
         runtimeparams_json = json.dumps(runtimeparams)
         params['passed_data'] = runtimeparams
         params_json = json.dumps(params)
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         opt_res = dayahead_forecast_optim(input_data_dict, logger, debug=True)
         self.assertIsInstance(opt_res, pd.DataFrame)
@@ -171,11 +170,9 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertEqual(opt_res['unit_prod_price'].values.tolist(), runtimeparams['prod_price_forecast'])
         
     def test_perfect_forecast_optim(self):
-        config_path = pathlib.Path(root+'/config_emhass.yaml')
-        base_path = str(config_path.parent)
         costfun = 'profit'
         action = 'perfect-optim'
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, self.params_json, self.runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, self.params_json, self.runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         opt_res = perfect_forecast_optim(input_data_dict, logger, debug=True)
         self.assertIsInstance(opt_res, pd.DataFrame)
@@ -185,12 +182,10 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertTrue('cost_fun_'+input_data_dict["costfun"] in opt_res.columns)
         
     def test_naive_mpc_optim(self):
-        config_path = pathlib.Path(root+'/config_emhass.yaml')
-        base_path = str(config_path.parent)
         costfun = 'profit'
         action = 'naive-mpc-optim'
         params = copy.deepcopy(json.loads(self.params_json))
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, self.params_json, self.runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, self.params_json, self.runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         opt_res = naive_mpc_optim(input_data_dict, logger, debug=True)
         self.assertIsInstance(opt_res, pd.DataFrame)
@@ -207,25 +202,23 @@ class TestCommandLineUtils(unittest.TestCase):
         params['optim_conf']['load_cost_forecast_method'] = 'hp_hc_periods'
         params['optim_conf']['prod_price_forecast_method'] = 'constant'
         params_json = json.dumps(params)
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         opt_res = naive_mpc_optim(input_data_dict, logger, debug=True)
         self.assertIsInstance(opt_res, pd.DataFrame)
         self.assertTrue(opt_res.isnull().sum().sum()==0)
         self.assertTrue(len(opt_res)==10)
         # Test publish after passing the forecast as list
-        config_path = pathlib.Path(root+'/config_emhass.yaml')
-        base_path = str(config_path.parent)
         costfun = 'profit'
         action = 'naive-mpc-optim'
         params = copy.deepcopy(json.loads(self.params_json))
         params['retrieve_hass_conf']['method_ts_round'] = 'first'
         params_json = json.dumps(params)
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, self.runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, self.runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         opt_res = naive_mpc_optim(input_data_dict, logger, debug=True)
         action = 'publish-data'
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, None, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, None, 
                                               action, logger, get_data_from_file=True)
         opt_res_first = publish_data(input_data_dict, logger, opt_res_latest=opt_res)
         self.assertTrue(len(opt_res_first)==1)
@@ -234,17 +227,17 @@ class TestCommandLineUtils(unittest.TestCase):
         params['retrieve_hass_conf']['method_ts_round'] = 'last'
         params['optim_conf']['set_use_battery'] = True
         params_json = json.dumps(params)
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, self.runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, self.runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         opt_res = naive_mpc_optim(input_data_dict, logger, debug=True)
         action = 'publish-data'
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, None, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, None, 
                                               action, logger, get_data_from_file=True)
         opt_res_last = publish_data(input_data_dict, logger, opt_res_latest=opt_res)
         self.assertTrue(len(opt_res_last)==1)
         # Reproduce when trying to publish data but params=None and runtimeparams=None
         action = 'publish-data'
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, None, None, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, None, None, 
                                               action, logger, get_data_from_file=True)
         opt_res_last = publish_data(input_data_dict, logger, opt_res_latest=opt_res)
         self.assertTrue(len(opt_res_last)==1)
@@ -264,8 +257,6 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertTrue(data['attributes']['friendly_name'] == 'EMHASS optimization status')
     
     def test_forecast_model_fit_predict_tune(self):
-        config_path = pathlib.Path(root+'/config_emhass.yaml')
-        base_path = str(config_path.parent)
         costfun = 'profit'
         action = 'forecast-model-fit' # fit, predict and tune methods
         params = TestCommandLineUtils.get_test_params()
@@ -286,13 +277,13 @@ class TestCommandLineUtils(unittest.TestCase):
         # params['passed_data'] = runtimeparams
         params['optim_conf']['load_forecast_method'] = 'skforecast'
         params_json = json.dumps(params)
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         self.assertTrue(input_data_dict['params']['passed_data']['model_type'] == 'load_forecast')
         self.assertTrue(input_data_dict['params']['passed_data']['sklearn_model'] == 'KNeighborsRegressor')
         self.assertTrue(input_data_dict['params']['passed_data']['perform_backtest'] == False)
         # Check that the default params are loaded
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, self.params_json, self.runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, self.params_json, self.runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         self.assertTrue(input_data_dict['params']['passed_data']['model_type'] == 'load_forecast')
         self.assertTrue(input_data_dict['params']['passed_data']['sklearn_model'] == 'KNeighborsRegressor')
@@ -306,7 +297,7 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertIsInstance(injection_dict, dict)
         self.assertIsInstance(injection_dict['figure_0'], str)
         # Test the predict method on observations following the train period
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         df_pred = forecast_model_predict(input_data_dict, logger, use_last_window=False, debug=True, mlf=mlf)
         self.assertIsInstance(df_pred, pd.Series)
@@ -324,13 +315,13 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertIsInstance(injection_dict, dict)
         self.assertIsInstance(injection_dict['figure_0'], str)
     
-    @patch('sys.argv', ['main', '--action', 'test', '--config', str(pathlib.Path(root+'/config_emhass.yaml')), 
+    @patch('sys.argv', ['main', '--action', 'test', '--config', str(emhass_conf['config_path']), 
                         '--debug', 'True'])
     def test_main_wrong_action(self):
         opt_res = main()
         self.assertEqual(opt_res, None)
         
-    @patch('sys.argv', ['main', '--action', 'perfect-optim', '--config', str(pathlib.Path(root+'/config_emhass.yaml')), 
+    @patch('sys.argv', ['main', '--action', 'perfect-optim', '--config', str(emhass_conf['config_path']), 
                         '--debug', 'True'])
     def test_main_perfect_forecast_optim(self):
         opt_res = main()
@@ -340,7 +331,7 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertIsInstance(opt_res.index.dtype, pd.core.dtypes.dtypes.DatetimeTZDtype)
         
     def test_main_dayahead_forecast_optim(self):
-        with patch('sys.argv', ['main', '--action', 'dayahead-optim', '--config', str(pathlib.Path(root+'/config_emhass.yaml')), 
+        with patch('sys.argv', ['main', '--action', 'dayahead-optim', '--config', str(emhass_conf['config_path']), 
                                 '--params', self.params_json, '--runtimeparams', self.runtimeparams_json,
                                 '--debug', 'True']):
             opt_res = main()
@@ -348,7 +339,7 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertTrue(opt_res.isnull().sum().sum()==0)
         
     def test_main_naive_mpc_optim(self):
-        with patch('sys.argv', ['main', '--action', 'naive-mpc-optim', '--config', str(pathlib.Path(root+'/config_emhass.yaml')), 
+        with patch('sys.argv', ['main', '--action', 'naive-mpc-optim', '--config', str(emhass_conf['config_path']), 
                                 '--params', self.params_json, '--runtimeparams', self.runtimeparams_json,
                                 '--debug', 'True']):
             opt_res = main()
@@ -371,7 +362,7 @@ class TestCommandLineUtils(unittest.TestCase):
         params['passed_data'] = runtimeparams
         params['optim_conf']['load_forecast_method'] = 'skforecast'
         params_json = json.dumps(params)
-        with patch('sys.argv', ['main', '--action', 'forecast-model-fit', '--config', str(pathlib.Path(root+'/config_emhass.yaml')), 
+        with patch('sys.argv', ['main', '--action', 'forecast-model-fit', '--config', str(emhass_conf['config_path']), 
                                 '--params', params_json, '--runtimeparams', runtimeparams_json,
                                 '--debug', 'True']):
             df_fit_pred, df_fit_pred_backtest, mlf = main()
@@ -393,7 +384,7 @@ class TestCommandLineUtils(unittest.TestCase):
         params['passed_data'] = runtimeparams
         params['optim_conf']['load_forecast_method'] = 'skforecast'
         params_json = json.dumps(params)
-        with patch('sys.argv', ['main', '--action', 'forecast-model-predict', '--config', str(pathlib.Path(root+'/config_emhass.yaml')), 
+        with patch('sys.argv', ['main', '--action', 'forecast-model-predict', '--config', str(emhass_conf['config_path']), 
                                 '--params', params_json, '--runtimeparams', runtimeparams_json,
                                 '--debug', 'True']):
             df_pred = main()
@@ -415,14 +406,14 @@ class TestCommandLineUtils(unittest.TestCase):
         params['passed_data'] = runtimeparams
         params['optim_conf']['load_forecast_method'] = 'skforecast'
         params_json = json.dumps(params)
-        with patch('sys.argv', ['main', '--action', 'forecast-model-tune', '--config', str(pathlib.Path(root+'/config_emhass.yaml')), 
+        with patch('sys.argv', ['main', '--action', 'forecast-model-tune', '--config', str(emhass_conf['config_path']), 
                                 '--params', params_json, '--runtimeparams', runtimeparams_json,
                                 '--debug', 'True']):
             df_pred_optim, mlf = main()
         self.assertIsInstance(df_pred_optim, pd.DataFrame)
         self.assertTrue(mlf.is_tuned == True)
         
-    @patch('sys.argv', ['main', '--action', 'publish-data', '--config', str(pathlib.Path(root+'/config_emhass.yaml')), 
+    @patch('sys.argv', ['main', '--action', 'publish-data', '--config', str(emhass_conf['config_path']), 
                         '--debug', 'True'])
     def test_main_publish_data(self):
         opt_res = main()

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -17,14 +17,19 @@ from emhass.utils import get_root, get_logger, get_yaml_parse, treat_runtimepara
 
 # the root folder
 root = str(get_root(__file__, num_parent=2))
+emhass_conf = {}
+emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
+emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
+emhass_conf['root_path'] = pathlib.Path(root)
+
 # create logger
-logger, ch = get_logger(__name__, root, save_to_file=False)
+logger, ch = get_logger(__name__, emhass_conf['root_path'], save_to_file=False)
 
 class TestForecast(unittest.TestCase):
     
     @staticmethod
     def get_test_params():
-        with open(root+'/config_emhass.yaml', 'r') as file:
+        with open(emhass_conf['config_path'], 'r') as file:
             params = yaml.load(file, Loader=yaml.FullLoader)
         params.update({
             'params_secrets': {
@@ -41,14 +46,14 @@ class TestForecast(unittest.TestCase):
     def setUp(self):
         self.get_data_from_file = True
         params = None
-        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse(pathlib.Path(root) / 'config_emhass.yaml', use_secrets=False)
+        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse(emhass_conf['config_path'], use_secrets=False)
         self.retrieve_hass_conf, self.optim_conf, self.plant_conf = \
             retrieve_hass_conf, optim_conf, plant_conf
         self.rh = RetrieveHass(self.retrieve_hass_conf['hass_url'], self.retrieve_hass_conf['long_lived_token'], 
                                self.retrieve_hass_conf['freq'], self.retrieve_hass_conf['time_zone'],
-                               params, root, logger)
+                               params, emhass_conf, logger)
         if self.get_data_from_file:
-            with open(pathlib.Path(root) / 'data' / 'test_df_final.pkl', 'rb') as inp:
+            with open(emhass_conf['data_path'] / 'test_df_final.pkl', 'rb') as inp:
                 self.rh.df_final, self.days_list, self.var_list = pickle.load(inp)
         else:
             self.days_list = get_days_list(self.retrieve_hass_conf['days_to_retrieve'])
@@ -62,7 +67,7 @@ class TestForecast(unittest.TestCase):
         self.df_input_data = self.rh.df_final.copy()
         
         self.fcst = Forecast(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
-                             params, root, logger, get_data_from_file=self.get_data_from_file)
+                             params, emhass_conf, logger, get_data_from_file=self.get_data_from_file)
         # The default for test is csv read
         self.df_weather_scrap = self.fcst.get_weather_forecast(method='csv')
         self.P_PV_forecast = self.fcst.get_power_from_weather(self.df_weather_scrap)
@@ -71,9 +76,9 @@ class TestForecast(unittest.TestCase):
         self.df_input_data_dayahead.columns = ['P_PV_forecast', 'P_load_forecast']
         self.opt = Optimization(retrieve_hass_conf, optim_conf, plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price, 
-                                'profit', root, logger)
+                                'profit', emhass_conf, logger)
         self.input_data_dict = {
-            'root': root,
+            'emhass_conf': emhass_conf,
             'retrieve_hass_conf': self.retrieve_hass_conf,
             'df_input_data': self.df_input_data,
             'df_input_data_dayahead': self.df_input_data_dayahead,
@@ -106,7 +111,7 @@ class TestForecast(unittest.TestCase):
     
     def test_get_weather_forecast_scrapper_method_mock(self):
         with requests_mock.mock() as m:
-            data = bz2.BZ2File(str(pathlib.Path(root+'/data/test_response_scrapper_get_method.pbz2')), "rb")
+            data = bz2.BZ2File(str(emhass_conf['data_path'] / 'test_response_scrapper_get_method.pbz2'), "rb")
             data = cPickle.load(data)
             get_url = "https://clearoutside.com/forecast/"+str(round(self.fcst.lat, 2))+"/"+str(round(self.fcst.lon, 2))+"?desktop=true"
             m.get(get_url, content=data)
@@ -139,7 +144,7 @@ class TestForecast(unittest.TestCase):
 
     def test_get_weather_forecast_solcast_method_mock(self):
         with requests_mock.mock() as m:
-            data = bz2.BZ2File(str(pathlib.Path(root+'/data/test_response_solcast_get_method.pbz2')), "rb")
+            data = bz2.BZ2File(str(emhass_conf['data_path'] / 'test_response_solcast_get_method.pbz2'), "rb")
             data = cPickle.load(data)
             get_url = "https://api.solcast.com.au/rooftop_sites/123456/forecasts?hours=24"
             m.get(get_url, json=data.json())
@@ -154,7 +159,7 @@ class TestForecast(unittest.TestCase):
         
     def test_get_weather_forecast_solarforecast_method_mock(self):
         with requests_mock.mock() as m:
-            data = bz2.BZ2File(str(pathlib.Path(root+'/data/test_response_solarforecast_get_method.pbz2')), "rb")
+            data = bz2.BZ2File(str(emhass_conf['data_path'] / 'test_response_solarforecast_get_method.pbz2'), "rb")
             data = cPickle.load(data)
             for i in range(len(self.plant_conf['module_model'])):
                 get_url = "https://api.forecast.solar/estimate/"+str(round(self.fcst.lat, 2))+"/"+str(round(self.fcst.lon, 2))+\
@@ -171,7 +176,7 @@ class TestForecast(unittest.TestCase):
                                 int(self.optim_conf['delta_forecast'].total_seconds()/3600/self.fcst.timeStep))
 
     def test_get_forecasts_with_lists(self):
-        with open(root+'/config_emhass.yaml', 'r') as file:
+        with open(emhass_conf['config_path'], 'r') as file:
             params = yaml.load(file, Loader=yaml.FullLoader)
         params.update({
             'params_secrets': {
@@ -192,7 +197,7 @@ class TestForecast(unittest.TestCase):
         runtimeparams_json = json.dumps(runtimeparams)
         params['passed_data'] = runtimeparams
         params_json = json.dumps(params)
-        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse(pathlib.Path(root+'/config_emhass.yaml'), 
+        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse((emhass_conf['config_path']), 
                                                                     use_secrets=False, params=params_json)
         set_type = "dayahead-optim"
         params, retrieve_hass_conf, optim_conf, plant_conf = treat_runtimeparams(
@@ -200,9 +205,9 @@ class TestForecast(unittest.TestCase):
             optim_conf, plant_conf, set_type, logger)
         rh = RetrieveHass(retrieve_hass_conf['hass_url'], retrieve_hass_conf['long_lived_token'], 
                           retrieve_hass_conf['freq'], retrieve_hass_conf['time_zone'],
-                          params, root, logger)
+                          params, emhass_conf, logger)
         if self.get_data_from_file:
-            with open(pathlib.Path(root+'/data/test_df_final.pkl'), 'rb') as inp:
+            with open((emhass_conf['data_path'] / 'test_df_final.pkl'), 'rb') as inp:
                 rh.df_final, days_list, var_list = pickle.load(inp)
         else:
             days_list = get_days_list(retrieve_hass_conf['days_to_retrieve'])
@@ -215,7 +220,7 @@ class TestForecast(unittest.TestCase):
                         var_interp = retrieve_hass_conf['var_interp'])
         df_input_data = rh.df_final.copy()
         fcst = Forecast(retrieve_hass_conf, optim_conf, plant_conf, 
-                        params_json, root, logger, get_data_from_file=True)
+                        params_json, emhass_conf, logger, get_data_from_file=True)
         df_input_data = copy.deepcopy(df_input_data).iloc[-49:-1]
         P_PV_forecast = fcst.get_weather_forecast(method='list')
         df_input_data.index = P_PV_forecast.index
@@ -246,7 +251,7 @@ class TestForecast(unittest.TestCase):
         self.assertTrue(df_input_data['unit_prod_price'].values[0] == 1)
         self.assertTrue(df_input_data['unit_prod_price'].values[-1] == 48)
         # Test with longer lists
-        with open(root+'/config_emhass.yaml', 'r') as file:
+        with open(emhass_conf['config_path'], 'r') as file:
             params = yaml.load(file, Loader=yaml.FullLoader)
         params.update({
             'params_secrets': {
@@ -267,14 +272,14 @@ class TestForecast(unittest.TestCase):
         runtimeparams_json = json.dumps(runtimeparams)
         params['passed_data'] = runtimeparams
         params_json = json.dumps(params)
-        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse(pathlib.Path(root+'/config_emhass.yaml'), 
+        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse((emhass_conf['config_path']), 
                                                                     use_secrets=False, params=params_json)
         optim_conf['delta_forecast'] = pd.Timedelta(days=2)
         params, retrieve_hass_conf, optim_conf, plant_conf = treat_runtimeparams(
             runtimeparams_json, params_json, retrieve_hass_conf, 
             optim_conf, plant_conf, set_type, logger)
         fcst = Forecast(retrieve_hass_conf, optim_conf, plant_conf, 
-                        params_json, root, logger, opt_time_delta=48, get_data_from_file=True)
+                        params_json, emhass_conf, logger, opt_time_delta=48, get_data_from_file=True)
         P_PV_forecast = fcst.get_weather_forecast(method='list')
         self.assertIsInstance(P_PV_forecast, type(pd.DataFrame()))
         self.assertIsInstance(P_PV_forecast.index, pd.core.indexes.datetimes.DatetimeIndex)
@@ -293,7 +298,7 @@ class TestForecast(unittest.TestCase):
         self.assertTrue(P_load_forecast.values[-1] == 2*48)
         
     def test_get_forecasts_with_lists_special_case(self):
-        with open(root+'/config_emhass.yaml', 'r') as file:
+        with open(emhass_conf['config_path'], 'r') as file:
             params = yaml.load(file, Loader=yaml.FullLoader)
         params.update({
             'params_secrets': {
@@ -312,7 +317,7 @@ class TestForecast(unittest.TestCase):
         runtimeparams_json = json.dumps(runtimeparams)
         params['passed_data'] = runtimeparams
         params_json = json.dumps(params)
-        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse(pathlib.Path(root+'/config_emhass.yaml'), 
+        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse((emhass_conf['config_path']), 
                                                                     use_secrets=False, params=params_json)
         set_type = "dayahead-optim"
         params, retrieve_hass_conf, optim_conf, plant_conf = treat_runtimeparams(
@@ -320,9 +325,9 @@ class TestForecast(unittest.TestCase):
             optim_conf, plant_conf, set_type, logger)
         rh = RetrieveHass(retrieve_hass_conf['hass_url'], retrieve_hass_conf['long_lived_token'], 
                           retrieve_hass_conf['freq'], retrieve_hass_conf['time_zone'],
-                          params, root, logger)
+                          params, emhass_conf, logger)
         if self.get_data_from_file:
-            with open(pathlib.Path(root+'/data/test_df_final.pkl'), 'rb') as inp:
+            with open(pathlib.Path(emhass_conf['data_path'] / 'test_df_final.pkl'), 'rb') as inp:
                 rh.df_final, days_list, var_list = pickle.load(inp)
         else:
             days_list = get_days_list(retrieve_hass_conf['days_to_retrieve'])
@@ -335,7 +340,7 @@ class TestForecast(unittest.TestCase):
                         var_interp = retrieve_hass_conf['var_interp'])
         df_input_data = rh.df_final.copy()
         fcst = Forecast(retrieve_hass_conf, optim_conf, plant_conf, 
-                        params_json, root, logger, get_data_from_file=True)
+                        params_json, emhass_conf, logger, get_data_from_file=True)
         df_input_data = copy.deepcopy(df_input_data).iloc[-49:-1]
         P_PV_forecast = fcst.get_weather_forecast()
         df_input_data.index = P_PV_forecast.index
@@ -367,7 +372,7 @@ class TestForecast(unittest.TestCase):
         self.plant_conf['modules_per_string'] = [8, 8]
         self.plant_conf['strings_per_inverter'] = [1, 1]
         self.fcst = Forecast(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
-                             None, root, logger, get_data_from_file=self.get_data_from_file)
+                             None, emhass_conf, logger, get_data_from_file=self.get_data_from_file)
         df_weather_scrap = self.fcst.get_weather_forecast(method='csv')
         P_PV_forecast = self.fcst.get_power_from_weather(df_weather_scrap)
         self.assertIsInstance(P_PV_forecast, pd.core.series.Series)
@@ -379,7 +384,7 @@ class TestForecast(unittest.TestCase):
         params = json.dumps({'passed_data':{'alpha':0.5,'beta':0.5}})
         df_input_data = self.input_data_dict['rh'].df_final.copy()
         self.fcst = Forecast(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
-                             params, root, logger, get_data_from_file=self.get_data_from_file)
+                             params, emhass_conf, logger, get_data_from_file=self.get_data_from_file)
         df_weather_scrap = self.fcst.get_weather_forecast(method='csv')
         P_PV_forecast = self.fcst.get_power_from_weather(df_weather_scrap, set_mix_forecast=True, df_now=df_input_data)
         self.assertIsInstance(P_PV_forecast, pd.core.series.Series)
@@ -400,7 +405,7 @@ class TestForecast(unittest.TestCase):
         params = json.dumps({'passed_data':{'alpha':0.5,'beta':0.5}})
         df_input_data = self.input_data_dict['rh'].df_final.copy()
         self.fcst = Forecast(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
-                             params, root, logger, get_data_from_file=self.get_data_from_file)
+                             params, emhass_conf, logger, get_data_from_file=self.get_data_from_file)
         P_load_forecast = self.fcst.get_load_forecast(set_mix_forecast=True, df_now=df_input_data)
         self.assertIsInstance(P_load_forecast, pd.core.series.Series)
         self.assertIsInstance(P_load_forecast.index, pd.core.indexes.datetimes.DatetimeIndex)
@@ -418,8 +423,6 @@ class TestForecast(unittest.TestCase):
     def test_get_load_forecast_mlforecaster(self):
         params = TestForecast.get_test_params()
         params_json = json.dumps(params)
-        config_path = pathlib.Path(root+'/config_emhass.yaml')
-        base_path = str(config_path.parent)
         costfun = 'profit'
         action = 'forecast-model-fit' # fit, predict and tune methods
         params = copy.deepcopy(json.loads(params_json))
@@ -434,14 +437,14 @@ class TestForecast(unittest.TestCase):
         params['passed_data'] = runtimeparams
         params['optim_conf']['load_forecast_method'] = 'mlforecaster'
         params_json = json.dumps(params)
-        input_data_dict = set_input_data_dict(config_path, base_path, costfun, params_json, runtimeparams_json, 
+        input_data_dict = set_input_data_dict(emhass_conf, costfun, params_json, runtimeparams_json, 
                                               action, logger, get_data_from_file=True)
         data = copy.deepcopy(input_data_dict['df_input_data'])
         model_type = input_data_dict['params']['passed_data']['model_type']
         var_model = input_data_dict['params']['passed_data']['var_model']
         sklearn_model = input_data_dict['params']['passed_data']['sklearn_model']
         num_lags = input_data_dict['params']['passed_data']['num_lags']
-        mlf = MLForecaster(data, model_type, var_model, sklearn_model, num_lags, root, logger)
+        mlf = MLForecaster(data, model_type, var_model, sklearn_model, num_lags, emhass_conf, logger)
         mlf.fit()
         P_load_forecast = input_data_dict['fcst'].get_load_forecast(method="mlforecaster", use_last_window=False, 
                                                                     debug=True, mlf=mlf)
@@ -457,7 +460,7 @@ class TestForecast(unittest.TestCase):
         self.assertTrue(self.fcst.var_load_cost in df_input_data.columns)
         self.assertTrue(df_input_data.isnull().sum().sum()==0)
         df_input_data = self.fcst.get_load_cost_forecast(self.df_input_data, method='csv',
-                                                         csv_path='/data/data_load_cost_forecast.csv')
+                                                         csv_path='data_load_cost_forecast.csv')
         self.assertTrue(self.fcst.var_load_cost in df_input_data.columns)
         self.assertTrue(df_input_data.isnull().sum().sum()==0)
         
@@ -466,7 +469,7 @@ class TestForecast(unittest.TestCase):
         self.assertTrue(self.fcst.var_prod_price in df_input_data.columns)
         self.assertTrue(df_input_data.isnull().sum().sum()==0)
         df_input_data = self.fcst.get_prod_price_forecast(self.df_input_data, method='csv',
-                                                          csv_path='/data/data_load_cost_forecast.csv')
+                                                          csv_path='data_load_cost_forecast.csv')
         self.assertTrue(self.fcst.var_prod_price in df_input_data.columns)
         self.assertTrue(df_input_data.isnull().sum().sum()==0)
         

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -16,22 +16,26 @@ from emhass.utils import get_root, get_yaml_parse, get_days_list, get_logger
 
 # the root folder
 root = str(get_root(__file__, num_parent=2))
+emhass_conf = {}
+emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
+emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
+emhass_conf['root_path'] = pathlib.Path(root)
 # create logger
-logger, ch = get_logger(__name__, root, save_to_file=False)
+logger, ch = get_logger(__name__, emhass_conf['root_path'], save_to_file=False)
 
 class TestOptimization(unittest.TestCase):
 
     def setUp(self):
         get_data_from_file = True
         params = None
-        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse(pathlib.Path(root+'/config_emhass.yaml'), use_secrets=False)
+        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse(pathlib.Path(emhass_conf['config_path']), use_secrets=False)
         self.retrieve_hass_conf, self.optim_conf, self.plant_conf = \
             retrieve_hass_conf, optim_conf, plant_conf
         self.rh = RetrieveHass(self.retrieve_hass_conf['hass_url'], self.retrieve_hass_conf['long_lived_token'], 
                                self.retrieve_hass_conf['freq'], self.retrieve_hass_conf['time_zone'],
-                               params, root, logger)
+                               params, emhass_conf, logger)
         if get_data_from_file:
-            with open(pathlib.Path(root+'/data/test_df_final.pkl'), 'rb') as inp:
+            with open(pathlib.Path(emhass_conf['data_path'] / 'test_df_final.pkl'), 'rb') as inp:
                 self.rh.df_final, self.days_list, self.var_list = pickle.load(inp)
         else:
             self.days_list = get_days_list(self.retrieve_hass_conf['days_to_retrieve'])
@@ -45,7 +49,7 @@ class TestOptimization(unittest.TestCase):
         self.df_input_data = self.rh.df_final.copy()
         
         self.fcst = Forecast(self.retrieve_hass_conf, self.optim_conf, self.plant_conf,
-                             params, root, logger, get_data_from_file=get_data_from_file)
+                             params, emhass_conf, logger, get_data_from_file=get_data_from_file)
         self.df_weather = self.fcst.get_weather_forecast(method='csv')
         self.P_PV_forecast = self.fcst.get_power_from_weather(self.df_weather)
         self.P_load_forecast = self.fcst.get_load_forecast(method=optim_conf['load_forecast_method'])
@@ -55,7 +59,7 @@ class TestOptimization(unittest.TestCase):
         self.costfun = 'profit'
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                self.costfun, root, logger)
+                                self.costfun, emhass_conf, logger)
         self.df_input_data = self.fcst.get_load_cost_forecast(self.df_input_data)
         self.df_input_data = self.fcst.get_prod_price_forecast(self.df_input_data)
         self.input_data_dict = {
@@ -87,7 +91,7 @@ class TestOptimization(unittest.TestCase):
         self.optim_conf.update({'set_nodischarge_to_grid': True})
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                self.costfun, root, logger)
+                                self.costfun, emhass_conf, logger)
         self.opt_res_dayahead = self.opt.perform_dayahead_forecast_optim(
             self.df_input_data_dayahead, self.P_PV_forecast, self.P_load_forecast)
         self.assertIsInstance(self.opt_res_dayahead, type(pd.DataFrame()))
@@ -95,7 +99,7 @@ class TestOptimization(unittest.TestCase):
         self.assertTrue('SOC_opt' in self.opt_res_dayahead.columns)
         self.assertAlmostEqual(self.opt_res_dayahead.loc[self.opt_res_dayahead.index[-1],'SOC_opt'], self.plant_conf['SOCtarget'])
         # Test table conversion
-        opt_res = pd.read_csv(root+'/data/opt_res_latest.csv', index_col='timestamp')
+        opt_res = pd.read_csv(emhass_conf['data_path'] / 'opt_res_latest.csv', index_col='timestamp')
         cost_cols = [i for i in opt_res.columns if 'cost_' in i]
         table = opt_res[cost_cols].reset_index().sum(numeric_only=True).to_frame(name='Cost Totals').reset_index()
         self.assertTrue(table.columns[0]=='index')
@@ -107,7 +111,7 @@ class TestOptimization(unittest.TestCase):
         self.optim_conf.update({'set_def_constant': [True, True]})
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                self.costfun, root, logger)
+                                self.costfun, emhass_conf, logger)
         self.opt_res_dayahead = self.opt.perform_dayahead_forecast_optim(
             self.df_input_data_dayahead, self.P_PV_forecast, self.P_load_forecast)
         self.assertTrue(self.opt.optim_status == 'Optimal')
@@ -115,7 +119,7 @@ class TestOptimization(unittest.TestCase):
         self.optim_conf.update({'set_def_constant': [True, True]})
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                self.costfun, root, logger)
+                                self.costfun, emhass_conf, logger)
         self.opt_res_dayahead = self.opt.perform_dayahead_forecast_optim(
             self.df_input_data_dayahead, self.P_PV_forecast, self.P_load_forecast)
         self.assertTrue(self.opt.optim_status == 'Optimal')
@@ -123,7 +127,7 @@ class TestOptimization(unittest.TestCase):
         self.optim_conf.update({'set_def_constant': [False, True]})
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                self.costfun, root, logger)
+                                self.costfun, emhass_conf, logger)
         self.opt_res_dayahead = self.opt.perform_dayahead_forecast_optim(
             self.df_input_data_dayahead, self.P_PV_forecast, self.P_load_forecast)
         self.assertTrue(self.opt.optim_status == 'Optimal')
@@ -131,7 +135,7 @@ class TestOptimization(unittest.TestCase):
         self.optim_conf.update({'set_def_constant': [False, True]})
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                self.costfun, root, logger)
+                                self.costfun, emhass_conf, logger)
         self.opt_res_dayahead = self.opt.perform_dayahead_forecast_optim(
             self.df_input_data_dayahead, self.P_PV_forecast, self.P_load_forecast)
         self.assertTrue(self.opt.optim_status == 'Optimal')
@@ -139,7 +143,7 @@ class TestOptimization(unittest.TestCase):
         self.optim_conf.update({'set_def_constant': [False, False]})
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                self.costfun, root, logger)
+                                self.costfun, emhass_conf, logger)
         self.opt_res_dayahead = self.opt.perform_dayahead_forecast_optim(
             self.df_input_data_dayahead, self.P_PV_forecast, self.P_load_forecast)
         self.assertTrue(self.opt.optim_status == 'Optimal')
@@ -152,7 +156,7 @@ class TestOptimization(unittest.TestCase):
         self.optim_conf['set_total_pv_sell'] = True
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                self.costfun, root, logger)
+                                self.costfun, emhass_conf, logger)
         
         unit_load_cost = self.df_input_data_dayahead[self.opt.var_load_cost].values
         unit_prod_price = self.df_input_data_dayahead[self.opt.var_prod_price].values
@@ -170,7 +174,7 @@ class TestOptimization(unittest.TestCase):
         costfun = 'self-consumption'
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                costfun, root, logger)
+                                costfun, emhass_conf, logger)
         self.df_input_data_dayahead = self.fcst.get_load_cost_forecast(self.df_input_data_dayahead)
         self.df_input_data_dayahead = self.fcst.get_prod_price_forecast(self.df_input_data_dayahead)
         self.opt_res_dayahead = self.opt.perform_dayahead_forecast_optim(
@@ -184,7 +188,7 @@ class TestOptimization(unittest.TestCase):
         costfun = 'cost'
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                costfun, root, logger)
+                                costfun, emhass_conf, logger)
         self.df_input_data_dayahead = self.fcst.get_load_cost_forecast(self.df_input_data_dayahead)
         self.df_input_data_dayahead = self.fcst.get_prod_price_forecast(self.df_input_data_dayahead)
         self.opt_res_dayahead = self.opt.perform_dayahead_forecast_optim(
@@ -200,7 +204,7 @@ class TestOptimization(unittest.TestCase):
         self.optim_conf['set_def_constant'] = [True, True]
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                self.costfun, root, logger)
+                                self.costfun, emhass_conf, logger)
         self.df_input_data_dayahead = self.fcst.get_load_cost_forecast(self.df_input_data_dayahead)
         self.df_input_data_dayahead = self.fcst.get_prod_price_forecast(self.df_input_data_dayahead)
         self.opt_res_dayahead = self.opt.perform_dayahead_forecast_optim(
@@ -216,7 +220,7 @@ class TestOptimization(unittest.TestCase):
                 self.optim_conf['lp_solver_path'] = os.getenv("LP_SOLVER_PATH", default=None)            
             self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                     self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                    self.costfun, root, logger)
+                                    self.costfun, emhass_conf, logger)
             self.df_input_data_dayahead = self.fcst.get_load_cost_forecast(self.df_input_data_dayahead)
             self.df_input_data_dayahead = self.fcst.get_prod_price_forecast(self.df_input_data_dayahead)
             self.opt_res_dayahead = self.opt.perform_dayahead_forecast_optim(
@@ -232,7 +236,7 @@ class TestOptimization(unittest.TestCase):
         self.optim_conf.update({'set_use_battery': True})
         self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price,  
-                                self.costfun, root, logger)
+                                self.costfun, emhass_conf, logger)
         prediction_horizon = 10
         soc_init = 0.4
         soc_final = 0.6

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -14,8 +14,13 @@ from emhass.utils import get_root, get_yaml_parse, get_days_list, get_logger
 
 # the root folder
 root = str(get_root(__file__, num_parent=2))
+emhass_conf = {}
+emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
+emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
+emhass_conf['root_path'] = pathlib.Path(root)
+
 # create logger
-logger, ch = get_logger(__name__, root, save_to_file=False)
+logger, ch = get_logger(__name__, emhass_conf['root_path'], save_to_file=False)
 
 class TestRetrieveHass(unittest.TestCase):
 
@@ -23,13 +28,13 @@ class TestRetrieveHass(unittest.TestCase):
         get_data_from_file = True
         save_data_to_file = False
         params = None
-        retrieve_hass_conf, _, _ = get_yaml_parse(pathlib.Path(root+'/config_emhass.yaml'), use_secrets=False)
+        retrieve_hass_conf, _, _ = get_yaml_parse(pathlib.Path(emhass_conf['config_path']), use_secrets=False)
         self.retrieve_hass_conf = retrieve_hass_conf
         self.rh = RetrieveHass(self.retrieve_hass_conf['hass_url'], self.retrieve_hass_conf['long_lived_token'], 
                                self.retrieve_hass_conf['freq'], self.retrieve_hass_conf['time_zone'],
-                               params, root, logger, get_data_from_file=get_data_from_file)
+                               params, emhass_conf, logger, get_data_from_file=get_data_from_file)
         if get_data_from_file:
-            with open(pathlib.Path(root+'/data/test_df_final.pkl'), 'rb') as inp:
+            with open(pathlib.Path(emhass_conf['data_path'] / 'test_df_final.pkl'), 'rb') as inp:
                 self.rh.df_final, self.days_list, self.var_list = pickle.load(inp)
         else:
             self.days_list = get_days_list(self.retrieve_hass_conf['days_to_retrieve'])
@@ -37,13 +42,13 @@ class TestRetrieveHass(unittest.TestCase):
             self.rh.get_data(self.days_list, self.var_list,
                              minimal_response=False, significant_changes_only=False)
             if save_data_to_file:
-                with open(pathlib.Path(root+'/data/test_df_final.pkl'), 'wb') as outp:
+                with open(pathlib.Path(emhass_conf['data_path'] / 'test_df_final.pkl'), 'wb') as outp:
                     pickle.dump((self.rh.df_final, self.days_list, self.var_list), 
                                 outp, pickle.HIGHEST_PROTOCOL)
         self.df_raw = self.rh.df_final.copy()
         
     def test_get_yaml_parse(self):
-        with open(root+'/config_emhass.yaml', 'r') as file:
+        with open(emhass_conf['config_path'], 'r') as file:
             params = yaml.load(file, Loader=yaml.FullLoader)
         params.update({
             'params_secrets': {
@@ -56,7 +61,7 @@ class TestRetrieveHass(unittest.TestCase):
             }
             })
         params = json.dumps(params)
-        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse(pathlib.Path(root+'/config_emhass.yaml'), 
+        retrieve_hass_conf, optim_conf, plant_conf = get_yaml_parse(pathlib.Path(emhass_conf['config_path']), 
                                                                     use_secrets=True, params=params)
         self.assertIsInstance(retrieve_hass_conf, dict)
         self.assertTrue('hass_url' in retrieve_hass_conf.keys())
@@ -65,7 +70,7 @@ class TestRetrieveHass(unittest.TestCase):
         self.assertIsInstance(plant_conf, dict)
     
     def test_yaml_parse_wab_server(self):
-        with open(pathlib.Path(root) / "config_emhass.yaml", 'r') as file:
+        with open(emhass_conf['config_path'], 'r') as file:
             config = yaml.load(file, Loader=yaml.FullLoader)
         retrieve_hass_conf = config['retrieve_hass_conf']
         optim_conf = config['optim_conf']
@@ -90,7 +95,7 @@ class TestRetrieveHass(unittest.TestCase):
         with requests_mock.mock() as m:
             days_list = get_days_list(1)
             var_list = [self.retrieve_hass_conf['var_load']]
-            data = bz2.BZ2File(str(pathlib.Path(root+'/data/test_response_get_data_get_method.pbz2')), "rb")
+            data = bz2.BZ2File(str(pathlib.Path(emhass_conf['data_path'] / 'test_response_get_data_get_method.pbz2')), "rb")
             data = cPickle.load(data)
             m.get(self.retrieve_hass_conf['hass_url'], json=data.json())
             self.rh.get_data(days_list, var_list,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,14 +9,19 @@ from emhass import utils
 
 # the root folder
 root = str(utils.get_root(__file__, num_parent=2))
+emhass_conf = {}
+emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
+emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
+emhass_conf['root_path'] = pathlib.Path(root)
+
 # create logger
-logger, ch = utils.get_logger(__name__, root, save_to_file=False)
+logger, ch = utils.get_logger(__name__, emhass_conf['root_path'], save_to_file=False)
 
 class TestCommandLineUtils(unittest.TestCase):
     
     @staticmethod
     def get_test_params():
-        with open(root+'/config_emhass.yaml', 'r') as file:
+        with open(emhass_conf['config_path'], 'r') as file:
             params = yaml.load(file, Loader=yaml.FullLoader)
         params.update({
             'params_secrets': {
@@ -47,16 +52,16 @@ class TestCommandLineUtils(unittest.TestCase):
         self.params_json = json.dumps(params)
         
     def test_get_yaml_parse(self):
-        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(pathlib.Path(root+'/config_emhass.yaml'), use_secrets=False)
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(pathlib.Path(emhass_conf['config_path']), use_secrets=False)
         self.assertIsInstance(retrieve_hass_conf, dict)
         self.assertIsInstance(optim_conf, dict)
         self.assertIsInstance(plant_conf, dict)
         self.assertTrue(retrieve_hass_conf['alt'] == 4807.8)
-        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(pathlib.Path(root+'/config_emhass.yaml'), use_secrets=True, params=self.params_json)
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(pathlib.Path(emhass_conf['config_path']), use_secrets=True, params=self.params_json)
         self.assertTrue(retrieve_hass_conf['alt'] == 8000.0)
         
     def test_get_forecast_dates(self):
-        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(pathlib.Path(root+'/config_emhass.yaml'), use_secrets=True, params=self.params_json)
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(pathlib.Path(emhass_conf['config_path']), use_secrets=True, params=self.params_json)
         freq = int(retrieve_hass_conf['freq'].seconds/60.0)
         delta_forecast = int(optim_conf['delta_forecast'].days)
         forecast_dates = utils.get_forecast_dates(freq, delta_forecast)
@@ -65,7 +70,7 @@ class TestCommandLineUtils(unittest.TestCase):
         
     def test_treat_runtimeparams(self):
         retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(
-            pathlib.Path(root+'/config_emhass.yaml'), use_secrets=True, params=self.params_json)
+            pathlib.Path(emhass_conf['config_path']), use_secrets=True, params=self.params_json)
         set_type = 'dayahead-optim'
         params, retrieve_hass_conf, optim_conf, plant_conf = utils.treat_runtimeparams(
             self.runtimeparams_json, self.params_json,
@@ -92,7 +97,7 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertTrue(params['passed_data']['def_total_hours'] == optim_conf['def_total_hours'])
         # This will be the case when using emhass in standalone mode
         retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(
-            pathlib.Path(root+'/config_emhass.yaml'), use_secrets=True, params=self.params_json)
+            pathlib.Path(emhass_conf['config_path']), use_secrets=True, params=self.params_json)
         params = json.dumps(None)
         params, retrieve_hass_conf, optim_conf, plant_conf = utils.treat_runtimeparams(
             self.runtimeparams_json, params,
@@ -133,7 +138,7 @@ class TestCommandLineUtils(unittest.TestCase):
         runtimeparams.update({'custom_deferrable_forecast_id':'my_custom_deferrable_forecast_id'})
         runtimeparams_json = json.dumps(runtimeparams)
         retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(
-            pathlib.Path(root+'/config_emhass.yaml'), use_secrets=True, params=self.params_json)
+            pathlib.Path(emhass_conf['config_path']), use_secrets=True, params=self.params_json)
         set_type = 'dayahead-optim'
         params, retrieve_hass_conf, optim_conf, plant_conf = utils.treat_runtimeparams(
             runtimeparams_json, self.params_json,
@@ -183,7 +188,7 @@ class TestCommandLineUtils(unittest.TestCase):
         params['optim_conf']['prod_price_forecast_method'] = 'list'
         params_json = json.dumps(params)
         retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(
-            pathlib.Path(root+'/config_emhass.yaml'), use_secrets=True, params=params_json)
+            pathlib.Path(emhass_conf['config_path']), use_secrets=True, params=params_json)
         set_type = 'dayahead-optim'
         params, retrieve_hass_conf, optim_conf, plant_conf = utils.treat_runtimeparams(
             runtimeparams_json, params_json,
@@ -209,7 +214,7 @@ class TestCommandLineUtils(unittest.TestCase):
         params['optim_conf']['prod_price_forecast_method'] = 'list'
         params_json = json.dumps(params)
         retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(
-            pathlib.Path(root+'/config_emhass.yaml'), use_secrets=True, params=params_json)
+            pathlib.Path(emhass_conf['config_path']), use_secrets=True, params=params_json)
         set_type = 'dayahead-optim'
         params, retrieve_hass_conf, optim_conf, plant_conf = utils.treat_runtimeparams(
             runtimeparams_json, params_json,
@@ -222,7 +227,7 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertIsInstance(runtimeparams['prod_price_forecast'], str)
     
     def test_build_params(self):
-        config_path = root / pathlib.Path("config_emhass.yaml")
+        config_path = emhass_conf['config_path']
         with open(config_path, 'r') as file:
             config = yaml.load(file, Loader=yaml.FullLoader)
         retrieve_hass_conf = config['retrieve_hass_conf']
@@ -232,7 +237,7 @@ class TestCommandLineUtils(unittest.TestCase):
         params['retrieve_hass_conf'] = retrieve_hass_conf
         params['optim_conf'] = optim_conf
         params['plant_conf'] = plant_conf
-        options_json = root / pathlib.Path("options.json")
+        options_json = emhass_conf['root_path'] / pathlib.Path("options.json")
         # Read options info
         with options_json.open('r') as data:
             options = json.load(data)


### PR DESCRIPTION
Will do more checking tomorrow. Here early for progress and help.

### Added Dictionary var containing EMHASS paths
`emhass_config` dictionary has been created *(currently, containing `data` and `config` paths)* to try and add directory structure consistency though the program.

Currently, if the `data` path is outside the root EMHASS directory, certain errors may occur from some hard coded paths.
emhass_config tried to change this by  passing in a dictionary to *(I believe)* all sub models.
 
### MLForcaster error suppression 
Added some more error suppression. (more testing should be done)
MLForcaster wise, I'm still not supper confident with how MLForcaster works. My assumption is, if there is missing data in the sensor, that days worth gets rejected, Causing the "ValueError: All arrays must be of the same length" error. (between `forecast_dates` and `forecast_out.`). 
I have added  an if statement to notify the user of the issue, replacing the ValueError. This however doesn't fix the issue.