### PR TITLE
Docs: Tiny typo at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 
 <br>
 <p align="left">
-EHMASS is a Python module designed to optimize your home energy interfacing with Home Assistant.
+EMHASS is a Python module designed to optimize your home energy interfacing with Home Assistant.
 </p>
 
 ## Introduction


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix typo at top of README, changing 'EHMASS' to 'EMHASS'