### PR TITLE
Feature: HA independant configuration

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -227,6 +227,7 @@ def set_input_data_dict(
     if get_data_from_file:
         with open(emhass_conf["data_path"] / test_df_literal, "rb") as inp:
             _, _, _, rh.ha_config = pickle.load(inp)
+    # Call to get HA configuration
     else:
         response = rh.get_ha_config()
         if response is False:
@@ -237,6 +238,8 @@ def set_input_data_dict(
                 params,
                 rh.ha_config,
             )
+        elif response is None:
+            rh.ha_config = {}
 
     # Define the forecast and optimization objects
     fcst = Forecast(

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -107,6 +107,7 @@ class RetrieveHass:
         """
         Extract some configuration data from HA.
 
+        :rtype: bool | None, if None then using addon configuration or no Home Assistant configuration
         """
         if not self.hass_url or not self.long_lived_token:
             self.logger.info(


### PR DESCRIPTION
This PR incorporates the feature to allow users to not use HA for configuration data. Like the already existing logs suggested, setting the url and/or token to 'empty' will skip getting configuration data from HA.

## Summary by Sourcery

Allow EMHASS to run without retrieving configuration from Home Assistant when HA connection details are not provided.

New Features:
- Support using only addon configuration by skipping Home Assistant configuration retrieval when HA URL or token are not set.

Bug Fixes:
- Handle the Home Assistant configuration retrieval result explicitly to avoid updating parameters when configuration fetching fails.