### PR TITLE
Let CONTRIBUTING.md refer to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,3 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository before making a change. 
-
-Please note we have a code of conduct, please follow it in all your interactions with the project.
-
-## Pull Request Process
-   
-1. Fork the repo and create your development branch from `master`.
-2. If you've added code that should be tested, add tests.
-3. If needed please update the documentation, including in-code docstrings.
-4. Ensure the test suite passes by summoning a `pytest` command.
-6. Issue the pull request.
+Pull requests are very much accepted on this project. For development, you can find some instructions here [Development](https://emhass.readthedocs.io/en/latest/develop.html).

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,5 +1,12 @@
 # EMHASS Development
 
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change.
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+# Setup
+
 There are multiple different approaches to developing for EMHASS.  
 The choice depends on your and preference (Python venv/DevContainer/Docker).  
 Below are some development workflow examples:  


### PR DESCRIPTION
The CONTRIBUTING.md seems to duplicate the role of the develop page in the docs, the lather of which seems way more up-to-date and complete.

I am interested on hacking this project myself and this file is where I started looking for instructions on how to get started, having it refer to the docs would have saved me some time looking :)

## Summary by Sourcery

Documentation:
- Simplified CONTRIBUTING.md to point to the more comprehensive development documentation