### PR TITLE
Refactored proposed changes for HA independent config

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -227,19 +227,15 @@ def set_input_data_dict(
     if get_data_from_file:
         with open(emhass_conf["data_path"] / test_df_literal, "rb") as inp:
             _, _, _, rh.ha_config = pickle.load(inp)
-    # Call to get HA configuration
     else:
-        response = rh.get_ha_config()
-        if response is False:
+        if not rh.get_ha_config():
             return False
-        elif response is True:
-            # Update the params dict using data from the HA configuration
-            params = utils.update_params_with_ha_config(
-                params,
-                rh.ha_config,
-            )
-        elif response is None:
-            rh.ha_config = {}
+
+    # Update the params dict using data from the HA configuration
+    params = utils.update_params_with_ha_config(
+        params,
+        rh.ha_config,
+    )
 
     # Define the forecast and optimization objects
     fcst = Forecast(


### PR DESCRIPTION
## Summary by Sourcery

Standardize Home Assistant configuration retrieval to always initialize an empty config, treat missing credentials as a valid local-config scenario, and simplify downstream usage to rely on a boolean success result.

Bug Fixes:
- Prevent crashes when Home Assistant credentials are missing by always initializing an empty configuration and treating this as a successful local-config setup.
- Improve robustness of Home Assistant config retrieval by validating HTTP responses and handling JSON and connection errors more gracefully.

Enhancements:
- Simplify the HA configuration retrieval API to return a strict boolean result instead of multiple sentinel values.
- Centralize parameter updating from Home Assistant configuration so it runs whenever configuration is loaded, regardless of source.