### PR TITLE
Reduce severity of logged Open Meteo forecast_days minimum override message

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -243,13 +243,13 @@ class Forecast:
 
         # Ensure at least 3 weather forecast days (and 1 more than requested)
         if forecast_days is None:
-            self.logger.warning(
+            self.logger.debug(
                 "Open-Meteo forecast_days is missing so defaulting to 3 days"
             )
             forecast_days = 3
         elif forecast_days < 3:
-            self.logger.warning(
-                "Open-Meteo forecast_days is too low (%s) so defaulting to 3 days",
+            self.logger.debug(
+                "Open-Meteo forecast_days is low (%s) so defaulting to 3 days",
                 forecast_days,
             )
             forecast_days = 3


### PR DESCRIPTION
This changes the severity of the message logged when setting a minimum value for Open Meteo forecast_days, from warning to debug. As a warning message it can suggest something is wrong, as seen in https://github.com/davidusb-geek/emhass/issues/578, when it is simply making sure we fetch enough forecast data from Open Meteo. A debug log message is sufficient to indicate that forecast_days has been set to a higher value than might be expected from delta_forecast_daily.

## Summary by Sourcery

Lower the logging level for defaulting missing or low Open-Meteo forecast_days from warning to debug.

Enhancements:
- Use debug instead of warning when defaulting missing forecast_days to 3 days
- Use debug instead of warning when overriding forecast_days values below 3 to 3 days