### PR TITLE
Use one ClientSession

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -264,144 +264,146 @@ class RetrieveHass:
         var_list = [var for var in var_list if var != ""]
         # Looping on each day from days list
         self.df_final = pd.DataFrame()
-        x = 0  # iterate based on days
 
-        for day in days_list:
-            for i, var in enumerate(var_list):
-                if test_url == "empty":
-                    if (
-                        self.hass_url == "http://supervisor/core/api"
-                    ):  # If we are using the supervisor API
-                        url = (
-                            self.hass_url
-                            + "/history/period/"
-                            + day.isoformat()
-                            + "?filter_entity_id="
-                            + var
-                        )
-                    else:  # Otherwise the Home Assistant Core API it is
-                        if self.hass_url[-1] != "/":
-                            self.logger.warning(
-                                "Missing slash </> at the end of the defined URL, appending a slash but please fix your URL"
+        async with aiohttp.ClientSession() as session:
+            x = 0  # iterate based on days
+
+            for day in days_list:
+                for i, var in enumerate(var_list):
+                    if test_url == "empty":
+                        if (
+                            self.hass_url == "http://supervisor/core/api"
+                        ):  # If we are using the supervisor API
+                            url = (
+                                self.hass_url
+                                + "/history/period/"
+                                + day.isoformat()
+                                + "?filter_entity_id="
+                                + var
                             )
-                            self.hass_url = self.hass_url + "/"
-                        url = (
-                            self.hass_url
-                            + "api/history/period/"
-                            + day.isoformat()
-                            + "?filter_entity_id="
-                            + var
-                        )
-                    if minimal_response:  # A support for minimal response
-                        url = url + "?minimal_response"
-                    if (
-                        significant_changes_only
-                    ):  # And for signicant changes only (check the HASS restful API for more info)
-                        url = url + "?significant_changes_only"
-                else:
-                    url = test_url
+                        else:  # Otherwise the Home Assistant Core API it is
+                            if self.hass_url[-1] != "/":
+                                self.logger.warning(
+                                    "Missing slash </> at the end of the defined URL, appending a slash but please fix your URL"
+                                )
+                                self.hass_url = self.hass_url + "/"
+                            url = (
+                                self.hass_url
+                                + "api/history/period/"
+                                + day.isoformat()
+                                + "?filter_entity_id="
+                                + var
+                            )
+                        if minimal_response:  # A support for minimal response
+                            url = url + "?minimal_response"
+                        if significant_changes_only:  # And for signicant changes only (check the HASS restful API for more info)
+                            url = url + "?significant_changes_only"
+                    else:
+                        url = test_url
 
-                try:
-                    async with aiohttp.ClientSession() as session:
+                    try:
                         async with session.get(url, headers=headers) as response:
                             response.raise_for_status()
                             data = await response.read()
                             data_list = orjson.loads(data)
-                except Exception:
-                    self.logger.error("Unable to access Home Assistant instance, check URL")
-                    self.logger.error("If using addon, try setting url and token to 'empty'")
-                    return False
-                else:
-                    if response.status == 401:
-                        self.logger.error("Unable to access Home Assistant instance, TOKEN/KEY")
+                    except Exception:
+                        self.logger.error("Unable to access Home Assistant instance, check URL")
                         self.logger.error("If using addon, try setting url and token to 'empty'")
                         return False
-                    if response.status > 299:
-                        self.logger.error(
-                            f"Home assistant request GET error: {response.status} for var {var}"
-                        )
+                    else:
+                        if response.status == 401:
+                            self.logger.error("Unable to access Home Assistant instance, TOKEN/KEY")
+                            self.logger.error(
+                                "If using addon, try setting url and token to 'empty'"
+                            )
+                            return False
+                        if response.status > 299:
+                            self.logger.error(
+                                f"Home assistant request GET error: {response.status} for var {var}"
+                            )
+                            return False
+                    """import bz2 # Uncomment to save a serialized data for tests
+                    import _pickle as cPickle
+                    with bz2.BZ2File("data/test_response_get_data_get_method.pbz2", "w") as f:
+                        cPickle.dump(response, f)"""
+
+                    try:  # Sometimes when there are connection problems we need to catch empty retrieved json
+                        data = data_list[0]
+                    except IndexError:
+                        if x == 0:
+                            self.logger.error(
+                                "The retrieved JSON is empty, A sensor:"
+                                + var
+                                + " may have 0 days of history, passed sensor may not be correct, or days to retrieve is set too high. Check your Logger configuration, ensuring the sensors are in the include list."
+                            )
+                        else:
+                            self.logger.error(
+                                "The retrieved JSON is empty for day:"
+                                + str(day)
+                                + ", days_to_retrieve may be larger than the recorded history of sensor:"
+                                + var
+                                + " (check your recorder settings)"
+                            )
                         return False
-                """import bz2 # Uncomment to save a serialized data for tests
-                import _pickle as cPickle
-                with bz2.BZ2File("data/test_response_get_data_get_method.pbz2", "w") as f:
-                    cPickle.dump(response, f)"""
 
-                try:  # Sometimes when there are connection problems we need to catch empty retrieved json
-                    data = data_list[0]
-                except IndexError:
-                    if x == 0:
-                        self.logger.error(
-                            "The retrieved JSON is empty, A sensor:"
+                    df_raw = pd.DataFrame.from_dict(data)
+                    if len(df_raw) == 0:
+                        if x == 0:
+                            self.logger.error(
+                                "The retrieved Dataframe is empty, A sensor:"
+                                + var
+                                + " may have 0 days of history or passed sensor may not be correct"
+                            )
+                        else:
+                            self.logger.error(
+                                "Retrieved empty Dataframe for day:"
+                                + str(day)
+                                + ", days_to_retrieve may be larger than the recorded history of sensor:"
+                                + var
+                                + " (check your recorder settings)"
+                            )
+                        return False
+
+                    if (
+                        len(df_raw) < ((60 / (self.freq.seconds / 60)) * 24)
+                        and x != len(days_list) - 1
+                    ):  # check if there is enough Dataframes for passed frequency per day (not inc current day)
+                        self.logger.debug(
+                            "sensor:"
                             + var
-                            + " may have 0 days of history, passed sensor may not be correct, or days to retrieve is set too high. Check your Logger configuration, ensuring the sensors are in the include list."
-                        )
-                    else:
-                        self.logger.error(
-                            "The retrieved JSON is empty for day:"
+                            + " retrieved Dataframe count: "
+                            + str(len(df_raw))
+                            + ", on day: "
                             + str(day)
-                            + ", days_to_retrieve may be larger than the recorded history of sensor:"
-                            + var
-                            + " (check your recorder settings)"
+                            + ". This is less than freq value passed: "
+                            + str(self.freq)
                         )
-                    return False
 
-                df_raw = pd.DataFrame.from_dict(data)
-                if len(df_raw) == 0:
-                    if x == 0:
-                        self.logger.error(
-                            "The retrieved Dataframe is empty, A sensor:"
-                            + var
-                            + " may have 0 days of history or passed sensor may not be correct"
-                        )
-                    else:
-                        self.logger.error(
-                            "Retrieved empty Dataframe for day:"
-                            + str(day)
-                            + ", days_to_retrieve may be larger than the recorded history of sensor:"
-                            + var
-                            + " (check your recorder settings)"
-                        )
-                    return False
+                    if i == 0:  # Defining the DataFrame container
+                        from_date = pd.to_datetime(df_raw["last_changed"], format="ISO8601").min()
+                        to_date = pd.to_datetime(df_raw["last_changed"], format="ISO8601").max()
+                        ts = pd.to_datetime(
+                            pd.date_range(start=from_date, end=to_date, freq=self.freq),
+                            format="%Y-%d-%m %H:%M",
+                        ).round(self.freq, ambiguous="infer", nonexistent="shift_forward")
+                        df_day = pd.DataFrame(index=ts)
 
-                if (
-                    len(df_raw) < ((60 / (self.freq.seconds / 60)) * 24) and x != len(days_list) - 1
-                ):  # check if there is enough Dataframes for passed frequency per day (not inc current day)
-                    self.logger.debug(
-                        "sensor:"
-                        + var
-                        + " retrieved Dataframe count: "
-                        + str(len(df_raw))
-                        + ", on day: "
-                        + str(day)
-                        + ". This is less than freq value passed: "
-                        + str(self.freq)
+                    # Caution with undefined string data: unknown, unavailable, etc.
+                    df_tp = (
+                        df_raw.copy()[["state"]]
+                        .replace(["unknown", "unavailable", ""], np.nan)
+                        .astype(float)
+                        .rename(columns={"state": var})
                     )
-
-                if i == 0:  # Defining the DataFrame container
-                    from_date = pd.to_datetime(df_raw["last_changed"], format="ISO8601").min()
-                    to_date = pd.to_datetime(df_raw["last_changed"], format="ISO8601").max()
-                    ts = pd.to_datetime(
-                        pd.date_range(start=from_date, end=to_date, freq=self.freq),
-                        format="%Y-%d-%m %H:%M",
-                    ).round(self.freq, ambiguous="infer", nonexistent="shift_forward")
-                    df_day = pd.DataFrame(index=ts)
-
-                # Caution with undefined string data: unknown, unavailable, etc.
-                df_tp = (
-                    df_raw.copy()[["state"]]
-                    .replace(["unknown", "unavailable", ""], np.nan)
-                    .astype(float)
-                    .rename(columns={"state": var})
-                )
-                # Setting index, resampling and concatenation
-                df_tp.set_index(
-                    pd.to_datetime(df_raw["last_changed"], format="ISO8601"),
-                    inplace=True,
-                )
-                df_tp = df_tp.resample(self.freq).mean()
-                df_day = pd.concat([df_day, df_tp], axis=1)
-            self.df_final = pd.concat([self.df_final, df_day], axis=0)
-            x += 1
+                    # Setting index, resampling and concatenation
+                    df_tp.set_index(
+                        pd.to_datetime(df_raw["last_changed"], format="ISO8601"),
+                        inplace=True,
+                    )
+                    df_tp = df_tp.resample(self.freq).mean()
+                    df_day = pd.concat([df_day, df_tp], axis=1)
+                self.df_final = pd.concat([self.df_final, df_day], axis=0)
+                x += 1
 
         self.df_final = set_df_index_freq(self.df_final)
         if self.df_final.index.freq != self.freq:


### PR DESCRIPTION
Only use one clientsession for data retrieval through rest-api

## Summary by Sourcery

Enhancements:
- Refactor REST API data retrieval to reuse one aiohttp ClientSession across all sensor/day requests instead of creating a session per request.