### PR TITLE
Add python files to source package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ package-data = { "emhass" = [
 
 [tool.hatch.build.targets.sdist]
 include = [
+    "src/emhass/*.py",
     "src/emhass/templates/",
     "src/emhass/static/",
     "src/emhass/img/",


### PR DESCRIPTION
The python files should be included in the source package.

## Summary by Sourcery

Build:
- Include *.py files from `src/emhass/` in the sdist package.