### PR TITLE
Added new dict format for sensors

### DIFF
--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -120,12 +120,12 @@ def get_forecast_dates(
 
     """
     freq = pd.to_timedelta(freq, "minutes")
-    start_forecast = pd.Timestamp(datetime.now()).replace(
-        hour=0, minute=0, second=0, microsecond=0
+    start_forecast = (
+        pd.Timestamp(datetime.now(), tz=time_zone)
+        .replace(microsecond=0)
+        .floor(freq=freq)
     )
-    end_forecast = (start_forecast + pd.Timedelta(days=delta_forecast)).replace(
-        microsecond=0
-    )
+    end_forecast = start_forecast + pd.Timedelta(days=delta_forecast)
     forecast_dates = (
         pd.date_range(
             start=start_forecast,
@@ -574,27 +574,39 @@ def treat_runtimeparams(
         # Loop forecasts, check if value is a list and greater than or equal to forecast_dates
         for method, forecast_key in enumerate(list_forecast_key):
             if forecast_key in runtimeparams.keys():
-                if isinstance(runtimeparams[forecast_key], list) and len(
-                    runtimeparams[forecast_key]
-                ) >= len(forecast_dates):
-                    params["passed_data"][forecast_key] = runtimeparams[forecast_key]
+                forecast_input = runtimeparams[forecast_key]
+                if isinstance(forecast_input, dict):
+                    forecast_data_df = pd.DataFrame.from_dict(forecast_input, orient="index").reset_index()
+                    forecast_data_df.columns = ["time", "value"]
+                    forecast_data_df['time'] = pd.to_datetime(forecast_data_df['time'], format='ISO8601', utc=True).dt.tz_convert(time_zone)
+
+                    # align index with forecast_dates
+                    forecast_data_df = (forecast_data_df
+                        .resample(pd.to_timedelta(optimization_time_step, "minutes"), on='time')
+                        .aggregate({'value': 'mean'})
+                        .reindex(forecast_dates, method='nearest')
+                    )
+                    forecast_data_df['value'] = forecast_data_df['value'].ffill().bfill()
+                    forecast_input = forecast_data_df['value'].tolist()
+                if isinstance(forecast_input, list) and len(forecast_input) >= len(forecast_dates):
+                    params["passed_data"][forecast_key] = forecast_input
                     params["optim_conf"][forecast_methods[method]] = "list"
                 else:
                     logger.error(
-                        f"ERROR: The passed data is either not a list or the length is not correct, length should be {str(len(forecast_dates))}"
+                        f"ERROR: The passed data is either the wrong type or the length is not correct, length should be {str(len(forecast_dates))}"
                     )
                     logger.error(
                         f"Passed type is {str(type(runtimeparams[forecast_key]))} and length is {str(len(runtimeparams[forecast_key]))}"
                     )
                 # Check if string contains list, if so extract
-                if isinstance(runtimeparams[forecast_key], str):
-                    if isinstance(ast.literal_eval(runtimeparams[forecast_key]), list):
-                        runtimeparams[forecast_key] = ast.literal_eval(
-                            runtimeparams[forecast_key]
+                if isinstance(forecast_input, str):
+                    if isinstance(ast.literal_eval(forecast_input), list):
+                        forecast_input = ast.literal_eval(
+                            forecast_input
                         )
                 list_non_digits = [
                     x
-                    for x in runtimeparams[forecast_key]
+                    for x in forecast_input
                     if not (isinstance(x, int) or isinstance(x, float))
                 ]
                 if len(list_non_digits) > 0:


### PR DESCRIPTION
- Changed forecast_dates to align with dateindex created in forecast.py
(It now starts at current time rather than midnight of current date)

- Added new format for sensors in runtime parameters.

New format accepts dict input like:

`{
    "2025-05-14 07:46:04.307132+10:00": 0.4,
    "2025-05-14T17:30:01+00:00": 0.25
  }`
  
 which is then resampled according to optimization_time_step and reindexed to align with forecast_dates