### PR TITLE
Fix Docker signal handling with tini and pin uvicorn version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ RUN apt-get update \
     patchelf \
     cmake \
     ninja-build \
+    # Runtime dependencies
+    tini \
     # Cleanup apt caches to reduce image size
     && rm -rf /var/cache/apt/* \
     && rm -rf /var/lib/apt/lists/* \
@@ -117,7 +119,7 @@ ENV PORT=5000
 ENV IP=0.0.0.0
 
 # Entrypoint script inline
-ENTRYPOINT ["/bin/bash", "-c", "set -e && \
+ENTRYPOINT ["/usr/bin/tini", "--", "/bin/bash", "-c", "set -e && \
 if [ ! -f /data/long_train_data.pkl ]; then \
     echo 'Initializing data: Copying default PKL file...'; \
     cp /app/data/long_train_data.pkl /data/; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "aiohttp",
     "orjson",
     "websockets",
-    "uvicorn>=0.30.0",
+    "uvicorn==0.30.6",
     "influxdb>=5.3.1",
 ]
 


### PR DESCRIPTION
The Gunicorn worker would timeout and fail to restart after approximately 1082 requests (default max_requests + jitter), resulting in an unhandled SIGCHLD signal error because the container lacked a proper init process.

This commit adds tini as PID 1 to correctly handle signal forwarding and zombie reaping, resolving the worker timeout issue.

It also pins uvicorn to 0.30.6 to avoid a regression in newer versions (0.34.x+) where ProxyHeadersMiddleware crashes with an AttributeError when processing trusted hosts.