### PR TITLE
Add vector support for maximum power to or from grid

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -134,6 +134,43 @@ class Optimization:
         )
         self.logger.debug(f"Number of threads: {self.num_threads}")
 
+    def _prepare_power_limit_array(self, limit_value, limit_name, data_length):
+        """
+        Convert power limit to numpy array for time-varying constraints.
+        
+        Args:
+            limit_value: Scalar, list, or array of power limit values
+            limit_name: Name of the limit (for logging)
+            data_length: Expected length of optimization horizon
+            
+        Returns:
+            numpy.ndarray: Array of power limits with length = data_length
+        """
+        if limit_value is None:
+            self.logger.error(f"{limit_name} is None, using default value 9000 W")
+            return np.full(data_length, 9000.0)
+        
+        # Convert to numpy array if it's a list
+        if isinstance(limit_value, list):
+            limit_array = np.array(limit_value, dtype=float)
+        elif isinstance(limit_value, np.ndarray):
+            limit_array = limit_value.astype(float)
+        else:
+            # Scalar value - broadcast to all timesteps
+            return np.full(data_length, float(limit_value))
+        
+        # Validate length
+        if len(limit_array) != data_length:
+            self.logger.warning(
+                f"{limit_name} length ({len(limit_array)}) doesn't match "
+                f"optimization horizon ({data_length}). Using scalar from first value."
+            )
+            return np.full(data_length, float(limit_array[0]) if len(limit_array) > 0 else 9000.0)
+        
+        self.logger.info(f"{limit_name} configured as time-varying with {data_length} values")
+        return limit_array
+
+
     def _setup_stress_cost(self, set_i, cost_conf_key, max_power, var_name_prefix):
         """
         Generic setup for a stress cost (battery or inverter).
@@ -322,13 +359,26 @@ class Optimization:
 
         n = len(data_opt.index)
         set_i = range(n)
+
+        # Prepare power limit arrays - allows time-varying limits (Tier 1a)
+        max_power_from_grid_array = self._prepare_power_limit_array(
+            self.plant_conf.get("maximum_power_from_grid", 9000),
+            "maximum_power_from_grid",
+            n
+        )
+        max_power_to_grid_array = self._prepare_power_limit_array(
+            self.plant_conf.get("maximum_power_to_grid", 9000),
+            "maximum_power_to_grid",
+            n
+        )
+
         M = 100000
 
         ## Add decision variables
         p_grid_neg = {
             (i): plp.LpVariable(
                 cat="Continuous",
-                lowBound=-self.plant_conf["maximum_power_to_grid"],
+                lowBound=-float(max_power_to_grid_array[i]),
                 upBound=0,
                 name=f"P_grid_neg{i}",
             )
@@ -338,7 +388,7 @@ class Optimization:
             (i): plp.LpVariable(
                 cat="Continuous",
                 lowBound=0,
-                upBound=self.plant_conf["maximum_power_from_grid"],
+                upBound=float(max_power_from_grid_array[i]),
                 name=f"P_grid_pos{i}",
             )
             for i in set_i
@@ -795,7 +845,7 @@ class Optimization:
         constraints.update(
             {
                 f"constraint_pgridpos_{i}": plp.LpConstraint(
-                    e=p_grid_pos[i] - self.plant_conf["maximum_power_from_grid"] * D[i],
+                    e=p_grid_pos[i] - float(max_power_from_grid_array[i]) * D[i],
                     sense=plp.LpConstraintLE,
                     rhs=0,
                 )
@@ -805,7 +855,7 @@ class Optimization:
         constraints.update(
             {
                 f"constraint_pgridneg_{i}": plp.LpConstraint(
-                    e=-p_grid_neg[i] - self.plant_conf["maximum_power_to_grid"] * (1 - D[i]),
+                    e=-p_grid_neg[i] - float(max_power_to_grid_array[i]) * (1 - D[i]),
                     sense=plp.LpConstraintLE,
                     rhs=0,
                 )
@@ -1719,6 +1769,11 @@ class Optimization:
         if self.plant_conf["compute_curtailment"]:
             opt_tp["P_PV_curtailment"] = [p_pv_curtailment[i].varValue for i in set_i]
         opt_tp.index = data_opt.index
+
+        # Add power limit columns to output (Tier 1a)
+        opt_tp["maximum_power_from_grid"] = max_power_from_grid_array.astype(int).tolist()
+        opt_tp["maximum_power_to_grid"] = max_power_to_grid_array.astype(int).tolist()
+
 
         # Lets compute the optimal cost function
         p_def_sum_tp = []

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -708,6 +708,47 @@ async def treat_runtimeparams(
                     # Check Legacy parameter name runtime
                     elif runtimeparams.get(association[1], None) is not None:
                         params[association[0]][association[2]] = runtimeparams[association[1]]
+        
+        # Special handling for power limit parameters - they can be vectors (Tier 1a)
+        # Parse maximum_power_from_grid (can be scalar or list/array)
+        if "maximum_power_from_grid" in runtimeparams:
+            import ast
+            value = runtimeparams["maximum_power_from_grid"]
+            try:
+                # If it's a string representation of a list, parse it
+                if isinstance(value, str):
+                    parsed = ast.literal_eval(value)
+                    params["plant_conf"]["maximum_power_from_grid"] = parsed
+                # If already a list/array, use it directly
+                elif isinstance(value, (list, tuple)):
+                    params["plant_conf"]["maximum_power_from_grid"] = list(value)
+                # If scalar, use as-is
+                else:
+                    params["plant_conf"]["maximum_power_from_grid"] = value
+            except (ValueError, SyntaxError) as e:
+                logger.warning(
+                    f"Could not parse maximum_power_from_grid: {e}. Using default."
+                )
+        
+        # Parse maximum_power_to_grid (can be scalar or list/array)
+        if "maximum_power_to_grid" in runtimeparams:
+            import ast
+            value = runtimeparams["maximum_power_to_grid"]
+            try:
+                # If it's a string representation of a list, parse it
+                if isinstance(value, str):
+                    parsed = ast.literal_eval(value)
+                    params["plant_conf"]["maximum_power_to_grid"] = parsed
+                # If already a list/array, use it directly
+                elif isinstance(value, (list, tuple)):
+                    params["plant_conf"]["maximum_power_to_grid"] = list(value)
+                # If scalar, use as-is
+                else:
+                    params["plant_conf"]["maximum_power_to_grid"] = value
+            except (ValueError, SyntaxError) as e:
+                logger.warning(
+                    f"Could not parse maximum_power_to_grid: {e}. Using default."
+                )
         else:
             logger.warning(
                 "Cant find associations file (associations.csv) in: "

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -2140,6 +2140,183 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         )
 
 
+
+    def test_prepare_power_limit_array_scalar(self):
+        """Test _prepare_power_limit_array with scalar input (existing behavior)"""
+        # Test scalar input should broadcast to all timesteps
+        result = self.opt._prepare_power_limit_array(9000, "test_scalar", 10)
+        
+        self.assertIsInstance(result, np.ndarray, "Should return numpy array")
+        self.assertEqual(len(result), 10, "Array length should match data_length")
+        self.assertTrue(np.all(result == 9000), "All values should equal the scalar input")
+
+    def test_prepare_power_limit_array_list(self):
+        """Test _prepare_power_limit_array with list input (new feature)"""
+        # Test list input with correct length
+        input_list = [9000, 8000, 7000, 6000, 5000]
+        result = self.opt._prepare_power_limit_array(input_list, "test_list", 5)
+        
+        self.assertIsInstance(result, np.ndarray, "Should return numpy array")
+        self.assertEqual(len(result), 5, "Array length should match input list length")
+        self.assertEqual(result[0], 9000, "First value should be preserved")
+        self.assertEqual(result[4], 5000, "Last value should be preserved")
+
+    def test_prepare_power_limit_array_numpy(self):
+        """Test _prepare_power_limit_array with numpy array input"""
+        # Test numpy array input
+        input_array = np.array([7000, 6000, 5000])
+        result = self.opt._prepare_power_limit_array(input_array, "test_array", 3)
+        
+        self.assertIsInstance(result, np.ndarray, "Should return numpy array")
+        self.assertEqual(len(result), 3, "Array length should match input")
+        self.assertTrue(np.array_equal(result, input_array), "Should preserve numpy array values")
+
+    def test_prepare_power_limit_array_wrong_length(self):
+        """Test _prepare_power_limit_array with mismatched list length"""
+        # Test list with wrong length should fallback to scalar (first value)
+        input_list = [9000, 8000]
+        result = self.opt._prepare_power_limit_array(input_list, "test_wrong_len", 5)
+        
+        self.assertIsInstance(result, np.ndarray, "Should return numpy array")
+        self.assertEqual(len(result), 5, "Should fallback to correct length")
+        self.assertTrue(np.all(result == 9000), "Should use first value as scalar fallback")
+
+    def test_prepare_power_limit_array_none(self):
+        """Test _prepare_power_limit_array with None input"""
+        # Test None input should use default value
+        result = self.opt._prepare_power_limit_array(None, "test_none", 5)
+        
+        self.assertIsInstance(result, np.ndarray, "Should return numpy array")
+        self.assertEqual(len(result), 5, "Should have correct length")
+        self.assertTrue(np.all(result == 9000), "Should use default value of 9000")
+
+    def test_optimization_with_scalar_power_limits(self):
+        """Test full optimization with scalar power limits (backward compatibility)"""
+        # This tests that existing behavior still works
+        df_input_data_dayahead = self.prepare_forecast_data()
+        P_PV = df_input_data_dayahead["p_pv_forecast"]
+        P_load = df_input_data_dayahead["p_load_forecast"]
+        
+        # Run optimization with scalar limits (default behavior)
+        opt_res = self.opt.perform_dayahead_forecast_optim(
+            df_input_data_dayahead, P_PV, P_load
+        )
+        
+        # Verify optimization succeeded
+        self.assertIsNotNone(opt_res, "Optimization should return results")
+        self.assertIsInstance(opt_res, pd.DataFrame, "Should return DataFrame")
+        
+        # Verify power limit columns exist
+        self.assertIn("maximum_power_from_grid", opt_res.columns, "Should have from_grid column")
+        self.assertIn("maximum_power_to_grid", opt_res.columns, "Should have to_grid column")
+        
+        # Verify scalar values are consistent (all same value)
+        from_grid_values = opt_res["maximum_power_from_grid"].unique()
+        to_grid_values = opt_res["maximum_power_to_grid"].unique()
+        
+        self.assertEqual(len(from_grid_values), 1, "Scalar should have single unique value")
+        self.assertEqual(len(to_grid_values), 1, "Scalar should have single unique value")
+
+    def test_optimization_with_vector_power_limits(self):
+        """Test full optimization with time-varying power limits (new feature)"""
+        df_input_data_dayahead = self.prepare_forecast_data()
+        n = len(df_input_data_dayahead)
+        
+        # Create time-varying limits: lower during middle hours
+        vector_from_grid = [9000] * n
+        for i in range(n // 4, 3 * n // 4):  # Middle half has lower limit
+            vector_from_grid[i] = 5000
+        
+        # Update config temporarily
+        original_from_grid = self.plant_conf["maximum_power_from_grid"]
+        self.plant_conf["maximum_power_from_grid"] = vector_from_grid
+        
+        # Recreate optimization object with new config
+        from emhass.optimization import Optimization
+        from emhass.utils import get_root
+        import pathlib
+        
+        # Setup emhass_conf for the test
+        root = pathlib.Path(get_root(__file__, num_parent=2))
+        emhass_conf = {
+            "data_path": root / "data/",
+            "root_path": root / "src/emhass/",
+        }
+        
+        opt_temp = Optimization(
+            self.retrieve_hass_conf,
+            self.optim_conf,
+            self.plant_conf,
+            "unit_load_cost",
+            "unit_prod_price",
+            "profit",
+            emhass_conf,
+            logger,
+        )
+        
+        try:
+            P_PV = df_input_data_dayahead["p_pv_forecast"]
+            P_load = df_input_data_dayahead["p_load_forecast"]
+            
+            # Run optimization with vector limits
+            opt_res = opt_temp.perform_dayahead_forecast_optim(
+                df_input_data_dayahead, P_PV, P_load
+            )
+            
+            # Verify optimization succeeded
+            self.assertIsNotNone(opt_res, "Optimization should return results")
+            self.assertIsInstance(opt_res, pd.DataFrame, "Should return DataFrame")
+            
+            # Verify power limit columns exist
+            self.assertIn("maximum_power_from_grid", opt_res.columns, "Should have from_grid column")
+            
+            # Verify vector values are present
+            from_grid_values = opt_res["maximum_power_from_grid"].values
+            self.assertEqual(len(from_grid_values), n, "Should have value for each timestep")
+            self.assertIn(5000, from_grid_values, "Should contain lower limit values")
+            self.assertIn(9000, from_grid_values, "Should contain higher limit values")
+            
+            # Verify the pattern matches our input
+            for i in range(n // 4, 3 * n // 4):
+                self.assertEqual(from_grid_values[i], 5000, 
+                               f"Timestep {i} should have lower limit")
+            
+            # Verify optimization respects the limits
+            p_grid_pos = opt_res["P_grid_pos"].values
+            for i in range(n):
+                self.assertLessEqual(p_grid_pos[i], from_grid_values[i] + 0.1,
+                                   f"Grid import at timestep {i} should not exceed limit")
+        
+        finally:
+            # Restore original config
+            self.plant_conf["maximum_power_from_grid"] = original_from_grid
+
+    def test_power_limit_columns_are_integers(self):
+        """Test that power limit columns are displayed as integers, not floats"""
+        df_input_data_dayahead = self.prepare_forecast_data()
+        P_PV = df_input_data_dayahead["p_pv_forecast"]
+        P_load = df_input_data_dayahead["p_load_forecast"]
+        
+        # Run optimization
+        opt_res = self.opt.perform_dayahead_forecast_optim(
+            df_input_data_dayahead, P_PV, P_load
+        )
+        
+        # Check that values are integers
+        from_grid_values = opt_res["maximum_power_from_grid"].values
+        to_grid_values = opt_res["maximum_power_to_grid"].values
+        
+        # All values should be whole numbers (no decimals)
+        self.assertTrue(
+            np.all(from_grid_values == from_grid_values.astype(int)),
+            "from_grid values should be integers"
+        )
+        self.assertTrue(
+            np.all(to_grid_values == to_grid_values.astype(int)),
+            "to_grid values should be integers"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()
     ch.close()


### PR DESCRIPTION
Adds support for time-varying (vector) power limits for both `maximum_power_from_grid` and `maximum_power_to_grid` parameters, without breaking existing configurations (using scalars). 

This PR implements vector limits. Future work could include soft limits with penalties (currently hard limits only).
This PR replaces [PR #630].

Related to #540, #557, #623 (capacity tariff and peak power management discussions).

## Example Usage
### Scalar (existing)
  maximum_power_from_grid: 9000
  maximum_power_to_grid: 9000

### Vector (new - time-varying limits)
  maximum_power_from_grid: [9000, 9000, 2000, 2000, ...]  # Lower during peak
  maximum_power_to_grid: 9000  # Can mix scalar and vector

## Summary by Sourcery

Add support for time-varying power limits for grid import/export while preserving existing scalar configuration behavior.

New Features:
- Allow maximum_power_from_grid and maximum_power_to_grid to be defined as time-varying vectors in the optimization model.
- Expose per-timestep grid power limit values in the optimization output for downstream analysis.

Enhancements:
- Gracefully handle mismatched or missing power limit configurations with sensible defaults and logging.
- Support parsing scalar or vector grid power limits from runtime parameters, including string-encoded lists.

Tests:
- Add unit tests for power limit array preparation, backward compatibility with scalar limits, vector limit behavior in full optimization, and integer formatting of power limit outputs.