### PR TITLE
Change regressor parameter to estimator in forecaster

### DIFF
--- a/src/emhass/machine_learning_forecaster.py
+++ b/src/emhass/machine_learning_forecaster.py
@@ -219,7 +219,7 @@ class MLForecaster:
             base_model = self._get_sklearn_model(self.sklearn_model)
 
             # Define the forecaster object
-            self.forecaster = ForecasterRecursive(regressor=base_model, lags=self.num_lags)
+            self.forecaster = ForecasterRecursive(estimator=base_model, lags=self.num_lags)
 
             # Fit and time it
             self.logger.info("Training a " + self.sklearn_model + " model")


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Align forecaster construction with the updated `ForecasterRecursive` API to prevent issues from using the deprecated `regressor` parameter.