### PR TITLE
Fix decimal precision for unit_load_cost and unit_prod_price sensors

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -436,11 +436,12 @@ class RetrieveHass:
         friendly_name: str,
         list_name: str,
         state: float,
+        decimals: int = 2,
     ) -> dict:
         list_df = copy.deepcopy(data_df).loc[data_df.index[idx] :].reset_index()
         list_df.columns = ["timestamps", entity_id]
         ts_list = [str(i) for i in list_df["timestamps"].tolist()]
-        vals_list = [str(np.round(i, 2)) for i in list_df[entity_id].tolist()]
+        vals_list = [str(np.round(i, decimals)) for i in list_df[entity_id].tolist()]
         forecast_list = []
         for i, ts in enumerate(ts_list):
             datum = {}
@@ -448,7 +449,7 @@ class RetrieveHass:
             datum[entity_id.split("sensor.")[1]] = vals_list[i]
             forecast_list.append(datum)
         data = {
-            "state": f"{state:.2f}",
+            "state": f"{state:.{decimals}f}",
             "attributes": {
                 "device_class": device_class,
                 "unit_of_measurement": unit_of_measurement,
@@ -593,6 +594,7 @@ class RetrieveHass:
                 friendly_name,
                 "unit_load_cost_forecasts",
                 state,
+                decimals=4,
             )
         elif type_var == "unit_prod_price":
             data = RetrieveHass.get_attr_data_dict(
@@ -604,6 +606,7 @@ class RetrieveHass:
                 friendly_name,
                 "unit_prod_price_forecasts",
                 state,
+                decimals=4,
             )
         elif type_var == "mlforecaster":
             data = RetrieveHass.get_attr_data_dict(


### PR DESCRIPTION
## Summary
Fix decimal precision for `unit_load_cost` and `unit_prod_price` sensors to show 4 decimal places instead of 2 in Home Assistant.

## Problem
Energy price sensors (`sensor.mpc_unit_load_cost` and `sensor.mpc_unit_prod_price`) were displaying only 2 decimal places (e.g., 0.14) in Home Assistant, despite internal calculations using 4 decimal precision (0.1417). This caused loss of precision in displayed energy pricing information.

## Root Cause
In `src/emhass/retrieve_hass.py`, the `get_attr_data_dict()` function had hardcoded 2-decimal formatting:
- Line 724: `"state": f"{state:.2f}"` 
- Line 716: `vals_list = [str(np.round(i, 2)) ...]`

## Solution
- Added configurable `decimals` parameter to `get_attr_data_dict()` with default value of 2 (backward compatible)
- Updated `unit_load_cost` sensor publishing to use `decimals=4`
- Updated `unit_prod_price` sensor publishing to use `decimals=4`
- Other sensors maintain default 2-decimal precision

## Test plan
- [x] Build and run EMHASS with modified code
- [x] Execute optimization and verify sensor values in Home Assistant
- [x] Confirm price sensors show 4 decimal places (e.g., 0.1417 instead of 0.14)
- [x] Verify other sensors maintain their existing decimal precision

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable decimal precision to sensor data formatting and apply four decimal places to unit_load_cost and unit_prod_price sensors

Bug Fixes:
- Display unit_load_cost and unit_prod_price sensors with four decimal places instead of two

Enhancements:
- Introduce optional decimals parameter in get_attr_data_dict to control rounding precision

Chores:
- Preserve default two-decimal behavior for other sensors