### PR TITLE
patch: Tests still succeed when sensor param changes in emhass_config

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -70,6 +70,10 @@ def set_input_data_dict(emhass_conf: dict, costfun: str,
         if get_data_from_file:
             with open(emhass_conf['data_path'] / 'test_df_final.pkl', 'rb') as inp:
                 rh.df_final, days_list, var_list = pickle.load(inp)
+            retrieve_hass_conf['var_load'] = str(var_list[0])
+            retrieve_hass_conf['var_PV'] = str(var_list[1])
+            retrieve_hass_conf['var_interp'] = [retrieve_hass_conf['var_PV'], retrieve_hass_conf['var_load']]
+            retrieve_hass_conf['var_replace_zero'] = [retrieve_hass_conf['var_PV']]
         else:
             days_list = utils.get_days_list(retrieve_hass_conf['days_to_retrieve'])
             var_list = [retrieve_hass_conf['var_load'], retrieve_hass_conf['var_PV']]
@@ -107,6 +111,10 @@ def set_input_data_dict(emhass_conf: dict, costfun: str,
         if get_data_from_file:
             with open(emhass_conf['data_path'] / 'test_df_final.pkl', 'rb') as inp:
                 rh.df_final, days_list, var_list = pickle.load(inp)
+            retrieve_hass_conf['var_load'] = str(var_list[0])
+            retrieve_hass_conf['var_PV'] = str(var_list[1])
+            retrieve_hass_conf['var_interp'] = [retrieve_hass_conf['var_PV'], retrieve_hass_conf['var_load']]
+            retrieve_hass_conf['var_replace_zero'] = [retrieve_hass_conf['var_PV']]
         else:
             days_list = utils.get_days_list(1)
             var_list = [retrieve_hass_conf['var_load'], retrieve_hass_conf['var_PV']]

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -629,7 +629,12 @@ class Forecast(object):
             if self.get_data_from_file:
                 filename_path = self.emhass_conf['data_path'] / 'test_df_final.pkl'
                 with open(filename_path, 'rb') as inp:
-                    rh.df_final, days_list, _ = pickle.load(inp)
+                    rh.df_final, days_list, var_list = pickle.load(inp)
+                    self.var_load = var_list[0]
+                    self.retrieve_hass_conf['var_load'] = self.var_load
+                    var_interp = [var_list[0]]
+                    self.var_list = [var_list[0]]
+                    self.var_load_new = self.var_load+'_positive'
             else:
                 days_list = get_days_list(days_min_load_forecast) 
                 if not rh.get_data(days_list, var_list):

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -37,8 +37,12 @@ class TestCommandLineUtils(unittest.TestCase):
                 'lat': 45.83,
                 'lon': 6.86,
                 'alt': 8000.0
-            }
-            })
+            }})
+        #Force config params for testing
+        params["retrieve_hass_conf"]['var_PV'] = 'sensor.power_photovoltaics'
+        params["retrieve_hass_conf"]['var_load'] = 'sensor.power_load_no_var_loads'
+        params["retrieve_hass_conf"]['var_replace_zero'] = ['sensor.power_photovoltaics']
+        params["retrieve_hass_conf"]['var_interp'] = ['sensor.power_photovoltaics','sensor.power_load_no_var_loads'] 
         return params
 
     def setUp(self):
@@ -322,7 +326,7 @@ class TestCommandLineUtils(unittest.TestCase):
         self.assertEqual(opt_res, None)
         
     @patch('sys.argv', ['main', '--action', 'perfect-optim', '--config', str(emhass_conf['config_path']), 
-                        '--debug', 'True'])
+                        '--debug', 'True', '--params', json.dumps(get_test_params())])
     def test_main_perfect_forecast_optim(self):
         opt_res = main()
         self.assertIsInstance(opt_res, pd.DataFrame)

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -55,6 +55,10 @@ class TestForecast(unittest.TestCase):
         if self.get_data_from_file:
             with open(emhass_conf['data_path'] / 'test_df_final.pkl', 'rb') as inp:
                 self.rh.df_final, self.days_list, self.var_list = pickle.load(inp)
+            self.retrieve_hass_conf['var_load'] = str(self.var_list[0])
+            self.retrieve_hass_conf['var_PV'] = str(self.var_list[1])
+            self.retrieve_hass_conf['var_interp'] = [retrieve_hass_conf['var_PV'], retrieve_hass_conf['var_load']]
+            self.retrieve_hass_conf['var_replace_zero'] = [retrieve_hass_conf['var_PV']]
         else:
             self.days_list = utils.get_days_list(self.retrieve_hass_conf['days_to_retrieve'])
             self.var_list = [self.retrieve_hass_conf['var_load'], self.retrieve_hass_conf['var_PV']]
@@ -74,7 +78,7 @@ class TestForecast(unittest.TestCase):
         self.P_load_forecast = self.fcst.get_load_forecast(method=optim_conf['load_forecast_method'])
         self.df_input_data_dayahead = pd.concat([self.P_PV_forecast, self.P_load_forecast], axis=1)
         self.df_input_data_dayahead.columns = ['P_PV_forecast', 'P_load_forecast']
-        self.opt = Optimization(retrieve_hass_conf, optim_conf, plant_conf, 
+        self.opt = Optimization(self.retrieve_hass_conf, self.optim_conf, self.plant_conf, 
                                 self.fcst.var_load_cost, self.fcst.var_prod_price, 
                                 'profit', emhass_conf, logger)
         self.input_data_dict = {
@@ -209,6 +213,10 @@ class TestForecast(unittest.TestCase):
         if self.get_data_from_file:
             with open((emhass_conf['data_path'] / 'test_df_final.pkl'), 'rb') as inp:
                 rh.df_final, days_list, var_list = pickle.load(inp)
+            retrieve_hass_conf['var_load'] = str(self.var_list[0])
+            retrieve_hass_conf['var_PV'] = str(self.var_list[1])
+            retrieve_hass_conf['var_interp'] = [retrieve_hass_conf['var_PV'], retrieve_hass_conf['var_load']]
+            retrieve_hass_conf['var_replace_zero'] = [retrieve_hass_conf['var_PV']]
         else:
             days_list = utils.get_days_list(retrieve_hass_conf['days_to_retrieve'])
             var_list = [retrieve_hass_conf['var_load'], retrieve_hass_conf['var_PV']]
@@ -342,6 +350,10 @@ class TestForecast(unittest.TestCase):
         if self.get_data_from_file:
             with open(emhass_conf['data_path'] / 'test_df_final.pkl', 'rb') as inp:
                 rh.df_final, days_list, var_list = pickle.load(inp)
+            retrieve_hass_conf['var_load'] = str(self.var_list[0])
+            retrieve_hass_conf['var_PV'] = str(self.var_list[1])
+            retrieve_hass_conf['var_interp'] = [retrieve_hass_conf['var_PV'], retrieve_hass_conf['var_load']]
+            retrieve_hass_conf['var_replace_zero'] = [retrieve_hass_conf['var_PV']]
         else:
             days_list = utils.get_days_list(retrieve_hass_conf['days_to_retrieve'])
             var_list = [retrieve_hass_conf['var_load'], retrieve_hass_conf['var_PV']]

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -37,6 +37,10 @@ class TestOptimization(unittest.TestCase):
         if get_data_from_file:
             with open(emhass_conf['data_path'] / 'test_df_final.pkl', 'rb') as inp:
                 self.rh.df_final, self.days_list, self.var_list = pickle.load(inp)
+            self.retrieve_hass_conf['var_load'] = str(self.var_list[0])
+            self.retrieve_hass_conf['var_PV'] = str(self.var_list[1])
+            self.retrieve_hass_conf['var_interp'] = [retrieve_hass_conf['var_PV'], retrieve_hass_conf['var_load']]
+            self.retrieve_hass_conf['var_replace_zero'] = [retrieve_hass_conf['var_PV']]
         else:
             self.days_list = get_days_list(self.retrieve_hass_conf['days_to_retrieve'])
             self.var_list = [self.retrieve_hass_conf['var_load'], self.retrieve_hass_conf['var_PV']]

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -29,6 +29,13 @@ class TestRetrieveHass(unittest.TestCase):
         save_data_to_file = False
         params = None
         retrieve_hass_conf, _, _ = get_yaml_parse(emhass_conf, use_secrets=False)
+        
+        #Force config params for testing
+        retrieve_hass_conf['var_PV'] = 'sensor.power_photovoltaics'
+        retrieve_hass_conf['var_load'] = 'sensor.power_load_no_var_loads'
+        retrieve_hass_conf['var_replace_zero'] = ['sensor.power_photovoltaics']
+        retrieve_hass_conf['var_interp'] = ['sensor.power_photovoltaics','sensor.power_load_no_var_loads'] 
+        
         self.retrieve_hass_conf = retrieve_hass_conf
         self.rh = RetrieveHass(self.retrieve_hass_conf['hass_url'], self.retrieve_hass_conf['long_lived_token'], 
                                self.retrieve_hass_conf['freq'], self.retrieve_hass_conf['time_zone'],


### PR DESCRIPTION
Feel free to close, branch of #247. Additional commit added for a quick example. Allowing user to run Python tests even sensor parameters have been changed in the config file.
I think the better option is a dedicated .json file _(containing all required params)_, which all tests use as a  emhass_config replacement.
This is just there as a Feature Request alternative.