### PR TITLE
Fix issue where setfreq seems to be trying to set the frequency to zero

### DIFF
--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -949,7 +949,8 @@ def set_df_index_freq(df: pd.DataFrame) -> pd.DataFrame:
 
     """
     idx_diff = np.diff(df.index)
+    # Sometimes there are zero values in this list.
+    idx_diff = idx_diff[np.nonzero(idx_diff)]
     sampling = pd.to_timedelta(np.median(idx_diff))
     df = df[~df.index.duplicated()]
-    df = df.asfreq(sampling)
-    return df
+    return df.asfreq(sampling)


### PR DESCRIPTION
I'm not really sure why this is happening, I debugged it and it turned out that `np.diff()` was giving a bunch of zeros and a bunch of correct values - but either way we don't want to try to set the frequency to zero so adding `np.nonzero` seems safe and reasonable.