### PR TITLE
Fix timestamp exception

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -362,7 +362,7 @@ class RetrieveHass:
         # Don't query into the future - cap end_time at current time
         # This prevents FILL(previous) from creating fake future datapoints
         # Use tz_localize(None) to to match timezone format to naive while preserving local time
-        now = pd.Timestamp.now(tz=self.time_zone)
+        now = pd.Timestamp.now(tz=self.time_zone).tz_localize(None)
         requested_end = (days_list[-1] + pd.Timedelta(days=1)).tz_localize(None)
         end_time = min(now, requested_end)
 


### PR DESCRIPTION
Before this fix the InfluxDB query would throw the following exception:
```
File "/app/src/emhass/retrieve_hass.py", line 366, in get_data_influxdb
end_time = min(now, requested_end)

               ^^^^^^^^^^^^^^^^^^^^^^^
File "pandas/_libs/tslibs/timestamps.pyx", line 387, in pandas._libs.tslibs.timestamps._Timestamp.__richcmp__
TypeError: Cannot compare tz-naive and tz-aware timestamps
```
Adding .tz_localize(None) to the timestamps fixes this issue.

## Summary by Sourcery

Bug Fixes:
- Strip timezone info from start_time, now, and requested_end using tz_localize(None) to prevent tz-aware vs tz-naive comparison errors