### PR TITLE
fix ruff format in retrieve_hass.py

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1240,7 +1240,9 @@ class RetrieveHass:
                         try:
                             metadata = orjson.loads(content)
                         except orjson.JSONDecodeError:
-                            self.logger.error(f"Corrupted metadata file found at {metadata_path}. Creating a new one.")
+                            self.logger.error(
+                                f"Corrupted metadata file found at {metadata_path}. Creating a new one."
+                            )
                             metadata = {}
                             # Rename the corrupted file to metadata_corrupt.json
                             corrupt_path = entities_path / "metadata_corrupt.json"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust logging statement formatting for corrupted metadata files to satisfy lint/format requirements.