### PR TITLE
Fix root_path issue #283

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -417,9 +417,9 @@ class Forecast(object):
                 # Setting the main parameters of the PV plant
                 location = Location(latitude=self.lat, longitude=self.lon)
                 temp_params = TEMPERATURE_MODEL_PARAMETERS['sapm']['close_mount_glass_glass']
-                cec_modules =  bz2.BZ2File(pathlib.Path(__file__).parent / 'data/cec_modules.pbz2', "rb")
+                cec_modules = bz2.BZ2File(self.emhass_conf['root_path'] / 'data/cec_modules.pbz2', "rb")
                 cec_modules = cPickle.load(cec_modules)
-                cec_inverters = bz2.BZ2File(pathlib.Path(__file__).parent / 'data/cec_inverters.pbz2', "rb")
+                cec_inverters = bz2.BZ2File(self.emhass_conf['root_path'] / 'data/cec_inverters.pbz2', "rb")
                 cec_inverters = cPickle.load(cec_inverters)
                 if type(self.plant_conf['module_model']) == list:
                     P_PV_forecast = pd.Series(0, index=df_weather.index)

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -521,7 +521,7 @@ def get_yaml_parse(emhass_conf: dict, use_secrets: Optional[bool] = True,
         input_conf = json.loads(params)
     if use_secrets:
         if params is None:
-            with open(emhass_conf["root_path"] / 'secrets_emhass.yaml', 'r') as file: #assume secrets file is in root path 
+            with open(emhass_conf["config_path"].parent / 'secrets_emhass.yaml', 'r') as file: # Assume secrets and config file paths are the same 
                 input_secrets = yaml.load(file, Loader=yaml.FullLoader)
         else:
             input_secrets = input_conf.pop("params_secrets", None)

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -238,6 +238,7 @@ if __name__ == "__main__":
     CONFIG_PATH = os.getenv("CONFIG_PATH", default="/app/config_emhass.yaml")
     OPTIONS_PATH = os.getenv('OPTIONS_PATH', default="/app/options.json")
     DATA_PATH = os.getenv("DATA_PATH", default="/app/data/")
+    ROOT_PATH = os.getenv("ROOT_PATH", default=str(Path(__file__).parent))
     
     #options None by default
     options = None 
@@ -273,10 +274,11 @@ if __name__ == "__main__":
     #save paths to dictionary
     config_path = Path(CONFIG_PATH)
     data_path = Path(DATA_PATH)
+    root_path = Path(ROOT_PATH)
     emhass_conf = {}
     emhass_conf['config_path'] = config_path
     emhass_conf['data_path'] = data_path
-    emhass_conf['root_path'] = Path(config_path).parent #assume root is parent of config_path
+    emhass_conf['root_path'] = root_path 
     
     # Read the example default config file
     if config_path.exists():

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -25,11 +25,12 @@ from emhass.command_line import main
 from emhass import utils
 
 # create paths
+
 root = str(utils.get_root(__file__, num_parent=2))
 emhass_conf = {}
 emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
 emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
-emhass_conf['root_path'] = pathlib.Path(root)
+emhass_conf['root_path'] = pathlib.Path(root) / 'src/emhass/'
 
 # create logger
 logger, ch = utils.get_logger(__name__, emhass_conf, save_to_file=False)

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -20,7 +20,7 @@ root = str(utils.get_root(__file__, num_parent=2))
 emhass_conf = {}
 emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
 emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
-emhass_conf['root_path'] = pathlib.Path(root)
+emhass_conf['root_path'] = pathlib.Path(root) / 'src/emhass/'
 
 # create logger
 logger, ch = utils.get_logger(__name__, emhass_conf, save_to_file=False)

--- a/tests/test_machine_learning_forecaster.py
+++ b/tests/test_machine_learning_forecaster.py
@@ -23,7 +23,7 @@ root = str(utils.get_root(__file__, num_parent=2))
 emhass_conf = {}
 emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
 emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
-emhass_conf['root_path'] = pathlib.Path(root)
+emhass_conf['root_path'] = pathlib.Path(root) / 'src/emhass/'
 
 # create logger
 logger, ch = utils.get_logger(__name__, emhass_conf, save_to_file=False)

--- a/tests/test_machine_learning_regressor.py
+++ b/tests/test_machine_learning_regressor.py
@@ -18,7 +18,8 @@ root = str(utils.get_root(__file__, num_parent=2))
 emhass_conf = {}
 emhass_conf["config_path"] = pathlib.Path(root) / "config_emhass.yaml"
 emhass_conf["data_path"] = pathlib.Path(root) / "data/"
-emhass_conf["root_path"] = pathlib.Path(root)
+emhass_conf['root_path'] = pathlib.Path(root) / 'src/emhass/'
+
 # create logger
 logger, ch = utils.get_logger(__name__, emhass_conf, save_to_file=False)
 

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -19,7 +19,8 @@ root = str(get_root(__file__, num_parent=2))
 emhass_conf = {}
 emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
 emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
-emhass_conf['root_path'] = pathlib.Path(root)
+emhass_conf['root_path'] = pathlib.Path(root) / 'src/emhass/'
+
 # create logger
 logger, ch = get_logger(__name__, emhass_conf, save_to_file=False)
 

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -17,7 +17,7 @@ root = str(get_root(__file__, num_parent=2))
 emhass_conf = {}
 emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
 emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
-emhass_conf['root_path'] = pathlib.Path(root)
+emhass_conf['root_path'] = pathlib.Path(root) / 'src/emhass/'
 
 # create logger
 logger, ch = get_logger(__name__, emhass_conf, save_to_file=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ root = str(utils.get_root(__file__, num_parent=2))
 emhass_conf = {}
 emhass_conf['config_path'] = pathlib.Path(root) / 'config_emhass.yaml'
 emhass_conf['data_path'] = pathlib.Path(root) / 'data/'
-emhass_conf['root_path'] = pathlib.Path(root)
+emhass_conf['root_path'] = pathlib.Path(root) / 'src/emhass/'
 
 # create logger
 logger, ch = utils.get_logger(__name__, emhass_conf, save_to_file=False)
@@ -231,11 +231,11 @@ class TestCommandLineUtils(unittest.TestCase):
         params['retrieve_hass_conf'] = retrieve_hass_conf
         params['optim_conf'] = optim_conf
         params['plant_conf'] = plant_conf
-        options_json = emhass_conf['root_path'] / "options.json"
+        options_json = emhass_conf['config_path'].parent / "options.json"
         # Read options info
         with options_json.open('r') as data:
             options = json.load(data)
-        with open(emhass_conf['root_path'] / "secrets_emhass(example).yaml", 'r') as file:
+        with open(emhass_conf['config_path'].parent / "secrets_emhass(example).yaml", 'r') as file:
             params_secrets = yaml.load(file, Loader=yaml.FullLoader)
         addon = 1
         params = utils.build_params(params, params_secrets, options, addon, logger)


### PR DESCRIPTION
Related to: https://github.com/davidusb-geek/emhass/issues/283
Root_path has been set to `emhass` package root directory *(with file parent)*:
 - EMHASS install *(E.g. Docker Standalone/Add-on)* : `/usr/local/lib/python3.11/dist-packages/emhass`
 - EMHASS install with `--editable` *(E.g. Development environment)* : `${PWD}/emhass/src/emhass`
 
 Haven't tested this thoroughly, but should work.

