### PR TITLE
Handle corrupted metadata.json file

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1237,7 +1237,14 @@ class RetrieveHass:
                 if os.path.isfile(metadata_path):
                     async with aiofiles.open(metadata_path) as file:
                         content = await file.read()
-                        metadata = orjson.loads(content)
+                        try:
+                            metadata = orjson.loads(content)
+                        except orjson.JSONDecodeError:
+                            self.logger.error(f"Corrupted metadata file found at {metadata_path}. Creating a new one.")
+                            metadata = {}
+                            # Rename the corrupted file to metadata_corrupt.json
+                            corrupt_path = entities_path / "metadata_corrupt.json"
+                            os.rename(metadata_path, corrupt_path)
                 else:
                     metadata = {}
 


### PR DESCRIPTION
Wrap metadata loading in try-except block to handle JSONDecodeError. If corruption is detected, log error, rename corrupted file, and initialize empty metadata to allow recovery.

## Summary by Sourcery

Bug Fixes:
- Recover gracefully from corrupted metadata.json by catching JSONDecodeError, logging the issue, renaming the corrupt file, and reinitializing metadata to an empty structure.