### PR TITLE
weather_forecast_cache (solcast)

### DIFF
--- a/docs/forecasts.md
+++ b/docs/forecasts.md
@@ -12,7 +12,7 @@ EMHASS will basically need 4 forecasts to work properly:
 
 There are methods that are generalized to the 4 forecast needed. For all there forecasts it is possible to pass the data either as a passed list of values or by reading from a CSV file. With these methods it is then possible to use data from external forecast providers.
     
-Then there are the methods that are specific to each type of forecast and that proposed forecast treated and generated internally by this EMHASS forecast class. For the weather forecast a first method (`scrapper`) uses a scrapping to the ClearOutside webpage which proposes detailed forecasts based on Lat/Lon locations. Another method (`solcast`) is using the SolCast PV production forecast service. A final method (`solar.forecast`) is using another external service: Solar.Forecast, for which just the nominal PV peak installed power should be provided. Search the forecast section on the documentation for examples on how to implement these different methods.
+Then there are the methods that are specific to each type of forecast and that proposed forecast treated and generated internally by this EMHASS forecast class. For the weather forecast a first method (`scrapper`) uses a scrapping to the ClearOutside webpage which proposes detailed forecasts based on Lat/Lon locations. Another method (`solcast`) is using the Solcast PV production forecast service. A final method (`solar.forecast`) is using another external service: Solar.Forecast, for which just the nominal PV peak installed power should be provided. Search the forecast section on the documentation for examples on how to implement these different methods.
 
 The `get_power_from_weather` method is proposed here to convert from irradiance data to electrical power. The PVLib module is used to model the PV plant. A dedicated webapp will help you search for your correct PV module and inverter: [https://emhass-pvlib-database.streamlit.app/](https://emhass-pvlib-database.streamlit.app/)
 
@@ -29,19 +29,47 @@ For the PV production selling price and Load cost forecasts the privileged metho
 
 ## PV power production forecast
 
+#### scrapper 
+
 The default method for PV power forecast is the scrapping of weather forecast data from the [https://clearoutside.com/](https://clearoutside.com/) website. This is obtained using `method=scrapper`. This site proposes detailed forecasts based on Lat/Lon locations. This method seems quite stable but as with any scrape method it will fail if any changes are made to the webpage API. The weather forecast data is then converted into PV power production using the `list_pv_module_model` and `list_pv_inverter_model` paramters defined in the configuration.
 
-A second method uses the SolCast solar forecast service. Go to [https://solcast.com/](https://solcast.com/) and configure your system. You will need to set `method=solcast` and basically use two parameters `solcast_rooftop_id` and `solcast_api_key` that should be passed as parameters at runtime. This will be limited to 10 API requests per day, the granularity will be 30 min and the forecast is updated every 6h. If needed, better performances may be obtained with paid plans: [https://solcast.com/pricing/live-and-forecast](https://solcast.com/pricing/live-and-forecast).
+#### solcast 
+
+A second method uses the Solcast solar forecast service. Go to [https://solcast.com/](https://solcast.com/) and configure your system. You will need to set `method=solcast` and basically use two parameters `solcast_rooftop_id` and `solcast_api_key` that should be passed as parameters at runtime or provided in the configuration/secrets. The free hobbyist account will be limited to 10 API requests per day, the granularity will be 30 min and the forecast is updated every 6h. If needed, better performances may be obtained with paid plans: [https://solcast.com/pricing/live-and-forecast](https://solcast.com/pricing/live-and-forecast).
 
 For example:
+```yaml
+# Set weather_forecast_method parameter to solcast in your configuration (configuration page / config_emhass.yaml)
+weather_forecast_method: 'solcast'
 ```
+
+```bash
 curl -i -H "Content-Type:application/json" -X POST -d '{"solcast_rooftop_id":"<your_system_id>","solcast_api_key":"<your_secret_api_key>"}' http://localhost:5000/action/dayahead-optim
 ```
+</br>
+For those who use the free plan and wish to use Solcast with MPC, you may wish to cache the output of a Solcast weather forecast request, then reference it in your automated MPC actions:
 
-A third method uses the Solar.Forecast service. You will need to set `method=solar.forecast` and use just one parameter `solar_forecast_kwp` (the PV peak installed power in kW) that should be passed at runtime. This will be using the free public Solar.Forecast account with 12 API requests per hour, per IP, and 1h data resolution. As with SolCast, there are paid account services that may results in better forecasts.
+```bash
+# Run forecast and cache results (Recommended to run this 1-10 times a day, throughout the day)
+curl -i -H 'Content-Type:application/json' -X POST -d {} http://localhost:5000/action/forecast-cache
+
+# Then run your regular MPC call (E.g. every 5 minutes)
+curl -i -H 'Content-Type:application/json' -X POST -d {} http://localhost:5000/action/naive-mpc-optim
+```
+
+`weather_forecast_cache` can also be provided via a optimization to save the forecast results to cache:
+```bash
+# Example of running day-ahead and optimization storing the retrieved Solcast data to cache
+curl -i -H 'Content-Type:application/json' -X POST -d '{"weather_forecast_cache":true}' http://localhost:5000/action/dayahead-optim
+```
+*The runtime parameter may be preferable for users that run a day-ahead at the start of the day everyday*
+
+#### solar.forecast 
+
+A third method uses the Solar.Forecast service. You will need to set `method=solar.forecast` and use just one parameter `solar_forecast_kwp` (the PV peak installed power in kW) that should be passed at runtime. This will be using the free public Solar.Forecast account with 12 API requests per hour, per IP, and 1h data resolution. As with Solcast, there are paid account services that may results in better forecasts.
 
 For example, for a 5 kWp installation:
-```
+```bash
 curl -i -H "Content-Type:application/json" -X POST -d '{"solar_forecast_kwp":5}' http://localhost:5000/action/dayahead-optim
 ```
 
@@ -129,17 +157,17 @@ The possible dictionnary keys to pass data are:
 - `prod_price_forecast` for the PV production selling price forecast.
 
 For example if using the add-on or the standalone docker installation you can pass this data as list of values to the data dictionnary during the `curl` POST:
-```
+```bash
 curl -i -H "Content-Type: application/json" -X POST -d '{"pv_power_forecast":[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 141.22, 246.18, 513.5, 753.27, 1049.89, 1797.93, 1697.3, 3078.93, 1164.33, 1046.68, 1559.1, 2091.26, 1556.76, 1166.73, 1516.63, 1391.13, 1720.13, 820.75, 804.41, 251.63, 79.25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}' http://localhost:5000/action/dayahead-optim
 ```
 
 You need to be careful here to send the correct amount of data on this list, the correct length. For example, if the data time step is defined to 1h and you are performing a day-ahead optimization, then this list length should be of 24 data points.
 
-### Example using: SolCast forecast + Amber prices
+### Example using: Solcast forecast + Amber prices
 
-If you're using SolCast then you can define the following sensors in your system:
+If you're using Solcast then you can define the following sensors in your system:
 
-```
+```yaml
 sensors:
 
   - platform: rest
@@ -166,11 +194,11 @@ sensors:
           {%- endfor %} {{ (values_all.all)[:48] }}
 ```
 
-With this you can now feed this SolCast forecast to EMHASS along with the mapping of the Amber prices. 
+With this you can now feed this Solcast forecast to EMHASS along with the mapping of the Amber prices. 
 
 A MPC call may look like this for 4 deferrable loads:
 
-```
+```yaml
     post_mpc_optim_solcast: "curl -i -H \"Content-Type: application/json\" -X POST -d '{\"load_cost_forecast\":{{(
           ([states('sensor.amber_general_price')|float(0)] +
           state_attr('sensor.amber_general_forecast', 'forecasts') |map(attribute='per_kwh')|list)[:48])
@@ -184,7 +212,7 @@ A MPC call may look like this for 4 deferrable loads:
 
 Thanks to [@purcell_labs](https://github.com/purcell-lab) for this example configuration.
 
-### Example combining multiple SolCast configurations
+### Example combining multiple Solcast configurations
 
 If you have multiple rooftops, for example for east-west facing solar panels, then you will need to fuze the sensors providing the different forecasts on a single one using templates in Home Assistant. Then feed that single sensor data passing the data as a list when calling the shell command.
 
@@ -192,7 +220,7 @@ Here is a sample configuration to achieve this, thanks to [@gieljnssns](https://
 
 The two sensors using rest sensors:
 
-```
+```yaml
 - platform: rest
   name: "Solcast Forecast huis"
   json_attributes:
@@ -220,7 +248,7 @@ The two sensors using rest sensors:
 
 Then two templates, one for each sensor:
 
-```
+```yaml
     solcast_24hrs_forecast_garage:
       value_template: >-
         {%- set power = state_attr('sensor.solcast_forecast_garage', 'forecasts') | map(attribute='pv_estimate') | list %}
@@ -242,7 +270,7 @@ Then two templates, one for each sensor:
 
 And the fusion of the two sensors:
 
-```
+```yaml
     solcast_24hrs_forecast:
       value_template: >-
         {% set a = states("sensor.solcast_24hrs_forecast_garage")[1:-1].split(',') | map('int') | list %}
@@ -256,7 +284,7 @@ And the fusion of the two sensors:
 
 And finally the shell command:
 
-```
+```yaml
 dayahead_optim: "curl -i -H \"Content-Type:application/json\" -X POST -d '{\"pv_power_forecast\":{{states('sensor.solcast_24hrs_forecast')}}}' http://localhost:5001/action/dayahead-optim"
 ```
 
@@ -269,7 +297,7 @@ After setup the sensors should appear in Home Assistant for raw `today` and `tom
 
 The subsequent shell command to concatenate `today` and `tomorrow` values can be for example:
 
-```
+```yaml
 shell_command:
   trigger_nordpool_forecast: "curl -i -H \"Content-Type: application/json\" -X POST -d '{\"load_cost_forecast\":{{((state_attr('sensor.nordpool', 'raw_today') | map(attribute='value') | list  + state_attr('sensor.nordpool', 'raw_tomorrow') | map(attribute='value') | list))[now().hour:][:24] }},\"prod_price_forecast\":{{((state_attr('sensor.nordpool', 'raw_today') | map(attribute='value') | list  + state_attr('sensor.nordpool', 'raw_tomorrow') | map(attribute='value') | list))[now().hour:][:24]}}}' http://localhost:5000/action/dayahead-optim"
 ```

--- a/docs/mlforecaster.md
+++ b/docs/mlforecaster.md
@@ -35,7 +35,7 @@ The minimum number of `days_to_retrieve` is hard coded to 9 by default. But it i
 - `perform_backtest`: if `True` then a back testing routine is performed to evaluate the performance of the model on the complete train set.
 
 The default values for these parameters are:
-```
+```yaml
 runtimeparams = {
     "days_to_retrieve": 9,
     "model_type": "load_forecast",
@@ -48,7 +48,7 @@ runtimeparams = {
 ```
 
 A correct `curl` call to launch a model fit can look like this:
-```
+```bash
 curl -i -H "Content-Type:application/json" -X POST -d '{}' http://localhost:5000/action/forecast-model-fit
 ```
 
@@ -90,7 +90,7 @@ To obtain a prediction using a previously trained model use the `forecast-model-
 curl -i -H "Content-Type:application/json" -X POST -d '{}' http://localhost:5000/action/forecast-model-predict
 ```
 If needed pass the correct `model_type` like this:
-```
+```bash
 curl -i -H "Content-Type:application/json" -X POST -d '{"model_type": "load_forecast"}' http://localhost:5000/action/forecast-model-predict
 ```
 The resulting forecast DataFrame is shown in the webui.
@@ -108,7 +108,7 @@ The list of parameters needed to set the data publish task is:
 - `model_predict_friendly_name`: the `friendly_name` to be used.
 
 The default values for these parameters are:
-```
+```yaml
 runtimeparams = {
     "model_predict_publish": False,
     "model_predict_entity_id": "sensor.p_load_forecast_custom_model",
@@ -122,7 +122,7 @@ runtimeparams = {
 With a previously fitted model you can use the `forecast-model-tune` end point to tune its hyperparameters. This will be using bayeasian optimization with a wrapper of `optuna` in the `skforecast` module.
 
 You can pass the same parameter you defined during the fit step, but `var_model` has to be defined at least. According to the example, the syntax will be:
-```
+```bash
 curl -i -H "Content-Type:application/json" -X POST -d '{"var_model": "sensor.power_load_no_var_loads"}' http://localhost:5000/action/forecast-model-tune
 ```
 This will launch the optimization routine and optimize the internal hyperparamters of the `scikit-learn` regressor and it will find the optimal number of lags.

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -247,7 +247,7 @@ def set_input_data_dict(emhass_conf: dict, costfun: str,
     }
     return input_data_dict
 
-def forecast_cache(emhass_conf: dict, params: str, 
+def weather_forecast_cache(emhass_conf: dict, params: str, 
                    runtimeparams: str, logger: logging.Logger) -> bool:
     """
     Perform a call to get forecast function, intend to save results to cache.
@@ -273,12 +273,12 @@ def forecast_cache(emhass_conf: dict, params: str,
     params, retrieve_hass_conf, optim_conf, plant_conf = utils.treat_runtimeparams(
         runtimeparams, params, retrieve_hass_conf, optim_conf, plant_conf, "forecast", logger)
     
-    # Make sure forecast_cache is true
+    # Make sure weather_forecast_cache is true
     if (params != None) and (params != "null"):
         params = json.loads(params)
     else:
         params = {}
-    params["passed_data"]["forecast_cache"] = True
+    params["passed_data"]["weather_forecast_cache"] = True
     params = json.dumps(params)
 
     # Create Forecast object
@@ -1174,7 +1174,7 @@ def main():
         logger.error("Could not find emhass/src foulder in: " + str(root_path))
         logger.error("Try setting emhass root path with --root")
         return False
-    # Additionnal argument
+    # Additional argument
     try:
         parser.add_argument(
             "--version",

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -231,10 +231,10 @@ class Forecast(object):
                 if not self.params["passed_data"]["weather_forecast_cache_only"]:
                     # Retrieve data from the Solcast API
                     if 'solcast_api_key' not in self.retrieve_hass_conf:
-                        self.logger.error("The solcast_api_key parameter was not defined, using dummy values for testing.")
+                        self.logger.error("The solcast_api_key parameter was not defined")
                         return False
                     if 'solcast_rooftop_id' not in self.retrieve_hass_conf:
-                        self.logger.error("The solcast_rooftop_id parameter was not defined, using dummy values for testing.")
+                        self.logger.error("The solcast_rooftop_id parameter was not defined")
                         return False
                     headers = {
                         'User-Agent': 'EMHASS',
@@ -302,7 +302,7 @@ class Forecast(object):
                     if not isinstance(data, pd.DataFrame) or len(data) < len(self.forecast_dates):
                         self.logger.error("There has been a error obtaining cached Solcast forecast data.")
                         self.logger.error("Try running optimization again with 'weather_forecast_cache': true, or run action `forecast-cache`, to pull new data from Solcast and cache.")
-                        self.logger.info("Removing old Solcast cache file.")
+                        self.logger.warning("Removing old Solcast cache file. Next optimization will pull data from Solcast, unless 'weather_forecast_cache_only': true")
                         os.remove(w_forecast_cache_path)
                         return False
                     # Filter cached forecast data to match current forecast_dates start-end range (reduce forecast Dataframe size to appropriate length)
@@ -312,7 +312,7 @@ class Forecast(object):
                     else:
                         self.logger.error("Unable to obtain cached Solcast forecast data within the requested timeframe range.")
                         self.logger.error("Try running optimization again (not using cache). Optionally, add runtime parameter 'weather_forecast_cache': true to pull new data from Solcast and cache.")
-                        self.logger.info("Removing old Solcast cache file.")
+                        self.logger.warning("Removing old Solcast cache file. Next optimization will pull data from Solcast, unless 'weather_forecast_cache_only': true")
                         os.remove(w_forecast_cache_path)
                         return False    
         elif method == 'solar.forecast': # using the solar.forecast API

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -278,6 +278,8 @@ class Forecast(object):
                             cPickle.dump(data_cache, file)
                         if not os.path.isfile(w_forecast_cache_path):
                             self.logger.warning("Solcast Forecast data could not be saved to file")
+                        else:
+                            self.logger.ifno("Saved the Solcast results to cache, for later reference")    
                     # Trim request results to forecast_dates        
                     data_list = data_list[0:len(self.forecast_dates)]
                     data_dict = {'ts':self.forecast_dates, 'yhat':data_list}
@@ -296,6 +298,7 @@ class Forecast(object):
                     # Filter cached forecast data to match current forecast_dates start-end range (reduce forecast Dataframe size to appropriate length)
                     if self.forecast_dates[0] in data.index and self.forecast_dates[-1] in data.index:
                         data = data.loc[self.forecast_dates[0]:self.forecast_dates[-1]]
+                        self.logger.info("Retrieved Solcast data from the previously saved cache")
                     else:
                         self.logger.error("Unable to obtain cached Solcast forecast data within the requested timeframe range.")
                         self.logger.error("Try running optimization again. Optionally, add runtime parameter 'weather_forecast_cache': true to pull new data from Solcast and cache.")

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -275,7 +275,9 @@ class Forecast(object):
                         data_cache = pd.DataFrame.from_dict(cache_data_dict)
                         data_cache.set_index('ts', inplace=True)
                         with open(w_forecast_cache_path, "wb") as file:    
-                            cPickle.dump(data_cache, file)    
+                            cPickle.dump(data_cache, file)
+                        if not os.path.isfile(w_forecast_cache_path):
+                            self.logger.warning("Solcast Forecast data could not be saved to file")
                     # Trim request results to forecast_dates        
                     data_list = data_list[0:len(self.forecast_dates)]
                     data_dict = {'ts':self.forecast_dates, 'yhat':data_list}
@@ -296,7 +298,9 @@ class Forecast(object):
                         data = data.loc[self.forecast_dates[0]:self.forecast_dates[-1]]
                     else:
                         self.logger.error("Unable to obtain cached Solcast forecast data within the requested timeframe range.")
-                        self.logger.error("Try running optimization again with 'weather_forecast_cache': true to pull new data from Solcast and cache.")
+                        self.logger.error("Try running optimization again. Optionally, add runtime parameter 'weather_forecast_cache': true to pull new data from Solcast and cache.")
+                        self.logger.info("Removing Solcast cache file")
+                        os.remove(w_forecast_cache_path)
                         return False    
         elif method == 'solar.forecast': # using the solar.forecast API
             # Retrieve data from the solar.forecast API

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -299,8 +299,6 @@ class Forecast(object):
                     else:
                         self.logger.error("Unable to obtain cached Solcast forecast data within the requested timeframe range.")
                         self.logger.error("Try running optimization again. Optionally, add runtime parameter 'weather_forecast_cache': true to pull new data from Solcast and cache.")
-                        self.logger.info("Removing Solcast cache file")
-                        os.remove(w_forecast_cache_path)
                         return False    
         elif method == 'solar.forecast': # using the solar.forecast API
             # Retrieve data from the solar.forecast API

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -227,81 +227,93 @@ class Forecast(object):
         elif method == 'solcast': # using Solcast API
             # Check if weather_forecast_cache is true or if forecast_data file does not exist
             if self.params["passed_data"]["weather_forecast_cache"] or not os.path.isfile(w_forecast_cache_path):
-                # Retrieve data from the Solcast API
-                if 'solcast_api_key' not in self.retrieve_hass_conf:
-                    self.logger.error("The solcast_api_key parameter was not defined, using dummy values for testing")
-                    return False
-                if 'solcast_rooftop_id' not in self.retrieve_hass_conf:
-                    self.logger.error("The solcast_rooftop_id parameter was not defined, using dummy values for testing")
-                    return False
-                headers = {
-                    'User-Agent': 'EMHASS',
-                    "Authorization": "Bearer " + self.retrieve_hass_conf['solcast_api_key'],
-                    "content-type": "application/json",
-                    }
-                days_solcast = int(len(self.forecast_dates)*self.freq.seconds/3600)
-                # If weather_forecast_cache, set request days as twice as long to avoid length issues (add a buffer) 
-                if self.params["passed_data"]["weather_forecast_cache"]:
-                    days_solcast = min((days_solcast * 2), 336)
-                url = "https://api.solcast.com.au/rooftop_sites/"+self.retrieve_hass_conf['solcast_rooftop_id']+"/forecasts?hours="+str(days_solcast)
-                response = get(url, headers=headers)
-                '''import bz2 # Uncomment to save a serialized data for tests
-                import _pickle as cPickle
-                with bz2.BZ2File("data/test_response_solcast_get_method.pbz2", "w") as f: 
-                    cPickle.dump(response, f)'''
-                # Verify the request passed
-                if int(response.status_code) == 200:
-                    data = response.json()
-                elif int(response.status_code) == 402 or int(response.status_code) == 429:
-                    self.logger.error("Solcast error: May have exceeded your subscription limit")
-                    return False  
-                elif int(response.status_code) >= 400 or int(response.status_code) >= 202:
-                    self.logger.error("Solcast error: There was a issue with the solcast request, check solcast API key and rooftop ID")
-                    self.logger.error("Solcast error: Check that your subscription is valid and your network can connect to Solcast")
-                    return False  
-                data_list = []
-                for elm in data['forecasts']:
-                    data_list.append(elm['pv_estimate']*1000) # Converting kW to W
-                # Check if the retrieved data has the correct length
-                if len(data_list) < len(self.forecast_dates):
-                    self.logger.error("Not enough data retried from Solcast service, try increasing the time step or use MPC")
-                else:
-                    # If runtime weather_forecast_cache is true save forecast result to file as cache
+                # Check if weather_forecast_cache_only is true, if so produce error for not finding cache file
+                if not self.params["passed_data"]["weather_forecast_cache_only"]:
+                    # Retrieve data from the Solcast API
+                    if 'solcast_api_key' not in self.retrieve_hass_conf:
+                        self.logger.error("The solcast_api_key parameter was not defined, using dummy values for testing.")
+                        return False
+                    if 'solcast_rooftop_id' not in self.retrieve_hass_conf:
+                        self.logger.error("The solcast_rooftop_id parameter was not defined, using dummy values for testing.")
+                        return False
+                    headers = {
+                        'User-Agent': 'EMHASS',
+                        "Authorization": "Bearer " + self.retrieve_hass_conf['solcast_api_key'],
+                        "content-type": "application/json",
+                        }
+                    days_solcast = int(len(self.forecast_dates)*self.freq.seconds/3600)
+                    # If weather_forecast_cache, set request days as twice as long to avoid length issues (add a buffer) 
                     if self.params["passed_data"]["weather_forecast_cache"]:
-                        # Add x2 forecast periods for cached results. This adds a extra delta_forecast amount of days for a buffer
-                        cached_forecast_dates =  self.forecast_dates.union(pd.date_range(self.forecast_dates[-1], periods=(len(self.forecast_dates) +1), freq=self.freq)[1:])
-                        cache_data_list = data_list[0:len(cached_forecast_dates)]
-                        cache_data_dict = {'ts':cached_forecast_dates, 'yhat':cache_data_list}
-                        data_cache = pd.DataFrame.from_dict(cache_data_dict)
-                        data_cache.set_index('ts', inplace=True)
-                        with open(w_forecast_cache_path, "wb") as file:    
-                            cPickle.dump(data_cache, file)
-                        if not os.path.isfile(w_forecast_cache_path):
-                            self.logger.warning("Solcast Forecast data could not be saved to file")
-                        else:
-                            self.logger.ifno("Saved the Solcast results to cache, for later reference")    
-                    # Trim request results to forecast_dates        
-                    data_list = data_list[0:len(self.forecast_dates)]
-                    data_dict = {'ts':self.forecast_dates, 'yhat':data_list}
-                    # Define DataFrame
-                    data = pd.DataFrame.from_dict(data_dict)
-                    # Define index
-                    data.set_index('ts', inplace=True)
-            # Else, open stored weather_forecast_data.pkl file for previous forecast data
+                        days_solcast = min((days_solcast * 2), 336)
+                    url = "https://api.solcast.com.au/rooftop_sites/"+self.retrieve_hass_conf['solcast_rooftop_id']+"/forecasts?hours="+str(days_solcast)
+                    response = get(url, headers=headers)
+                    '''import bz2 # Uncomment to save a serialized data for tests
+                    import _pickle as cPickle
+                    with bz2.BZ2File("data/test_response_solcast_get_method.pbz2", "w") as f: 
+                        cPickle.dump(response, f)'''
+                    # Verify the request passed
+                    if int(response.status_code) == 200:
+                        data = response.json()
+                    elif int(response.status_code) == 402 or int(response.status_code) == 429:
+                        self.logger.error("Solcast error: May have exceeded your subscription limit.")
+                        return False  
+                    elif int(response.status_code) >= 400 or int(response.status_code) >= 202:
+                        self.logger.error("Solcast error: There was a issue with the solcast request, check solcast API key and rooftop ID.")
+                        self.logger.error("Solcast error: Check that your subscription is valid and your network can connect to Solcast.")
+                        return False  
+                    data_list = []
+                    for elm in data['forecasts']:
+                        data_list.append(elm['pv_estimate']*1000) # Converting kW to W
+                    # Check if the retrieved data has the correct length
+                    if len(data_list) < len(self.forecast_dates):
+                        self.logger.error("Not enough data retried from Solcast service, try increasing the time step or use MPC.")
+                    else:
+                        # If runtime weather_forecast_cache is true save forecast result to file as cache
+                        if self.params["passed_data"]["weather_forecast_cache"]:
+                            # Add x2 forecast periods for cached results. This adds a extra delta_forecast amount of days for a buffer
+                            cached_forecast_dates =  self.forecast_dates.union(pd.date_range(self.forecast_dates[-1], periods=(len(self.forecast_dates) +1), freq=self.freq)[1:])
+                            cache_data_list = data_list[0:len(cached_forecast_dates)]
+                            cache_data_dict = {'ts':cached_forecast_dates, 'yhat':cache_data_list}
+                            data_cache = pd.DataFrame.from_dict(cache_data_dict)
+                            data_cache.set_index('ts', inplace=True)
+                            with open(w_forecast_cache_path, "wb") as file:    
+                                cPickle.dump(data_cache, file)
+                            if not os.path.isfile(w_forecast_cache_path):
+                                self.logger.warning("Solcast forecast data could not be saved to file.")
+                            else:
+                                self.logger.info("Saved the Solcast results to cache, for later reference.")    
+                        # Trim request results to forecast_dates        
+                        data_list = data_list[0:len(self.forecast_dates)]
+                        data_dict = {'ts':self.forecast_dates, 'yhat':data_list}
+                        # Define DataFrame
+                        data = pd.DataFrame.from_dict(data_dict)
+                        # Define index
+                        data.set_index('ts', inplace=True)
+            # Else, notify user to update cache
+                else:
+                    self.logger.error("Unable to obtain Solcast cache file.")
+                    self.logger.error("Try running optimization again with 'weather_forecast_cache_only': false")
+                    self.logger.error("Optionally, obtain new Solcast cache with runtime parameter 'weather_forecast_cache': true in an optimization, or run the `forecast-cache` action, to pull new data from Solcast and cache.")
+                    return False
+            # Else, open stored weather_forecast_data.pkl file for previous forecast data (cached data)
             else:
                 with open(w_forecast_cache_path, "rb") as file:
                     data = cPickle.load(file)
                     if not isinstance(data, pd.DataFrame) or len(data) < len(self.forecast_dates):
                         self.logger.error("There has been a error obtaining cached Solcast forecast data.")
-                        self.logger.error("Try running optimization again with 'weather_forecast_cache': true to pull new data from Solcast and cache.")
+                        self.logger.error("Try running optimization again with 'weather_forecast_cache': true, or run action `forecast-cache`, to pull new data from Solcast and cache.")
+                        self.logger.info("Removing old Solcast cache file.")
+                        os.remove(w_forecast_cache_path)
                         return False
                     # Filter cached forecast data to match current forecast_dates start-end range (reduce forecast Dataframe size to appropriate length)
                     if self.forecast_dates[0] in data.index and self.forecast_dates[-1] in data.index:
                         data = data.loc[self.forecast_dates[0]:self.forecast_dates[-1]]
-                        self.logger.info("Retrieved Solcast data from the previously saved cache")
+                        self.logger.info("Retrieved Solcast data from the previously saved cache.")
                     else:
                         self.logger.error("Unable to obtain cached Solcast forecast data within the requested timeframe range.")
-                        self.logger.error("Try running optimization again. Optionally, add runtime parameter 'weather_forecast_cache': true to pull new data from Solcast and cache.")
+                        self.logger.error("Try running optimization again (not using cache). Optionally, add runtime parameter 'weather_forecast_cache': true to pull new data from Solcast and cache.")
+                        self.logger.info("Removing old Solcast cache file.")
+                        os.remove(w_forecast_cache_path)
                         return False    
         elif method == 'solar.forecast': # using the solar.forecast API
             # Retrieve data from the solar.forecast API

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -230,10 +230,10 @@ class Forecast(object):
                 # Retrieve data from the Solcast API
                 if 'solcast_api_key' not in self.retrieve_hass_conf:
                     self.logger.error("The solcast_api_key parameter was not defined, using dummy values for testing")
-                    self.retrieve_hass_conf['solcast_api_key'] = "123456"
+                    return False
                 if 'solcast_rooftop_id' not in self.retrieve_hass_conf:
                     self.logger.error("The solcast_rooftop_id parameter was not defined, using dummy values for testing")
-                    self.retrieve_hass_conf['solcast_rooftop_id'] = "123456"
+                    return False
                 headers = {
                     'User-Agent': 'EMHASS',
                     "Authorization": "Bearer " + self.retrieve_hass_conf['solcast_api_key'],

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -182,7 +182,7 @@ class Forecast(object):
         
         """
         csv_path  = self.emhass_conf['data_path'] / csv_path
-        w_forecast_cache_path = self.emhass_conf['data_path'] / "weather_forecast_data.pkl"
+        w_forecast_cache_path = os.path.abspath(self.emhass_conf['data_path'] / "weather_forecast_data.pkl")
 
         self.logger.info("Retrieving weather forecast data using method = "+method)
         self.weather_forecast_method = method # Saving this attribute for later use to identify csv method usage

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -303,6 +303,11 @@ def treat_runtimeparams(runtimeparams: str, params: str, retrieve_hass_conf: dic
         # Treat passed forecast data lists
         list_forecast_key = ['pv_power_forecast', 'load_power_forecast', 'load_cost_forecast', 'prod_price_forecast']
         forecast_methods = ['weather_forecast_method', 'load_forecast_method', 'load_cost_forecast_method', 'prod_price_forecast_method']
+        if "forecast_cache" not in runtimeparams.keys():
+            forecast_cache = False
+        else:
+            forecast_cache = runtimeparams["forecast_cache"]
+        params["passed_data"]["forecast_cache"] = forecast_cache  
         for method, forecast_key in enumerate(list_forecast_key):
             if forecast_key in runtimeparams.keys():
                 if type(runtimeparams[forecast_key]) == list and len(runtimeparams[forecast_key]) >= len(forecast_dates):

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -303,11 +303,18 @@ def treat_runtimeparams(runtimeparams: str, params: str, retrieve_hass_conf: dic
         # Treat passed forecast data lists
         list_forecast_key = ['pv_power_forecast', 'load_power_forecast', 'load_cost_forecast', 'prod_price_forecast']
         forecast_methods = ['weather_forecast_method', 'load_forecast_method', 'load_cost_forecast_method', 'prod_price_forecast_method']
+        # Param to save forecast cache (i.e. Solcast)
         if "weather_forecast_cache" not in runtimeparams.keys():
             weather_forecast_cache = False
         else:
             weather_forecast_cache = runtimeparams["weather_forecast_cache"]
         params["passed_data"]["weather_forecast_cache"] = weather_forecast_cache  
+        # Param to make sure optimization only uses cached data. (else produce error)
+        if "weather_forecast_cache_only" not in runtimeparams.keys():
+            weather_forecast_cache_only = False
+        else:
+            weather_forecast_cache_only = runtimeparams["weather_forecast_cache_only"]
+        params["passed_data"]["weather_forecast_cache_only"] = weather_forecast_cache_only  
         for method, forecast_key in enumerate(list_forecast_key):
             if forecast_key in runtimeparams.keys():
                 if type(runtimeparams[forecast_key]) == list and len(runtimeparams[forecast_key]) >= len(forecast_dates):

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -303,11 +303,11 @@ def treat_runtimeparams(runtimeparams: str, params: str, retrieve_hass_conf: dic
         # Treat passed forecast data lists
         list_forecast_key = ['pv_power_forecast', 'load_power_forecast', 'load_cost_forecast', 'prod_price_forecast']
         forecast_methods = ['weather_forecast_method', 'load_forecast_method', 'load_cost_forecast_method', 'prod_price_forecast_method']
-        if "forecast_cache" not in runtimeparams.keys():
-            forecast_cache = False
+        if "weather_forecast_cache" not in runtimeparams.keys():
+            weather_forecast_cache = False
         else:
-            forecast_cache = runtimeparams["forecast_cache"]
-        params["passed_data"]["forecast_cache"] = forecast_cache  
+            weather_forecast_cache = runtimeparams["weather_forecast_cache"]
+        params["passed_data"]["weather_forecast_cache"] = weather_forecast_cache  
         for method, forecast_key in enumerate(list_forecast_key):
             if forecast_key in runtimeparams.keys():
                 if type(runtimeparams[forecast_key]) == list and len(runtimeparams[forecast_key]) >= len(forecast_dates):

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -477,7 +477,10 @@ if __name__ == "__main__":
         if len(entity_pathContents) > 0:
             for entity in entity_pathContents:
                 os.remove(entity_path / entity)
-
+    # If weather_forecast_cache pickle file exists, remove it
+    if os.path.isfile(emhass_conf['data_path'] / "weather_forecast_data.pkl"):
+        os.remove(emhass_conf['data_path'] / "weather_forecast_data.pkl")
+        
     # Initialise continual publish thread list
     continual_publish_thread = []
     

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -477,9 +477,6 @@ if __name__ == "__main__":
         if len(entity_pathContents) > 0:
             for entity in entity_pathContents:
                 os.remove(entity_path / entity)
-    # If weather_forecast_cache pickle file exists, remove it
-    if os.path.isfile(emhass_conf['data_path'] / "weather_forecast_data.pkl"):
-        os.remove(emhass_conf['data_path'] / "weather_forecast_data.pkl")
         
     # Initialise continual publish thread list
     continual_publish_thread = []

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -477,9 +477,6 @@ if __name__ == "__main__":
         if len(entity_pathContents) > 0:
             for entity in entity_pathContents:
                 os.remove(entity_path / entity)
-    # If weather_forecast_cache pickle file exists, remove it
-    if os.path.isfile(emhass_conf['data_path'] / "weather_forecast_data.pkl"): 
-        os.remove(emhass_conf['data_path'] / "weather_forecast_data.pkl")
 
     # Initialise continual publish thread list
     continual_publish_thread = []

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -12,7 +12,7 @@ from distutils.util import strtobool
 
 from emhass.command_line import set_input_data_dict
 from emhass.command_line import perfect_forecast_optim, dayahead_forecast_optim, naive_mpc_optim
-from emhass.command_line import forecast_model_fit, forecast_model_predict, forecast_model_tune
+from emhass.command_line import forecast_model_fit, forecast_model_predict, forecast_model_tune, forecast_cache
 from emhass.command_line import regressor_model_fit, regressor_model_predict
 from emhass.command_line import publish_data, continual_publish
 from emhass.utils import get_injection_dict, get_injection_dict_forecast_model_fit, \
@@ -106,6 +106,17 @@ def action_call(action_name):
     if runtimeparams is not None and runtimeparams != '{}':
         app.logger.info("Passed runtime parameters: " + str(runtimeparams))
     runtimeparams = json.dumps(runtimeparams)
+    
+    # Run action if forecast_cache
+    if action_name == 'forecast-cache':
+        ActionStr = " >> Performing forecast, try to caching result"
+        app.logger.info(ActionStr)
+        forecast_cache(emhass_conf, params, runtimeparams, app.logger)
+        msg = f'EMHASS >> Forecast has run and results possibly cached... \n'
+        if not checkFileLog(ActionStr):
+            return make_response(msg, 201)
+        return make_response(grabLog(ActionStr), 400)
+
     ActionStr = " >> Setting input data dict"
     app.logger.info(ActionStr)
     input_data_dict = set_input_data_dict(emhass_conf, costfun, 

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -12,7 +12,7 @@ from distutils.util import strtobool
 
 from emhass.command_line import set_input_data_dict
 from emhass.command_line import perfect_forecast_optim, dayahead_forecast_optim, naive_mpc_optim
-from emhass.command_line import forecast_model_fit, forecast_model_predict, forecast_model_tune, forecast_cache
+from emhass.command_line import forecast_model_fit, forecast_model_predict, forecast_model_tune, weather_forecast_cache
 from emhass.command_line import regressor_model_fit, regressor_model_predict
 from emhass.command_line import publish_data, continual_publish
 from emhass.utils import get_injection_dict, get_injection_dict_forecast_model_fit, \
@@ -107,11 +107,11 @@ def action_call(action_name):
         app.logger.info("Passed runtime parameters: " + str(runtimeparams))
     runtimeparams = json.dumps(runtimeparams)
     
-    # Run action if forecast_cache
+    # Run action if weather_forecast_cache
     if action_name == 'forecast-cache':
         ActionStr = " >> Performing forecast, try to caching result"
         app.logger.info(ActionStr)
-        forecast_cache(emhass_conf, params, runtimeparams, app.logger)
+        weather_forecast_cache(emhass_conf, params, runtimeparams, app.logger)
         msg = f'EMHASS >> Forecast has run and results possibly cached... \n'
         if not checkFileLog(ActionStr):
             return make_response(msg, 201)
@@ -470,14 +470,16 @@ if __name__ == "__main__":
     app.logger.addHandler(fileLogger)   
     clearFileLog() #Clear Action File logger file, ready for new instance
 
-
-    #If entity_path exists, remove any entity/metadata files 
+    # If entity_path exists, remove any entity/metadata files 
     entity_path = emhass_conf['data_path'] / "entities"
     if os.path.exists(entity_path): 
         entity_pathContents = os.listdir(entity_path)
         if len(entity_pathContents) > 0:
             for entity in entity_pathContents:
                 os.remove(entity_path / entity)
+    # If weather_forecast_cache pickle file exists, remove it
+    if os.path.isfile(emhass_conf['data_path'] / "weather_forecast_data.pkl"): 
+        os.remove(emhass_conf['data_path'] / "weather_forecast_data.pkl")
 
     # Initialise continual publish thread list
     continual_publish_thread = []

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -148,7 +148,7 @@ class TestForecast(unittest.TestCase):
             self.assertEqual(len(df_weather_scrap), len(P_PV_forecast))
 
     def test_get_weather_forecast_solcast_method_mock(self):
-        self.fcst.params = {'passed_data': {'weather_forecast_cache': False}}
+        self.fcst.params = {'passed_data': {'weather_forecast_cache': False, 'weather_forecast_cache_only': False}}
         self.fcst.retrieve_hass_conf['solcast_api_key'] = "123456"
         self.fcst.retrieve_hass_conf['solcast_rooftop_id'] =  "123456"
         if os.path.isfile(emhass_conf['data_path'] / "weather_forecast_data.pkl"): 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import os
 import requests_mock
 import pandas as pd
 import pathlib, pickle, json, copy, yaml
@@ -147,7 +148,11 @@ class TestForecast(unittest.TestCase):
             self.assertEqual(len(df_weather_scrap), len(P_PV_forecast))
 
     def test_get_weather_forecast_solcast_method_mock(self):
-        self.fcst.params = {'passed_data': {'forecast_cache': False}}
+        self.fcst.params = {'passed_data': {'weather_forecast_cache': False}}
+        self.fcst.retrieve_hass_conf['solcast_api_key'] = "123456"
+        self.fcst.retrieve_hass_conf['solcast_rooftop_id'] =  "123456"
+        if os.path.isfile(emhass_conf['data_path'] / "weather_forecast_data.pkl"): 
+            os.rename(emhass_conf['data_path'] / "weather_forecast_data.pkl", emhass_conf['data_path'] / "temp_weather_forecast_data.pkl")
         with requests_mock.mock() as m:
             data = bz2.BZ2File(str(emhass_conf['data_path'] / 'test_response_solcast_get_method.pbz2'), "rb")
             data = cPickle.load(data)
@@ -161,6 +166,8 @@ class TestForecast(unittest.TestCase):
             self.assertTrue(self.fcst.start_forecast < ts for ts in df_weather_scrap.index)
             self.assertEqual(len(df_weather_scrap), 
                             int(self.optim_conf['delta_forecast'].total_seconds()/3600/self.fcst.timeStep))
+            if os.path.isfile(emhass_conf['data_path'] / "temp_weather_forecast_data.pkl"): 
+                os.rename(emhass_conf['data_path'] / "temp_weather_forecast_data.pkl", emhass_conf['data_path'] / "weather_forecast_data.pkl")
         
     def test_get_weather_forecast_solarforecast_method_mock(self):
         with requests_mock.mock() as m:

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -147,6 +147,7 @@ class TestForecast(unittest.TestCase):
             self.assertEqual(len(df_weather_scrap), len(P_PV_forecast))
 
     def test_get_weather_forecast_solcast_method_mock(self):
+        self.fcst.params = {'passed_data': {'forecast_cache': False}}
         with requests_mock.mock() as m:
             data = bz2.BZ2File(str(emhass_conf['data_path'] / 'test_response_solcast_get_method.pbz2'), "rb")
             data = cPickle.load(data)


### PR DESCRIPTION
### Changes
- New runtime parameter created `weather_forecast_cache`, for caching results of a weather forecast to Pickle file: *(Only supports Solcast as of now)*
    ```bash
    curl -i -H 'Content-Type:application/json' -X POST -d '{"weather_forecast_cache":true}' http://localhost:5000/action/dayahead-optim
     ```
    *Example: Ran in the morning with day-ahead to store current days forecast data.*
- New push action for running forecast separately, try to cache result to Pickle file:  *(Only supports Solcast as of now)*
    ```bash
    curl -i -H 'Content-Type:application/json' -X POST -d {} http://localhost:5000/action/forecast-cache
    ```
    *Example: Run a couple of times throughout the day to update cached forecast data with the current Solcast data.*
- EMHASS will check to see if there is a  weather_forecast_data pickle file. If so, forecast will use the file instead of sending a POST request *(Only supports Solcast as of now)*
- Added custom header for Solcast POST requests, following Solcast CTO's guidelines
- Adjusted Solcast error handling 


### Pprogress
- [x] Test
- [x] Add documentation 
- [x] Adjust naming conventions
- [ ] Check error handling
    - [x] File exists but no data 
    - [x] User runs forecast but data has expired
    - [ ] Other weather forecasts (optional)
- [ ]  Add tests (optional?)