### PR TITLE
Fix link to installation methods in quick start guide

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -7,7 +7,7 @@ Installation instructions and example Home Assistant automation configurations a
 You must follow these steps to make EMHASS work properly:
 
 1) Install and run EMHASS.
-    - There are multiple methods of installing and Running EMHASS. See [Installation Method](installation_methods) section to pick a method that best suits your use case.
+    - There are multiple methods of installing and Running EMHASS. See [Installation Method](installation_methods.md) section to pick a method that best suits your use case.
 
 2) Define all the parameters in the configuration file *(`config.json`)* or configuration page *(`YOURIP:5000/configuration`)*.
     - The default configuration does not need to retrieve any data from Home Assistant! After installing and running the add-on, EMHASS should start and it will be ready to launch an optimization.


### PR DESCRIPTION
By accident I noticed the link was not working from the quickstart guide to the installation methods.

## Summary by Sourcery

Documentation:
- Correct the quick start guide link so it points to the installation_methods.md page.