### PR TITLE
Implement inverter AC input limit constraint

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -657,6 +657,22 @@ class Optimization:
             }
         )
 
+        # Constraint for inverter AC input limit
+        # Only apply this if the inverter is hybrid. 
+        if self.plant_conf["inverter_is_hybrid"]:
+            inverter_ac_input_limit = self.plant_conf.get("inverter_ac_input_max")
+            if inverter_ac_input_limit is not None:
+                constraints.update(
+                    {
+                        f"constraint_inverter_ac_input_{i}": plp.LpConstraint(
+                            e=P_grid_pos[i] - inverter_ac_input_limit,
+                            sense=plp.LpConstraintLE,
+                            rhs=0,
+                        )
+                        for i in set_I
+                    }
+                )
+
         # Treat deferrable loads constraints
         predicted_temps = {}
         for k in range(self.optim_conf["number_of_deferrable_loads"]):


### PR DESCRIPTION
Add constraint for inverter AC input limit if hybrid.

## Summary by Sourcery

Bug Fixes:
- Prevent optimization from exceeding the configured maximum AC input when the inverter is hybrid.

With this `inverter_ac_input_max` will affect the battery charger limits, but it won't limit the main grid connection for non-hybrid users.