### PR TITLE
Only automatically set the DateTimeIndex frequency if no "freq" is set in retrieve_hass_conf

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -109,7 +109,11 @@ def set_input_data_dict(emhass_conf: dict, costfun: str,
         df_input_data_dayahead = pd.DataFrame(np.transpose(np.vstack(
             [P_PV_forecast.values, P_load_forecast.values])), index=P_PV_forecast.index,
             columns=["P_PV_forecast", "P_load_forecast"])
-        df_input_data_dayahead = utils.set_df_index_freq(df_input_data_dayahead)
+        if "freq" in retrieve_hass_conf and retrieve_hass_conf["freq"]:
+            freq = pd.to_timedelta(retrieve_hass_conf["freq"], "minute")
+            df_input_data_dayahead = df_input_data_dayahead.asfreq(freq)
+        else:
+            df_input_data_dayahead = utils.set_df_index_freq(df_input_data_dayahead)
         params = json.loads(params)
         if ("prediction_horizon" in params["passed_data"] and params["passed_data"]["prediction_horizon"] is not None):
             prediction_horizon = params["passed_data"]["prediction_horizon"]
@@ -155,7 +159,11 @@ def set_input_data_dict(emhass_conf: dict, costfun: str,
                 "Unable to get sensor power photovoltaics, or sensor power load no var loads. Check HA sensors and their daily data")
             return False
         df_input_data_dayahead = pd.concat([P_PV_forecast, P_load_forecast], axis=1)
-        df_input_data_dayahead = utils.set_df_index_freq(df_input_data_dayahead)
+        if "freq" in retrieve_hass_conf and retrieve_hass_conf["freq"]:
+            freq = pd.to_timedelta(retrieve_hass_conf["freq"], "minute")
+            df_input_data_dayahead = df_input_data_dayahead.asfreq(freq)
+        else:
+            df_input_data_dayahead = utils.set_df_index_freq(df_input_data_dayahead)
         df_input_data_dayahead.columns = ["P_PV_forecast", "P_load_forecast"]
         params = json.loads(params)
         if ("prediction_horizon" in params["passed_data"] and params["passed_data"]["prediction_horizon"] is not None):


### PR DESCRIPTION
... otherwise, explicitly set the frequency to match the value of `freq` in `retrieve_hass_conf`.

The DateTimeIndex frequency needs to match the `freq` in `retrieve_hass_conf`, because lots of input data is being provided in "timesteps", and indexed within that input data by index.

Without this change, you get the following error message:

ERROR - web_server - Exception on /action/naive-mpc-optim [POST] Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/flask/app.py", line 1473, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/flask/app.py", line 882, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/emhass/web_server.py", line 122, in action_call
    input_data_dict = set_input_data_dict(emhass_conf, costfun,
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/emhass/command_line.py", line 164, in set_input_data_dict
    df_input_data_dayahead.index[0]: df_input_data_dayahead.index[prediction_horizon - 1]]
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pandas/core/indexes/base.py", line 5175, in __getitem__
    return getitem(key)
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pandas/core/arrays/datetimelike.py", line 370, in __getitem__
    "Union[DatetimeLikeArrayT, DTScalarOrNaT]", super().__getitem__(key)
                                                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pandas/core/arrays/_mixins.py", line 272, in __getitem__
    result = self._ndarray[key]
             ~~~~~~~~~~~~~^^^^^
IndexError: index 47 is out of bounds for axis 0 with size 25