### PR TITLE
fix: gracefully skip days with no history data in REST API retrieval

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -375,33 +375,34 @@ class RetrieveHass:
             return data_list[0]
         except IndexError:
             if is_first_day:
-                self.logger.error(
-                    f"The retrieved JSON is empty. A sensor: {var} may have 0 days of history, "
-                    "the passed sensor may not be correct, or days_to_retrieve is set too high."
+                self.logger.debug(
+                    f"No history data for sensor: {var} on {day.date()}. "
+                    "The sensor may not have existed yet, or days_to_retrieve "
+                    "may exceed the available history. Skipping this day."
                 )
             else:
-                self.logger.error(
-                    f"The retrieved JSON is empty for day: {day}. days_to_retrieve may be larger "
-                    f"than the recorded history of sensor: {var}"
+                self.logger.debug(
+                    f"No history data for sensor: {var} on day: {day.date()}. Skipping this day."
                 )
-            return False
+            return None
 
     def _process_history_dataframe(
         self, data: list, var: str, day: pd.Timestamp, is_first_day: bool, is_last_day: bool
-    ) -> pd.DataFrame | bool:
+    ) -> pd.DataFrame | None:
         """Helper to convert raw data to a resampled DataFrame."""
         df_raw = pd.DataFrame.from_dict(data)
         # Check for empty DataFrame
         if len(df_raw) == 0:
             if is_first_day:
-                self.logger.error(
-                    f"The retrieved Dataframe is empty. A sensor: {var} may have 0 days of history."
+                self.logger.debug(
+                    f"Empty dataframe for sensor: {var} on {day.date()}. "
+                    "The sensor may not have existed yet. Skipping this day."
                 )
             else:
-                self.logger.error(
-                    f"Retrieved empty Dataframe for day: {day}, check recorder settings."
+                self.logger.debug(
+                    f"Empty dataframe for sensor: {var} on day: {day.date()}. Skipping this day."
                 )
-            return False
+            return None
         freq_minutes = self.freq.total_seconds() / 60.0
         expected_count = (60.0 / freq_minutes) * 24.0
         if len(df_raw) < expected_count and not is_last_day:
@@ -437,9 +438,11 @@ class RetrieveHass:
         var_list = [var for var in var_list if var != ""]
         self.df_final = pd.DataFrame()
 
+        days_skipped = 0
         async with aiohttp.ClientSession() as session:
             for day_idx, day in enumerate(days_list):
                 df_day = pd.DataFrame()
+                skip_day = False
                 for i, var in enumerate(var_list):
                     # Build URL
                     url = self._build_history_url(
@@ -451,6 +454,9 @@ class RetrieveHass:
                     )
                     if data is False:
                         return False
+                    if data is None:
+                        skip_day = True
+                        break
                     # Process Data
                     df_resampled = self._process_history_dataframe(
                         data,
@@ -459,8 +465,9 @@ class RetrieveHass:
                         is_first_day=(day_idx == 0),
                         is_last_day=(day_idx == len(days_list) - 1),
                     )
-                    if df_resampled is False:
-                        return False
+                    if df_resampled is None:
+                        skip_day = True
+                        break
                     # Merge into daily DataFrame
                     # If it's the first variable, we initialize the day's index based on it
                     if i == 0:
@@ -470,7 +477,20 @@ class RetrieveHass:
                         # resampled index from the first variable is safer and cleaner if
                         # _process_history_dataframe handles resampling correctly.
                     df_day = pd.concat([df_day, df_resampled], axis=1)
+                if skip_day:
+                    days_skipped += 1
+                    continue
                 self.df_final = pd.concat([self.df_final, df_day], axis=0)
+        if days_skipped > 0:
+            self.logger.warning(
+                f"Skipped {days_skipped} of {len(days_list)} days due to missing history data"
+            )
+        if self.df_final.empty:
+            self.logger.error(
+                "No data was retrieved for any day in the requested range. "
+                "Check sensor names and recorder history settings."
+            )
+            return False
 
         # Final Cleanup
         self.df_final = set_df_index_freq(self.df_final)

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -596,9 +596,96 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
             result = await self.rh._get_data_rest_api(days_list, var_list)
             self.assertFalse(result)
 
-        # Test Empty JSON Response (IndexError)
+        # Test Empty JSON Response — all days empty should still fail
         with aioresponses() as mocked:
             mocked.get(url, payload=[], status=200)
+            result = await self.rh._get_data_rest_api(days_list, var_list)
+            self.assertFalse(result)
+
+    async def test_get_data_rest_api_skips_empty_days(self):
+        """Test that days with no data are skipped gracefully instead of aborting."""
+        # Create a 3-day range where day 1 returns empty, days 2–3 return data
+        days_list = pd.date_range(start="2024-01-01", periods=3, freq="D", tz="UTC")
+        var_list = ["sensor.test_power"]
+
+        # Build URLs for each day
+        base_url = self.retrieve_hass_conf["hass_url"] + "api/history/period/"
+        urls = [
+            base_url + day.strftime("%Y-%m-%dT%H:%M:%SZ") + "?filter_entity_id=sensor.test_power"
+            for day in days_list
+        ]
+
+        # Build mock data: 96 records per day at 15-min intervals
+        def make_day_data(date_str, entity_id="sensor.test_power"):
+            records = []
+            base = pd.Timestamp(date_str, tz="UTC")
+            for i in range(96):
+                ts = base + pd.Timedelta(minutes=15 * i)
+                records.append(
+                    {
+                        "entity_id": entity_id,
+                        "state": str(100.0 + i),
+                        "attributes": {},
+                        "last_changed": ts.isoformat(),
+                        "last_updated": ts.isoformat(),
+                    }
+                )
+            return [records]  # HA wraps per-entity in a list
+
+        with aioresponses() as mocked:
+            # Day 1: empty (sensor didn't exist yet)
+            mocked.get(urls[0], payload=[], status=200)
+            # Day 2: has data
+            mocked.get(urls[1], payload=make_day_data("2024-01-02"), status=200)
+            # Day 3: has data
+            mocked.get(urls[2], payload=make_day_data("2024-01-03"), status=200)
+
+            result = await self.rh._get_data_rest_api(days_list, var_list)
+            # Should succeed with partial data
+            self.assertTrue(result)
+            # Should have data from 2 days, not 3
+            self.assertIsInstance(self.rh.df_final, pd.DataFrame)
+            self.assertFalse(self.rh.df_final.empty)
+            # First data point should be from day 2, not day 1
+            self.assertGreaterEqual(
+                self.rh.df_final.index[0], pd.Timestamp("2024-01-02", tz="UTC")
+            )
+
+    async def test_get_data_rest_api_all_days_empty_fails(self):
+        """Test that if ALL days return empty, it still fails with an error."""
+        days_list = pd.date_range(start="2024-01-01", periods=3, freq="D", tz="UTC")
+        var_list = ["sensor.test_power"]
+
+        base_url = self.retrieve_hass_conf["hass_url"] + "api/history/period/"
+        urls = [
+            base_url + day.strftime("%Y-%m-%dT%H:%M:%SZ") + "?filter_entity_id=sensor.test_power"
+            for day in days_list
+        ]
+
+        with aioresponses() as mocked:
+            for url in urls:
+                mocked.get(url, payload=[], status=200)
+
+            result = await self.rh._get_data_rest_api(days_list, var_list)
+            # All days empty → should fail
+            self.assertFalse(result)
+
+    async def test_get_data_rest_api_error_still_aborts(self):
+        """Test that real errors (HTTP 401, network) still abort immediately."""
+        days_list = pd.date_range(start="2024-01-01", periods=3, freq="D", tz="UTC")
+        var_list = ["sensor.test_power"]
+
+        base_url = self.retrieve_hass_conf["hass_url"] + "api/history/period/"
+        urls = [
+            base_url + day.strftime("%Y-%m-%dT%H:%M:%SZ") + "?filter_entity_id=sensor.test_power"
+            for day in days_list
+        ]
+
+        # Day 1: empty (skip), Day 2: auth error (abort)
+        with aioresponses() as mocked:
+            mocked.get(urls[0], payload=[], status=200)
+            mocked.get(urls[1], status=401)
+
             result = await self.rh._get_data_rest_api(days_list, var_list)
             self.assertFalse(result)
 


### PR DESCRIPTION
# DISCMLAIMER: Claude generated code.

Sometimes I run into issues and try to fix them. Might as well PR. Close if you like, merge if you like.

## Problem

When `historic_days_to_retrieve` exceeds the actual data available in Home Assistant (e.g. a sensor was created recently, or the recorder history is shorter than requested), the REST API returns empty JSON (`[]`) for those days.

Previously, `_get_data_rest_api()` treated this as a fatal error and returned `False` immediately. This caused a `TypeError` crash downstream:

```
TypeError: cannot concatenate object of type '<class 'bool'>'; only Series and DataFrame objs are valid
```

This is a common scenario — the EMHASS docs recommend "retrieve as much history data as possible" (e.g. 240 days), but a newly added sensor may only have a few weeks of data.

## Solution

Changed `_fetch_history_data()` and `_process_history_dataframe()` to distinguish between:

- **No data available** (empty JSON / empty DataFrame): Return `None` → skip the day with a warning
- **Real errors** (HTTP 401, network failure, etc.): Return `False` → abort immediately (unchanged)

Updated `_get_data_rest_api()` to:
- Skip days where any sensor returns `None` (no data)
- Still abort on `False` (real errors)
- Log a summary: `Skipped X of Y days due to missing history data`
- If **all** days are empty, still fail with a clear error

## Behavior Change

| Scenario | Before | After |
|---|---|---|
| `historic_days=90`, sensor has 25 days | ❌ Crash (TypeError) | ✅ Uses 25 days, warns about 65 skipped |
| `historic_days=90`, sensor has 0 days | ❌ Error + crash | ❌ Clear error ("No data was retrieved for any day") |
| HTTP 401 on any day | ❌ Abort | ❌ Abort (unchanged) |
| Network error on any day | ❌ Abort | ❌ Abort (unchanged) |

Users can now set `historic_days_to_retrieve` generously without needing to know exactly how far back each sensor's history extends. The retrieval will automatically use whatever data is available.

## Testing

- 3 new unit tests covering: partial data, all-empty, and error-still-aborts scenarios
- Existing `test_get_data_rest_api_errors` still passes (single-day all-empty → fails)
- **Production validated**: Tested with 90-day request against HA instance where sensor only had 25 days of history — successfully skipped 64 days and returned a valid DataFrame

```
WARNING: Skipped 64 of 90 days due to missing history data
Result: True
DataFrame shape: (2492, 3)
Date range: 2026-02-10 to 2026-03-07
```

Full test suite: 22 passed, 0 failed.

## Summary by Sourcery

Handle missing Home Assistant history data more gracefully during REST API retrieval and ensure partial data ranges can still be used without crashing.

Bug Fixes:
- Treat days that return empty JSON or empty dataframes as missing data to skip instead of hard errors that cause downstream type errors.
- Fail with a clear error message when no data is retrieved for any day in the requested range while still aborting on real HTTP or network errors.

Enhancements:
- Log a summary of how many days were skipped due to missing history data when retrieving history via the REST API.

Tests:
- Add tests covering partial history where some days are empty, all-days-empty failure, and scenarios where real errors still abort retrieval.