### PR TITLE
HiGHS solver, fix glpk solver, config num_threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,9 @@ RUN apt-get update \
     libhdf5-serial-dev \
     # cbc
     coinor-cbc \
-    coinor-libcbc-dev
+    coinor-libcbc-dev \
+    # glpk
+    glpk-utils
 
 # add build packadges (just in case wheel does not exist)
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ Pull requests are very much accepted on this project. For development, you can f
 
 Some problems may arise from solver-related issues in the Pulp package. It was found that for arm64 architectures (ie. Raspberry Pi4, 64 bits) the default solver is not available. A workaround is to use another solver. The `glpk` solver is an option.
 
-This can be controlled in the configuration file with parameters `lp_solver` and `lp_solver_path`. The options for `lp_solver` are: 'PULP_CBC_CMD', 'GLPK_CMD' and 'COIN_CMD'. If using 'COIN_CMD' as the solver you will need to provide the correct path to this solver in parameter `lp_solver_path`, ex: '/usr/bin/cbc'.
+This can be controlled in the configuration file with parameters `lp_solver` and `lp_solver_path`. The options for `lp_solver` are: 'PULP_CBC_CMD', 'GLPK_CMD', 'HiGHS', and 'COIN_CMD'. If using 'COIN_CMD' as the solver you will need to provide the correct path to this solver in parameter `lp_solver_path`, ex: '/usr/bin/cbc'.
 
 
 ## License

--- a/docs/config.md
+++ b/docs/config.md
@@ -80,8 +80,9 @@ The following parameters and definitions are only needed if load_cost_forecast_m
 - `production_price_forecast_method`: Define the method that will be used for PV power production price forecast. This is the price that is paid by the utility for energy injected into the grid. The options are 'constant' for a constant fixed value or 'csv' to load custom price forecasts from a CSV file. The default CSV file path that will be used is '/data/data_prod_price_forecast.csv'.
 - `photovoltaic_production_sell_price`: The paid price for energy injected to the grid from excedent PV production in €/kWh. Defaults to 0.065. This parameter is only needed if production_price_forecast_method='constant'.
 - `set_total_pv_sell`: Set this parameter to true to consider that all the PV power produced is injected to the grid. No direct self-consumption. The default is false, for a system with direct self-consumption.
-- `lp_solver`: Set the name of the linear programming solver that will be used. Defaults to 'COIN_CMD'. The options are 'PULP_CBC_CMD', 'GLPK_CMD' and 'COIN_CMD'. 
+- `lp_solver`: Set the name of the linear programming solver that will be used. Defaults to 'COIN_CMD'. The options are 'PULP_CBC_CMD', 'GLPK_CMD', 'HiGHS', and 'COIN_CMD'.
 - `lp_solver_path`: Set the path to the LP solver. Defaults to '/usr/bin/cbc'. 
+- `num_threads`: Set the number of threads to pass to LP solvers that support specifying a number of threads. Defaults to 0 (auto-detect).
 - `set_nocharge_from_grid`: Set this to true if you want to forbid charging the battery from the grid. The battery will only be charged from excess PV.
 - `set_nodischarge_to_grid`: Set this to true if you want to forbid discharging battery power to the grid.
 - `set_battery_dynamic`: Set a power dynamic limiting condition to the battery power. This is an additional constraint on the battery dynamic in power per unit of time, which allows you to set a percentage of the battery's nominal full power as the maximum power allowed for (dis)charge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pytz>=2024.2",
     "requests>=2.32.2",
     "h5py>=3.12.1",
+    "highspy>=1.10.0",
     "pulp>=2.8.0",
     "pyyaml>=6.0.2",
     "tables>=3.10.0",

--- a/scripts/script_debug_optim.py
+++ b/scripts/script_debug_optim.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     # Solver configurations
     optim_conf.update(
         {"lp_solver": "PULP_CBC_CMD"}
-    )  # set the name of the linear programming solver that will be used. Options are 'PULP_CBC_CMD', 'GLPK_CMD' and 'COIN_CMD'.
+    )  # set the name of the linear programming solver that will be used. Options are 'PULP_CBC_CMD', 'GLPK_CMD', 'HiGHS' and 'COIN_CMD'.
     optim_conf.update(
         {"lp_solver_path": "empty"}
     )  # set the path to the LP solver, COIN_CMD default is /usr/bin/cbc

--- a/scripts/script_simple_thermal_model.py
+++ b/scripts/script_simple_thermal_model.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     # Solver configurations
     optim_conf.update(
         {"lp_solver": "PULP_CBC_CMD"}
-    )  # set the name of the linear programming solver that will be used. Options are 'PULP_CBC_CMD', 'GLPK_CMD' and 'COIN_CMD'.
+    )  # set the name of the linear programming solver that will be used. Options are 'PULP_CBC_CMD', 'GLPK_CMD', 'HiGHS', and 'COIN_CMD'.
     optim_conf.update(
         {"lp_solver_path": "empty"}
     )  # set the path to the LP solver, COIN_CMD default is /usr/bin/cbc

--- a/scripts/script_thermal_model_optim.py
+++ b/scripts/script_thermal_model_optim.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     # Solver configurations
     optim_conf.update(
         {"lp_solver": "PULP_CBC_CMD"}
-    )  # set the name of the linear programming solver that will be used. Options are 'PULP_CBC_CMD', 'GLPK_CMD' and 'COIN_CMD'.
+    )  # set the name of the linear programming solver that will be used. Options are 'PULP_CBC_CMD', 'GLPK_CMD', 'HiGHS', and 'COIN_CMD'.
     optim_conf.update(
         {"lp_solver_path": "empty"}
     )  # set the path to the LP solver, COIN_CMD default is /usr/bin/cbc

--- a/scripts/special_options.json
+++ b/scripts/special_options.json
@@ -9,6 +9,8 @@
   "set_total_pv_sell": true,                                                                                                                                                                                    
   "lp_solver": "default",                                                                                                                                                                                       
   "lp_solver_path": "empty",                                                                                                                                                                              
+  "num_threads": 0,
+
   "set_nocharge_from_grid": false,                                                                                                                                                                               
   "set_nodischarge_to_grid": false,
   "set_battery_dynamic": false,

--- a/src/emhass/data/associations.csv
+++ b/src/emhass/data/associations.csv
@@ -39,6 +39,7 @@ optim_conf,set_total_pv_sell,set_total_pv_sell
 optim_conf,lp_solver,lp_solver
 optim_conf,lp_solver_path,lp_solver_path
 optim_conf,lp_solver_timeout,lp_solver_timeout
+optim_conf,num_threads,num_threads
 optim_conf,set_nocharge_from_grid,set_nocharge_from_grid
 optim_conf,set_nodischarge_to_grid,set_nodischarge_to_grid
 optim_conf,set_battery_dynamic,set_battery_dynamic

--- a/src/emhass/data/config_defaults.json
+++ b/src/emhass/data/config_defaults.json
@@ -10,6 +10,7 @@
   "lp_solver": "default",
   "lp_solver_path": "empty",
   "lp_solver_timeout": 45,
+  "num_threads": 0,
   "set_nocharge_from_grid": false,
   "set_nodischarge_to_grid": true,
   "set_battery_dynamic": false,

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -10,7 +10,7 @@ from math import ceil
 import numpy as np
 import pandas as pd
 import pulp as plp
-from pulp import COIN_CMD, GLPK_CMD, HiGHS, PULP_CBC_CMD
+from pulp import COIN_CMD, GLPK_CMD, PULP_CBC_CMD, HiGHS
 
 
 class Optimization:
@@ -90,11 +90,11 @@ class Optimization:
         self.optim_status = None
         if "num_threads" in optim_conf.keys():
             if optim_conf["num_threads"] == 0:
-                self.num_threads = str(os.cpu_count())
+                self.num_threads = int(os.cpu_count())
             else:
-                self.num_threads = str(optim_conf["num_threads"])
+                self.num_threads = int(optim_conf["num_threads"])
         else:
-            self.num_threads = str(os.cpu_count())
+            self.num_threads = int(os.cpu_count())
         if "lp_solver" in optim_conf.keys():
             self.lp_solver = optim_conf["lp_solver"]
         else:

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -10,7 +10,6 @@ from math import ceil
 import numpy as np
 import pandas as pd
 import pulp as plp
-import highspy
 from pulp import COIN_CMD, GLPK_CMD, HiGHS, PULP_CBC_CMD
 
 

--- a/src/emhass/static/data/param_definitions.json
+++ b/src/emhass/static/data/param_definitions.json
@@ -122,13 +122,14 @@
     },
     "lp_solver": {
       "friendly_name": "Linear programming solver",
-      "Description": "Set the name of the linear programming solver that will be used. Defaults to ‘COIN_CMD’. The options are ‘PULP_CBC_CMD’, ‘GLPK_CMD’ and ‘COIN_CMD’.",
+      "Description": "Set the name of the linear programming solver that will be used. Defaults to ‘COIN_CMD’. The options are ‘PULP_CBC_CMD’, ‘GLPK_CMD’, ‘HiGHS’, and ‘COIN_CMD’.",
       "input": "select",
       "select_options": [
         "default",
         "COIN_CMD",
         "PULP_CBC_CMD",
-        "GLPK_CMD"
+        "GLPK_CMD",
+        "HiGHS"
       ],
       "default_value": "COIN_CMD"
     },
@@ -137,6 +138,12 @@
       "Description": "Set the path to the LP solver. Defaults to ‘/usr/bin/cbc’.",
       "input": "text",
       "default_value": "/usr/bin/cbc"
+    },
+    "num_threads": {
+      "friendly_name": "Number of threads to use for the LP solver",
+      "Description": "Set the number of threads for the LP solver to use, when supported by the solver. Defaults to 0 (autodetect)",
+      "input": "int",
+      "default_value": 0
     },
     "lp_solver_timeout": {
       "friendly_name": "Linear programming solver timeout",

--- a/tests/config_emhass.yaml
+++ b/tests/config_emhass.yaml
@@ -54,7 +54,7 @@ optim_conf:
   prod_price_forecast_method: 'constant' # options are 'constant' for constant fixed value or 'csv' to load custom price forecast from a CSV file
   prod_sell_price: 0.065 # power production selling price in €/kWh (only needed if prod_price_forecast_method='constant')
   set_total_pv_sell: False # consider that all PV power is injected to the grid (self-consumption with total sell)
-  lp_solver: 'default' # set the name of the linear programming solver that will be used. Options are 'PULP_CBC_CMD', 'GLPK_CMD' and 'COIN_CMD'. 
+  lp_solver: 'default' # set the name of the linear programming solver that will be used. Options are 'PULP_CBC_CMD', 'GLPK_CMD', 'HiGHS', and 'COIN_CMD'.
   lp_solver_path: 'empty' # set the path to the LP solver, COIN_CMD default is /usr/bin/cbc
   set_nocharge_from_grid: False # avoid battery charging from the grid
   set_nodischarge_to_grid: True # avoid battery discharging to the grid


### PR DESCRIPTION
- Introduce new `num_threads` option (0 = auto-detect) across:
  - special_options.json, config_defaults.json, associations.csv
  - param_definitions.json (with description & default)
- Wire `num_threads` into the Optimization class:
  - detect CPU count when set to 0
  - debug log the thread count
  - pass threads to CBC and COIN solvers (since they support it)
  - removed threads option from `GLPK_CMD` since it does not support it.
- Add HiGHS as a solver:
  - import `HiGHS` interface from pulp, add `highspy` dependency
  - branch in perform_optimization() to call HiGHS(msg=0, timeLimit)
  - include `HiGHS` in `lp_solver` options everywhere (docs, README, scripts, tests)
- Update Dockerfile to install glpk-utils for GLPK support

## Summary by Sourcery

Enhance optimization solver capabilities by adding HiGHS solver, improving thread configuration, and updating solver support across the project

New Features:
- Add HiGHS solver as a new linear programming solver option
- Introduce configurable `num_threads` option for supported solvers

Enhancements:
- Improve solver configuration flexibility
- Auto-detect CPU thread count when num_threads is set to 0

Deployment:
- Update Dockerfile to install glpk-utils for GLPK support

Documentation:
- Update documentation to include HiGHS solver in solver options
- Add documentation for new `num_threads` configuration parameter

Chores:
- Update project dependencies to include highspy
- Modify configuration files to support new solver and thread options