### PR TITLE
Use delta_forecast_daily to determine the number of days of forecast data to fetch from Open-Meteo

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -302,6 +302,7 @@ def set_input_data_dict(
         else:
             P_PV_forecast = pd.Series(0, index=fcst.forecast_dates)
         P_load_forecast = fcst.get_load_forecast(
+            days_min_load_forecast=optim_conf["delta_forecast_daily"].days,
             method=optim_conf["load_forecast_method"]
         )
         if isinstance(P_load_forecast, bool) and not P_load_forecast:
@@ -400,6 +401,7 @@ def set_input_data_dict(
         else:
             P_PV_forecast = pd.Series(0, index=fcst.forecast_dates)
         P_load_forecast = fcst.get_load_forecast(
+            days_min_load_forecast=optim_conf["delta_forecast_daily"].days,
             method=optim_conf["load_forecast_method"],
             set_mix_forecast=set_mix_forecast,
             df_now=df_input_data,

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -218,7 +218,7 @@ class Forecast:
     def get_cached_open_meteo_forecast_json(
         self,
         max_age: int | None = 30,
-        forecast_days: int | None = 2
+        forecast_days: int = 3
     ) -> dict:
         r"""
         Get weather forecast json from Open-Meteo and cache it for re-use.
@@ -244,6 +244,17 @@ class Forecast:
         :rtype: dict
 
         """
+
+        # Ensure at least 3 weather forecast days (and 1 more than requested)
+        if forecast_days is None:
+            self.logger.warning("Open-Meteo forecast_days is missing so defaulting to 3 days")
+            forecast_days = 3
+        elif forecast_days < 3:
+            self.logger.warning("Open-Meteo forecast_days is too low (%s) so defaulting to 3 days", forecast_days)
+            forecast_days = 3
+        else:
+            forecast_days = forecast_days + 1
+
         json_path = os.path.abspath(
             self.emhass_conf["data_path"] / "cached-open-meteo-forecast.json"
         )
@@ -292,7 +303,7 @@ class Forecast:
                 + "shortwave_radiation_instant,"
                 + "diffuse_radiation_instant,"
                 + "direct_normal_irradiance_instant"
-                + "&forecast_days=" + str(forecast_days+1)
+                + "&forecast_days=" + str(forecast_days)
                 + "&timezone="
                 + quote(str(self.time_zone), safe="")
             )

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -409,11 +409,10 @@ def treat_runtimeparams(
             runtimeparams.get("delta_forecast_daily", None) is not None
             or runtimeparams.get("delta_forecast", None) is not None
         ):
-            delta_forecast = int(
-                runtimeparams.get(
-                    "delta_forecast_daily", runtimeparams["delta_forecast"]
-                )
-            )
+            # Use old param name delta_forecast (if provided) for backwards compatibility
+            delta_forecast = runtimeparams.get("delta_forecast", None)
+            # Prefer new param name delta_forecast_daily
+            delta_forecast = int(runtimeparams.get("delta_forecast_daily", delta_forecast))
             params["optim_conf"]["delta_forecast_daily"] = pd.Timedelta(
                 days=delta_forecast
             )

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -412,7 +412,20 @@ def treat_runtimeparams(
             # Use old param name delta_forecast (if provided) for backwards compatibility
             delta_forecast = runtimeparams.get("delta_forecast", None)
             # Prefer new param name delta_forecast_daily
-            delta_forecast = int(runtimeparams.get("delta_forecast_daily", delta_forecast))
+            delta_forecast = runtimeparams.get("delta_forecast_daily", delta_forecast)
+            # Ensure delta_forecast is numeric and at least 1 day
+            if delta_forecast is None:
+                logger.warning("delta_forecast_daily is missing so defaulting to 1 day")
+                delta_forecast = 1
+            else:
+                try:
+                    delta_forecast = int(delta_forecast)
+                except ValueError:
+                    logger.warning("Invalid delta_forecast_daily value (%s) so defaulting to 1 day", delta_forecast)
+                    delta_forecast = 1
+            if delta_forecast <= 0:
+                logger.warning("delta_forecast_daily is too low (%s) so defaulting to 1 day", delta_forecast)
+                delta_forecast = 1
             params["optim_conf"]["delta_forecast_daily"] = pd.Timedelta(
                 days=delta_forecast
             )


### PR DESCRIPTION
Currently the EMHASS use of the Open-Meteo weather source only fetches a default of 3 days of forecast data.
This is an issue when trying to forecast more than 3 days into the future.
This PR uses the existing `delta_forecast_daily` configuration option to pass the `forecast_days` parameter value into the Open-Meteo REST API call to fetch the required number of days.
An additional day is always requested so the locally cached Open-Meteo JSON has another days worth of data in it.

When creating this PR I did consider the fact that is does not attempt to query the locally cached Open-Meteo JSON to see how many days of data are currently cached and then re-fetch if the current cache has an insufficient number of days for a longer term forecast.  I decided, for now, to avoid adding complexity and just handle it outside of emhass by passing `"open_meteo_cache_max_age": 0` in the REST API call to emhass whenever want I do a long term forecast (once a day) to force any prior cached JSON to be discarded and re-fetched with a larger number of forecast days.  If you prefer, we could change the default forecast_days from 3 to 7 (or 14) days when querying Open-Meteo so we always have enough weather data for 1-2 weeks ahead. Alternatively, add a config parameter for the number of weather forecast days to fetch which is not tied to `delta_forecast_daily`. I am happy with the manual approach I am using, so just suggested these as options for the future if required.

This PR also fixes the delta_forecast KeyError when `delta_forecast_daily` is provided in the emhass REST URL parameters,
as seen in issue https://github.com/davidusb-geek/emhass/issues/479 - `delta_forecast_daily` is used if provided and `delta_forecast` is a fallback.

## Summary by Sourcery

Update Open-Meteo weather data fetching to use the configured forecast duration, ensuring sufficient forecast days are retrieved for longer-term forecasts and improving parameter handling for compatibility.

New Features:
- Allow dynamic specification of forecast days for Open-Meteo API requests based on the delta_forecast_daily configuration.

Bug Fixes:
- Fix KeyError when delta_forecast_daily is provided in REST parameters by preferring it over delta_forecast.

Enhancements:
- Always fetch an additional day of forecast data to ensure cache sufficiency.
- Improve backward compatibility and parameter handling for forecast duration configuration.