### PR TITLE
removed device class and unit of measurement for optim status

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1099,7 +1099,7 @@ class RetrieveHass:
             data = {
                 "state": state,
                 "attributes": {
-                "friendly_name": friendly_name,
+                    "friendly_name": friendly_name,
                 },
             }
         elif type_var == "mlregressor":


### PR DESCRIPTION
fix issue reported here:
HA Sensor Optimization Status has misleading Attribute leading to wrong chart #651

## Summary by Sourcery

Bug Fixes:
- Stop sending device_class and unit_of_measurement attributes for the optimization status sensor to prevent incorrect interpretation and charting in Home Assistant.