### PR TITLE
Ignore sensor_power_photovoltaics_forecast when set_use_adjusted_pv is false

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -71,8 +71,8 @@ def retrieve_home_assistant_data(
         var_list = [retrieve_hass_conf["sensor_power_load_no_var_loads"]]
         if optim_conf.get("set_use_pv", True):
             var_list.append(retrieve_hass_conf["sensor_power_photovoltaics"])
-        if optim_conf.get("set_use_adjusted_pv", True):
-            var_list.append(retrieve_hass_conf["sensor_power_photovoltaics_forecast"])
+            if optim_conf.get("set_use_adjusted_pv", True):
+                var_list.append(retrieve_hass_conf["sensor_power_photovoltaics_forecast"])
         if not rh.get_data(
             days_list, var_list, minimal_response=False, significant_changes_only=False
         ):

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -71,6 +71,7 @@ def retrieve_home_assistant_data(
         var_list = [retrieve_hass_conf["sensor_power_load_no_var_loads"]]
         if optim_conf.get("set_use_pv", True):
             var_list.append(retrieve_hass_conf["sensor_power_photovoltaics"])
+        if optim_conf.get("set_use_adjusted_pv", True):
             var_list.append(retrieve_hass_conf["sensor_power_photovoltaics_forecast"])
         if not rh.get_data(
             days_list, var_list, minimal_response=False, significant_changes_only=False


### PR DESCRIPTION
This is a proposed fix for the issue encountered in https://github.com/davidusb-geek/emhass/issues/519 and https://github.com/davidusb-geek/emhass/issues/517 where the sensor default value `sensor.p_pv_forecast` for config option `sensor_power_photovoltaics_forecast` is added to the var_list to be fetched from Home Assistant when `set_use_pv` is true but the new `set_use_adjusted_pv` is false. Is that default sensor doesn't exist in HA then you get the error _The retrieved JSON is empty, A sensor:sensor.p_pv_forecast may have 0 days of history, ..._

This change is to only add `sensor_power_photovoltaics_forecast` to the var_list when both `set_use_pv` and `set_use_adjusted_pv` are true .

## Summary by Sourcery

Bug Fixes:
- Fix an issue where the PV forecast sensor was being fetched even when adjusted PV was disabled, potentially causing errors if the sensor does not exist