### PR TITLE
Ml regressor fix

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -96,9 +96,9 @@ emhass --action 'dayahead-optim' --config ./config.json --root ./src/emhass --co
 **Run unittests**
 
 ```bash
+python3 -m pip install -e '.[test]'
 python3 -m unittest discover -s ./tests -p 'test_*.py'
 ```
-_Note:unittest will need to be installed prior_
 
 ### Method 2: VS-Code Debug and Run via Dev Container
 

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1720,7 +1720,7 @@ def add_date_features(
 
     # Determine whether to use index or a timestamp column
     if timestamp:
-        df[timestamp] = pd.to_datetime(df[timestamp])
+        df[timestamp] = pd.to_datetime(df[timestamp], utc=True)
         source = df[timestamp].dt
     else:
         if not isinstance(df.index, pd.DatetimeIndex):


### PR DESCRIPTION
Since the update to 0.13 my MLRegressor cal doesn't work anymore
```
2025-04-25 06:02:18 +0200] [27] [INFO] Performing a MLRegressor fit for heating_dd_gradientboosting
/app/src/emhass/utils.py:1723: FutureWarning:
In a future version of pandas, parsing datetimes with mixed time zones will raise an error unless `utc=True`. Please specify `utc=True` to opt in to the new behaviour and silence this warning. To create a `Series` with mixed offsets and `object` dtype, please use `apply` and `datetime.datetime.strptime`
[2025-04-25 06:02:18 +0200] [27] [ERROR] Exception on /action/regressor-model-fit [POST]
Traceback (most recent call last):
  File "/app/.venv/lib/python3.12/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/emhass/web_server.py", line 529, in action_call
    regressor_model_fit(input_data_dict, app.logger)
  File "/app/src/emhass/command_line.py", line 1057, in regressor_model_fit
    fit = mlr.fit(date_features=date_features)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/emhass/machine_learning_regressor.py", line 186, in fit
    self.data_exo = utils.add_date_features(
                    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/emhass/utils.py", line 1724, in add_date_features
    source = df[timestamp].dt
             ^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/pandas/core/generic.py", line 6299, in __getattr__
    return object.__getattribute__(self, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/pandas/core/accessor.py", line 224, in __get__
    accessor_obj = self._accessor(obj)
                   ^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/pandas/core/indexes/accessors.py", line 643, in __new__
    raise AttributeError("Can only use .dt accessor with datetimelike values")
AttributeError: Can only use .dt accessor with datetimelike values
```
When i try v0.12.8 in vscode I only get the warning
```
2025-04-25 15:35:14,095 - web_server - INFO - Performing a MLRegressor fit for heating_dd
/Users/giel/Dev/python/emhass/src/emhass/machine_learning_regressor.py:140: FutureWarning: In a future version of pandas, parsing datetimes with mixed time zones will raise an error unless `utc=True`. Please specify `utc=True` to opt in to the new behaviour and silence this warning. To create a `Series` with mixed offsets and `object` dtype, please use `apply` and `datetime.datetime.strptime`
  df[timestamp] = pd.to_datetime(df["timestamp"])
2025-04-25 15:35:14,109 - web_server - INFO - Training a RandomForestRegression model
2025-04-25 15:35:21,903 - web_server - INFO - Elapsed time for model fit: 7.79394793510437
2025-04-25 15:35:21,906 - web_server - INFO - Prediction R2 score of fitted model on test data: 0.7038738149247994
```
I think this happens because of this in my csv file
```
2025-03-28 23:59:32.421561+01:00,10.99,14.912,27.171,0.08,19.23,7.01,0.84,0.15,14407.043,2852.891,1.627,17568.568,28.798
2025-03-29 23:59:32.140540+01:00,9.55,36.193,19.447,0.47,19.01,8.45,4.49,0.99,14443.236,2862.337,9.446,17597.461,28.893
2025-03-30 23:59:32.108841+02:00,7.99,23.022,19.016,0.38,19.25,10.01,3.05,0.78,14466.258,2868.611,6.274,17622.751,25.29
2025-03-31 23:59:32.268709+02:00,8.33,40.608,22.88,0.0,19.48,9.67,0.0,0.0,14506.866,2868.611,0.0,17645.631,22.88
```
Thats the change from winter to summer hour

If i make this change to the code my MLRegressor call works again

## Summary by Sourcery

Fix ML regressor failure caused by mixed timezone timestamps.

Bug Fixes:
- Ensure timestamps are parsed as UTC in `add_date_features` to handle mixed timezones correctly.

Documentation:
- Update developer documentation with instructions to install test dependencies.