### PR TITLE
Implement start penalty functionality

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -340,6 +340,9 @@ class Optimization:
                     for i in set_I})
 
             # Treat the number of starts for a deferrable load
+            current_state = 1
+            if 'def_current_state' in self.optim_conf and len(self.optim_conf['def_current_state']) > k:
+                current_state = 1 if self.optim_conf['def_current_state'][k] else 0
             # P_deferrable < P_def_bin2 * 1 million
             # P_deferrable must be zero if P_def_bin2 is zero
             constraints.update({"constraint_pdef{}_start1_{}".format(k, i) :
@@ -350,9 +353,10 @@ class Optimization:
                 for i in set_I})
             # P_def_start + P_def_bin2[i-1] >= P_def_bin2[i]
             # If load is on this cycle (P_def_bin2[i] is 1) then P_def_start must be 1 OR P_def_bin2[i-1] must be 1
+            # For first timestep, use current state if provided by caller.
             constraints.update({"constraint_pdef{}_start2_{}".format(k, i):
                 plp.LpConstraint(
-                    e=P_def_start[k][i] - P_def_bin2[k][i] + (P_def_bin2[k][i-1] if i-1 >= 0 else 0),
+                    e=P_def_start[k][i] - P_def_bin2[k][i] + (P_def_bin2[k][i-1] if i-1 >= 0 else current_state),
                     sense=plp.LpConstraintGE,
                     rhs=0)
                 for i in set_I})

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -414,7 +414,7 @@ def treat_runtimeparams(runtimeparams: str, params: str, retrieve_hass_conf: dic
         if "def_end_timestep" in runtimeparams.keys():
             optim_conf["def_end_timestep"] = runtimeparams["def_end_timestep"]
         if "def_current_state" in runtimeparams.keys():
-            optim_conf["def_current_state"] = [bool(s) for s in runtimeparams["def_current_state"]
+            optim_conf["def_current_state"] = [bool(s) for s in runtimeparams["def_current_state"]]
         if "treat_def_as_semi_cont" in runtimeparams.keys():
             optim_conf["treat_def_as_semi_cont"] = [
                 eval(str(k).capitalize())

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -413,6 +413,8 @@ def treat_runtimeparams(runtimeparams: str, params: str, retrieve_hass_conf: dic
             optim_conf["def_start_timestep"] = runtimeparams["def_start_timestep"]
         if "def_end_timestep" in runtimeparams.keys():
             optim_conf["def_end_timestep"] = runtimeparams["def_end_timestep"]
+        if "def_current_state" in runtimeparams.keys():
+            optim_conf["def_current_state"] = [bool(s) for s in runtimeparams["def_current_state"]
         if "treat_def_as_semi_cont" in runtimeparams.keys():
             optim_conf["treat_def_as_semi_cont"] = [
                 eval(str(k).capitalize())


### PR DESCRIPTION
How to use:

* Set `def_start_penalty` to a list of floats. For each deferrable load with a penalty `P`, each time the deferrable load turns on will incur an additional cost of `P` • `P_deferrable_nom` • `cost of electricity at that time`. Intuitively, how many extra hours would the load have to run to avoid starting up again.
* Pass `def_current_state` in `runtime_params` to avoid incorrectly penalizing a start if a forecast is run when the load is already running.

I also made a couple of other supporting changes:

* Added unit tests for the relevant scenarios in `test_optimization.py`, plus one for the `set_def_constant` function. In doing so, I found a missing constraint for `set_def_constant` and added it to the optimizer (`P_def_bin2` was not constrained to be zero when `P_deferrable` was zero).
* Added comments for all the start-related constraints to help myself understand it.