### PR TITLE
feat(lpsolver): add timeout

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,12 +34,11 @@ jobs:
         with:
           python-version-file: ".python-version"
 
-      # not necessary as its already running
-      # - uses: sourcery-ai/action@v1
-      #   continue-on-error: true
-      #   with:
-      #     token: ${{ secrets.SOURCERY_TOKEN }}
-      #     diff_ref: ${{ github.event.pull_request.base.sha }}
+      - uses: sourcery-ai/action@v1
+        continue-on-error: true
+        with:
+          token: ${{ secrets.SOURCERY_TOKEN }}
+          diff_ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Install the project
         run: uv sync --reinstall --extra test

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,11 +34,12 @@ jobs:
         with:
           python-version-file: ".python-version"
 
-      - uses: sourcery-ai/action@v1
-        continue-on-error: true
-        with:
-          token: ${{ secrets.SOURCERY_TOKEN }}
-          diff_ref: ${{ github.event.pull_request.base.sha }}
+      # not necessary as its already running
+      # - uses: sourcery-ai/action@v1
+      #   continue-on-error: true
+      #   with:
+      #     token: ${{ secrets.SOURCERY_TOKEN }}
+      #     diff_ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Install the project
         run: uv sync --reinstall --extra test

--- a/.github/workflows/publish_docker-test.yaml
+++ b/.github/workflows/publish_docker-test.yaml
@@ -4,7 +4,9 @@ name: "Publish Docker test image"
 
 on:
   push:
-    branches: [testing]
+    branches: 
+      - testing
+      - master
   workflow_dispatch:
 
 env:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,7 @@
       "type": "debugpy",
       "request": "launch",
       "console": "integratedTerminal",
-      "module": "gunicorn",
+      "program": ".venv/lib/python3.12/site-packages/gunicorn",
       "purpose": [
         "debug-in-terminal"
       ],

--- a/docs/mlforecaster.md
+++ b/docs/mlforecaster.md
@@ -38,7 +38,7 @@ The default values for these parameters are:
 ```yaml
 runtimeparams = {
     'historic_days_to_retrieve': 9,
-    "model_type": "load_forecast",
+    "model_type": "long_train_data",
     "var_model": "sensor.power_load_no_var_loads",
     "sklearn_model": "KNeighborsRegressor",
     "num_lags": 48,
@@ -91,7 +91,7 @@ curl -i -H "Content-Type:application/json" -X POST -d '{}' http://localhost:5000
 ```
 If needed pass the correct `model_type` like this:
 ```bash
-curl -i -H "Content-Type:application/json" -X POST -d '{"model_type": "load_forecast"}' http://localhost:5000/action/forecast-model-predict
+curl -i -H "Content-Type:application/json" -X POST -d '{"model_type": "long_train_data"}' http://localhost:5000/action/forecast-model-predict
 ```
 The resulting forecast DataFrame is shown in the web UI.
 

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -853,6 +853,7 @@ def forecast_model_fit(
         filename_path = input_data_dict["emhass_conf"]["data_path"] / filename
         with open(filename_path, "wb") as outp:
             pickle.dump(mlf, outp, pickle.HIGHEST_PROTOCOL)
+            logger.debug("saved model to " + str(filename_path))
     return df_pred, df_pred_backtest, mlf
 
 
@@ -891,9 +892,12 @@ def forecast_model_predict(
         if filename_path.is_file():
             with open(filename_path, "rb") as inp:
                 mlf = pickle.load(inp)
+                logger.debug("loaded saved model from " + str(filename_path))
         else:
             logger.error(
-                "The ML forecaster file was not found, please run a model fit method before this predict method",
+                "The ML forecaster file ("
+                + str(filename_path)
+                + ") was not found, please run a model fit method before this predict method",
             )
             return
     # Make predictions
@@ -982,9 +986,12 @@ def forecast_model_tune(
         if filename_path.is_file():
             with open(filename_path, "rb") as inp:
                 mlf = pickle.load(inp)
+                logger.debug("loaded saved model from " + str(filename_path))
         else:
             logger.error(
-                "The ML forecaster file was not found, please run a model fit method before this tune method",
+                "The ML forecaster file ("
+                + str(filename_path)
+                + ") was not found, please run a model fit method before this tune method",
             )
             return None, None
     # Tune the model
@@ -995,6 +1002,7 @@ def forecast_model_tune(
         filename_path = input_data_dict["emhass_conf"]["data_path"] / filename
         with open(filename_path, "wb") as outp:
             pickle.dump(mlf, outp, pickle.HIGHEST_PROTOCOL)
+            logger.debug("Saved model to " + str(filename_path))
     return df_pred_optim, mlf
 
 

--- a/src/emhass/data/associations.csv
+++ b/src/emhass/data/associations.csv
@@ -38,6 +38,7 @@ optim_conf,prod_sell_price,photovoltaic_production_sell_price
 optim_conf,set_total_pv_sell,set_total_pv_sell
 optim_conf,lp_solver,lp_solver
 optim_conf,lp_solver_path,lp_solver_path
+optim_conf,lp_solver_timeout,lp_solver_timeout
 optim_conf,set_nocharge_from_grid,set_nocharge_from_grid
 optim_conf,set_nodischarge_to_grid,set_nodischarge_to_grid
 optim_conf,set_battery_dynamic,set_battery_dynamic

--- a/src/emhass/data/config_defaults.json
+++ b/src/emhass/data/config_defaults.json
@@ -9,6 +9,7 @@
   "set_total_pv_sell": false,
   "lp_solver": "default",
   "lp_solver_path": "empty",
+  "lp_solver_timeout": 45,
   "set_nocharge_from_grid": false,
   "set_nodischarge_to_grid": true,
   "set_battery_dynamic": false,

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -1079,14 +1079,16 @@ class Optimization:
         ## Finally, we call the solver to solve our optimization model:
         # solving with default solver CBC
         if self.lp_solver == "PULP_CBC_CMD":
-            opt_model.solve(PULP_CBC_CMD(msg=0))
+            opt_model.solve(PULP_CBC_CMD(msg=0, maxSeconds=45, timeLimit=45, threads=7))
         elif self.lp_solver == "GLPK_CMD":
-            opt_model.solve(GLPK_CMD(msg=0))
+            opt_model.solve(GLPK_CMD(msg=0, maxSeconds=45, timeLimit=45, threads=7))
         elif self.lp_solver == "COIN_CMD":
-            opt_model.solve(COIN_CMD(msg=0, path=self.lp_solver_path))
+            opt_model.solve(
+                COIN_CMD(msg=0, path=self.lp_solver_path, timeLimit=45, threads=7)
+            )
         else:
             self.logger.warning("Solver %s unknown, using default", self.lp_solver)
-            opt_model.solve()
+            opt_model.solve(COIN_CMD(msg=0, timeLimit=45, threads=8))
 
         # The status of the solution is printed to the screen
         self.optim_status = plp.LpStatus[opt_model.status]

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -1089,7 +1089,7 @@ class Optimization:
             )
         else:
             self.logger.warning("Solver %s unknown, using default", self.lp_solver)
-            opt_model.solve(COIN_CMD(msg=0, timeLimit=45, threads=7))
+            opt_model.solve(PULP_CBC_CMD(msg=0, timeLimit=timeout, threads=7))
 
         # The status of the solution is printed to the screen
         self.optim_status = plp.LpStatus[opt_model.status]

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -1079,16 +1079,16 @@ class Optimization:
         ## Finally, we call the solver to solve our optimization model:
         # solving with default solver CBC
         if self.lp_solver == "PULP_CBC_CMD":
-            opt_model.solve(PULP_CBC_CMD(msg=0, maxSeconds=45, timeLimit=45, threads=7))
+            opt_model.solve(PULP_CBC_CMD(msg=0, timeLimit=45, threads=7))
         elif self.lp_solver == "GLPK_CMD":
-            opt_model.solve(GLPK_CMD(msg=0, maxSeconds=45, timeLimit=45, threads=7))
+            opt_model.solve(GLPK_CMD(msg=0, timeLimit=45, threads=7))
         elif self.lp_solver == "COIN_CMD":
             opt_model.solve(
                 COIN_CMD(msg=0, path=self.lp_solver_path, timeLimit=45, threads=7)
             )
         else:
             self.logger.warning("Solver %s unknown, using default", self.lp_solver)
-            opt_model.solve(COIN_CMD(msg=0, timeLimit=45, threads=8))
+            opt_model.solve(COIN_CMD(msg=0, timeLimit=45, threads=7))
 
         # The status of the solution is printed to the screen
         self.optim_status = plp.LpStatus[opt_model.status]

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -1077,14 +1077,15 @@ class Optimization:
         opt_model.constraints = constraints
 
         ## Finally, we call the solver to solve our optimization model:
+        timeout = self.optim_conf["lp_solver_timeout"]
         # solving with default solver CBC
         if self.lp_solver == "PULP_CBC_CMD":
-            opt_model.solve(PULP_CBC_CMD(msg=0, timeLimit=45, threads=7))
+            opt_model.solve(PULP_CBC_CMD(msg=0, timeLimit=timeout, threads=7))
         elif self.lp_solver == "GLPK_CMD":
-            opt_model.solve(GLPK_CMD(msg=0, timeLimit=45, threads=7))
+            opt_model.solve(GLPK_CMD(msg=0, timeLimit=timeout, threads=7))
         elif self.lp_solver == "COIN_CMD":
             opt_model.solve(
-                COIN_CMD(msg=0, path=self.lp_solver_path, timeLimit=45, threads=7)
+                COIN_CMD(msg=0, path=self.lp_solver_path, timeLimit=timeout, threads=7)
             )
         else:
             self.logger.warning("Solver %s unknown, using default", self.lp_solver)

--- a/src/emhass/static/data/param_definitions.json
+++ b/src/emhass/static/data/param_definitions.json
@@ -138,6 +138,12 @@
       "input": "text",
       "default_value": "/usr/bin/cbc"
     },
+    "lp_solver_timeout": {
+      "friendly_name": "Linear programming solver timeout",
+      "Description": "Set the maximum time (in seconds) for the LP solver. Defaults to 45.",
+      "input": "int",
+      "default_value": 45
+    },
     "weather_forecast_method": {
       "friendly_name": "Weather forecast method",
       "Description": "This will define the weather forecast method that will be used. options are 'open-meteo', 'Solcast', 'solar.forecast' (forecast.solar) and 'csv' to load a CSV file. When loading a CSV file this will be directly considered as the PV power forecast in Watts.",


### PR DESCRIPTION
## Summary by Sourcery

Add timeout and thread configuration to linear programming solvers

New Features:
- Add timeout and thread configuration for different LP solvers (CBC, GLPK, COIN) with a default time limit of 45 seconds and 7 threads

Enhancements:
- Improve solver configuration by adding explicit time and thread limits to prevent long-running optimization tasks