### PR TITLE
Fix for pytz.exceptions.NonExistentTimeError with Open Meteo weather source during DST change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ MANIFEST
 # Local session data 
 data/actionLogs.txt
 data/debug-*.csv
-data/cached-open-meteo-forecast.json
+data/cached-open-meteo-forecast*.json
 data/entities/*.json
 
 # PyInstaller

--- a/docs/forecasts.md
+++ b/docs/forecasts.md
@@ -98,7 +98,7 @@ curl -i -H 'Content-Type:application/json' -X POST -d '{"weather_forecast_cache_
 
 When you have EMHASS configured to use the Open-Meteo weather service, to minimize API calls to the service, and to provide
 resilience in case of transient connectivity issues, EMHASS caches successful calls to the Open-Meteo API in a
-`cached-open-meteo-forecast.json` file in the data directory. The JSON file contains the default 3 days of weather forecast data.
+`cached-open-meteo-forecast-b.json` file in the data directory. The JSON file contains the default 3 days of weather forecast data.
 This Open-Meteo cache is independent of the PV cache discussed above and will be used even when the PV cache is not enabled.
 By default, when the JSON file is older than 30 minutes, attempts will be made to replace it with a more recent version
 from the Open-Meteo weather service. It will only be replaced if this is successful. If any errors occur the older version

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -381,8 +381,8 @@ class Forecast:
                 data_15min = pd.DataFrame.from_dict(data_raw["minutely_15"])
                 # Date/times in the Open-Meteo JSON are now unix timestamps and need to
                 # be converted locally to DST/TimeZone aware date/times.
-                data_15min["time"] = pd.to_datetime(data_15min["time"], unit='s', utc=True)
-                data_15min['time'] = data_15min['time'].dt.tz_convert(self.time_zone)
+                data_15min["time"] = pd.to_datetime(data_15min["time"], unit="s", utc=True)
+                data_15min["time"] = data_15min["time"].dt.tz_convert(self.time_zone)
                 data_15min.set_index("time", inplace=True)
 
                 data_15min = data_15min.rename(


### PR DESCRIPTION
This is a fix for the pytz.exceptions.NonExistentTimeError that occurs when using Open Meteo as the weather source.  It should fix the issues seen in https://github.com/davidusb-geek/emhass/issues/589 and https://github.com/davidusb-geek/emhass/issues/590

Open Meteo can include non-existent times in the JSON forecast response when an upcoming DST change will trigger clocks to go forward e.g. 2am to 3am in Sydney on 5 Oct 2025. The 02:00, 02:15, 02:30 and 02:45 times do not occur on that day and that causes pandas to throw a pytz.exceptions.NonExistentTimeError when parsing them.

This change modifies the Open Meteo API request to switch from the default formatted date/times to requesting UNIX epoch UTC timestamps instead, which are then converted into local time-zone DST aware date/times using pandas in emhass.

The file name for the cached Open Meteo JSON response has also changed so that emhass does not attempt to use the old formatted date/times in an previously cached response after an upgrade.

## Summary by Sourcery

Fix DST-related parsing errors by switching the Open-Meteo API to return UNIX timestamps for all times, convert them locally to timezone-aware datetimes, rename the cache file to avoid format conflicts, and update documentation accordingly.

Bug Fixes:
- Prevent NonExistentTimeError at DST transitions by requesting and handling UNIX timestamps from the Open-Meteo API.

Enhancements:
- Append ".json"-b suffix to the cached Open-Meteo forecast file to avoid conflicts with the old time format.
- Export fetched minutely forecast data to a CSV file when debug logging is enabled.

Documentation:
- Update forecast caching documentation to reference the new cached-open-meteo-forecast-b.json file.