### PR TITLE
utils.py: use SVG render mode for Plotly figures

### DIFF
--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -962,6 +962,7 @@ def get_injection_dict(df: pd.DataFrame, plot_size: int | None = 1366) -> dict:
         template="presentation",
         line_shape="hv",
         color_discrete_sequence=colors,
+        render_mode="svg",
     )
     fig_0.update_layout(xaxis_title="Timestamp", yaxis_title="System powers (W)")
     if "SOC_opt" in df.columns.to_list():
@@ -971,6 +972,7 @@ def get_injection_dict(df: pd.DataFrame, plot_size: int | None = 1366) -> dict:
             template="presentation",
             line_shape="hv",
             color_discrete_sequence=colors,
+            render_mode="svg",
         )
         fig_1.update_layout(xaxis_title="Timestamp", yaxis_title="Battery SOC (%)")
     cols_cost = [i for i in df.columns.to_list() if "cost_" in i or "unit_" in i]
@@ -984,6 +986,7 @@ def get_injection_dict(df: pd.DataFrame, plot_size: int | None = 1366) -> dict:
         template="presentation",
         line_shape="hv",
         color_discrete_sequence=colors,
+        render_mode="svg",
     )
     fig_2.update_layout(xaxis_title="Timestamp", yaxis_title="System costs (currency)")
     # Get full path to image


### PR DESCRIPTION
Set `render_mode="svg"` for system power, SOC, and cost plots in `get_injection_dict`. This improves rendering consistency when embedding them in the web UI.