### PR TITLE
Fix InfluxDB future data query and use_influxdb parameter type

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -350,11 +350,19 @@ class RetrieveHass:
             return False
 
         start_time = days_list[0]
-        end_time = days_list[-1] + pd.Timedelta(days=1)
+
+        # Don't query into the future - cap end_time at current time
+        # This prevents FILL(previous) from creating fake future datapoints
+        now = pd.Timestamp.now(tz=self.time_zone)
+        requested_end = days_list[-1] + pd.Timedelta(days=1)
+        end_time = min(now, requested_end)
+
         total_days = (end_time - start_time).days
 
         self.logger.info(f"Retrieving {len(var_list)} sensors over {total_days} days from InfluxDB")
         self.logger.debug(f"Time range: {start_time} to {end_time}")
+        if end_time < requested_end:
+            self.logger.debug(f"End time capped at current time (requested: {requested_end})")
 
         # Collect sensor dataframes
         sensor_dfs = []

--- a/src/emhass/static/data/param_definitions.json
+++ b/src/emhass/static/data/param_definitions.json
@@ -44,7 +44,7 @@
     "use_influxdb": {
       "friendly_name": "Use InfluxDB for data retrieval",
       "Description": "Enable InfluxDB as data source instead of Home Assistant API. This allows for longer historical data retention and better performance for machine learning models.",
-      "input": "bool",
+      "input": "boolean",
       "default_value": false
     },
     "influxdb_host": {


### PR DESCRIPTION
This commit fixes two issues:

1. InfluxDB querying into the future with FILL(previous)
2. use_influxdb parameter using "bool" instead of "boolean"

## Fix 1: Cap InfluxDB end_time at current time

**Problem:**
When using historic_days_to_retrieve, the InfluxDB query would request data up to midnight of the current day, creating fake future datapoints via FILL(previous).

Example at 14:30:
- Query: 2025-10-29 00:00 to 2025-11-01 00:00 (tomorrow midnight)
- FILL(previous) creates 19 fake datapoints (14:30 - 00:00)
- These fake values might contaminate ML training data

**Solution:**
Cap end_time at current timestamp to prevent querying future data:
```python
now = pd.Timestamp.now(tz=self.time_zone)
requested_end = days_list[-1] + pd.Timedelta(days=1)
end_time = min(now, requested_end)
```

**Impact:**
- No more fake future data in InfluxDB queries
- Consistent behavior with Home Assistant API (which has no future data)
- ML models train on actual data only
- FILL(previous) still works for historical gaps

**Location:** src/emhass/retrieve_hass.py lines 354-365

## Fix 2: Change use_influxdb from "bool" to "boolean" (as fixed by @gieljnssns in the big ASYNC PR)

**Problem:**
The use_influxdb parameter was defined with "input": "bool" instead of "input": "boolean", which is inconsistent with all other boolean parameters in EMHASS.

This inconsistency could cause the Web UI to handle the parameter incorrectly, potentially storing string "false" instead of boolean false, leading to the parameter being truthy.

**Solution:**
Changed "input": "bool" to "input": "boolean" to match the pattern used by all other boolean parameters (set_use_battery, load_negative, set_zero_min, inverter_is_hybrid, etc.)

**Impact:**
- Consistent with imenad's fix in commit a9071d7
- Web UI correctly recognizes parameter as boolean checkbox
- Prevents potential "false" string vs False boolean issues

**Location:** src/emhass/static/data/param_definitions.json line 47

## Testing

Both fixes verified:
- InfluxDB end_time correctly capped at current time
- JSON validation passed
- use_influxdb now uses "boolean" like other boolean parameters

## Summary by Sourcery

Prevent InfluxDB queries into the future and fix inconsistent boolean parameter type for use_influxdb

Bug Fixes:
- Cap InfluxDB end_time at the current timestamp to avoid generating fake future datapoints
- Change use_influxdb parameter definition from "bool" to "boolean" for consistent UI handling