### PR TITLE
Update forecast.py to align CSV data with prediction window

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -1243,6 +1243,15 @@ class Forecast:
                         index=fcst_index,
                     )
                 forecast_out = pd.concat([forecast_out, forecast_tp], axis=0)
+        merged = pd.merge_asof(
+            df_final.sort_index(),
+            forecast_out.sort_index(),
+            left_index=True,
+            right_index=True,
+            direction='nearest'
+        )
+        # Keep only forecast_out columns
+        forecast_out = merged[forecast_out.columns]
         return forecast_out
 
     @staticmethod


### PR DESCRIPTION
Based on the following issue: https://github.com/davidusb-geek/emhass/issues/597

For me the CSV data was no longer aligned properly with the prediction window.
This addition fixes it for me.

The code will align the forecasted CSV data to the df_final, based on the datetime. 
The values of the CSV will be mapped on to the nearest datetime of the df_final.

It is also possible to add a tolerance to the function, i did not do this. By adding a tolerance argument it can be made such, that the user is informed if the data is deviating too much or if there is data missing.
I liked it to be just the nearest, also if you would simulate for more days, it will just extend the latest CSV value this way.
Which is for me the desired behavior.

## Summary by Sourcery

Align forecasted CSV data with the prediction window by snapping timestamps to the nearest datetime index and preserving only forecast columns.

Enhancements:
- Use pandas.merge_asof to map CSV forecast values to the nearest timestamps in the final prediction dataframe
- Filter merged result to include only the original forecast output columns