### PR TITLE
Revert "Implement inverter AC input limit constraint"

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -638,22 +638,6 @@ class Optimization:
             }
         )
 
-        # Constraint for inverter AC input limit
-        # Only apply this if the inverter is hybrid.
-        if self.plant_conf["inverter_is_hybrid"]:
-            inverter_ac_input_limit = self.plant_conf.get("inverter_ac_input_max")
-            if inverter_ac_input_limit is not None:
-                constraints.update(
-                    {
-                        f"constraint_inverter_ac_input_{i}": plp.LpConstraint(
-                            e=P_grid_pos[i] - inverter_ac_input_limit,
-                            sense=plp.LpConstraintLE,
-                            rhs=0,
-                        )
-                        for i in set_I
-                    }
-                )
-
         # Treat deferrable loads constraints
         predicted_temps = {}
         for k in range(self.optim_conf["number_of_deferrable_loads"]):


### PR DESCRIPTION
This reverts commit b2a0647b28cde365d0254c8c72da2ebe445fe6d5.

The previous commit incorrectly capped total grid import at the inverter's AC input limit, rather than allowing for additional household loads.

For example: if the grid limit is 15kW and the inverter limit is 10kW, the system should allow 10kW for the battery and 5kW for the home simultaneously. The previous implementation capped the entire site at 10kW, unnecessarily throttling the inverter whenever other household loads were present.

## Summary by Sourcery

Bug Fixes:
- Remove the incorrect constraint that capped total grid import at the inverter AC input limit for hybrid inverters, which was throttling site power unnecessarily.