### PR TITLE
Missing unit convertion for load_power

### DIFF
--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -23,6 +23,9 @@ if TYPE_CHECKING:
 
 pd.options.plotting.backend = "plotly"
 
+# Unit conversion constants
+W_TO_KW = 1000  # Watts to kilowatts conversion factor
+
 
 def get_root(file: str, num_parent: int = 3) -> str:
     """
@@ -490,9 +493,23 @@ def calculate_heating_demand_physics(
                 f"outdoor_temperature_forecast length ({len(outdoor_temps)})"
             )
 
+        # Warn if values seem like they might be in kW instead of W
+        # Typical household load is 100-10000W; values below 10 suggest kW was passed
+        max_load = np.max(internal_gains)
+        if max_load > 0 and max_load < 10:
+            import warnings
+
+            warnings.warn(
+                f"internal_gains_forecast max value ({max_load:.2f}) is very low. "
+                "Expected values in W (e.g., 500-5000), but received values that "
+                "look like kW. Please ensure you're passing Watts, not kilowatts.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Internal gains: Q_internal = load_power * factor
         # load_power is in W, convert to kW; factor is dimensionless (0-1)
-        internal_gains_kw = internal_gains * internal_gains_factor / 1000
+        internal_gains_kw = internal_gains * internal_gains_factor / W_TO_KW
 
         # Subtract internal gains from heat loss (but never go negative)
         total_loss_kw = np.maximum(total_loss_kw - internal_gains_kw, 0.0)


### PR DESCRIPTION
@davidusb-geek I am really sorry, just realized that I forgot to do a unit convertion from W to kW in the inter_gains calculation. Just a small PR :)

## Summary by Sourcery

Correct internal gains unit handling by treating electrical load forecasts as Watts and converting to kW in the heating demand physics calculation.

Bug Fixes:
- Fix internal gains calculation by converting electrical load power from Watts to kilowatts before subtracting from heating demand.

Documentation:
- Clarify the calculate_heating_demand_physics parameter documentation to state that internal gains forecasts are expected in Watts.

Tests:
- Update heating demand physics tests to provide electrical load forecasts in Watts instead of kilowatts and maintain consistency with the new unit convention.