### PR TITLE
Fix aarch64 docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ COPY pyproject.toml /app/
 COPY .python-version /app/
 COPY gunicorn.conf.py /app/
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+RUN apt update \
+    && apt install -y --no-install-recommends \
     # Numpy
     libgfortran5 \
     libopenblas0-pthread \
@@ -39,15 +39,15 @@ RUN apt-get update \
     coinor-cbc \
     coinor-libcbc-dev \
     # glpk
-    glpk-utils
-
-# add build packadges (just in case wheel does not exist)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    glpk-utils \
+    # build packages (just in case wheel does not exist)
     gcc \
+    g++ \
     patchelf \
     cmake \
-    ninja-build
+    ninja-build \
+    && rm -rf /var/cache/apt/* \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install uv (pip alternative)
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
@@ -107,14 +107,6 @@ RUN [[ "${TARGETARCH}" == "aarch64" ]] && uv pip install --verbose ndindex || ec
 # install packadges and build EMHASS
 RUN uv pip install --verbose .
 RUN uv lock
-
-# remove build only packages
-RUN apt-get remove --purge -y --auto-remove \
-    gcc \
-    patchelf \
-    cmake \
-    ninja-build \
-    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "uv", "run", "--frozen", "gunicorn", "emhass.web_server:create_app()" ]
 


### PR DESCRIPTION
According to the CI, the docker build for 64 bit ARM is failing. Judging from the logs it seems to be missing the C++ compiler for this target. This is an attempted fix...

I have also merged the apt commands in the Dockerfile and removed the part that removed packages again as that does actually not save space in the Docker image being built.

## Summary by Sourcery

Fix the aarch64 Docker build by installing the missing C++ compiler and streamlining package installation and cleanup

Bug Fixes:
- Install g++ to support 64-bit ARM builds

Build:
- Merge multiple apt installs into a single RUN and switch from apt-get to apt
- Remove the separate package purge step and clean apt caches inline to reduce layers