### PR TITLE
Fix: REST API sends 'Bearer empty' when token not configured in addon…

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -178,13 +178,20 @@ class RetrieveHass:
         # Initialize empty config immediately for safety
         self.ha_config = {}
 
-        # Check if variables are None, empty strings, or explicitly set to "empty"
-        if (
-            not self.hass_url
-            or self.hass_url == "empty"
-            or not self.long_lived_token
-            or self.long_lived_token == "empty"
-        ):
+        # Resolve the token: if empty, fall back to SUPERVISOR_TOKEN env var (injected by HA addon supervisor)
+        token = self.long_lived_token
+        if not token or token == "empty":
+            token = os.getenv("SUPERVISOR_TOKEN", "")
+            if token:
+                self.logger.debug("Using SUPERVISOR_TOKEN from environment for HA config retrieval.")
+
+        # Resolve the URL: if empty, use the default supervisor URL
+        url_to_use = self.hass_url
+        if not url_to_use or url_to_use == "empty":
+            url_to_use = hass_url  # default: http://supervisor/core/api
+
+        # If we still have no token after checking env, skip HA config retrieval
+        if not token:
             self.logger.info(
                 "No Home Assistant URL or Long Lived Token found. Using only local configuration file."
             )
@@ -198,22 +205,22 @@ class RetrieveHass:
 
         # Set up headers
         headers = {
-            "Authorization": header_auth + " " + self.long_lived_token,
+            "Authorization": header_auth + " " + token,
             "content-type": header_accept,
         }
 
         # Construct the URL (incorporating the PR's helpful checks)
         # The Supervisor API sometimes uses a different path structure
-        if self.hass_url == hass_url:
-            url = self.hass_url + "/config"
+        if url_to_use == hass_url:
+            url = url_to_use + "/config"
         else:
             # Helpful check for users who forget the trailing slash
-            if not self.hass_url.endswith("/"):
+            if not url_to_use.endswith("/"):
                 self.logger.warning(
                     "The defined HA URL is missing a trailing slash </>. Appending it, but please fix your configuration."
                 )
-                self.hass_url = self.hass_url + "/"
-            url = self.hass_url + "api/config"
+                url_to_use = url_to_use + "/"
+            url = url_to_use + "api/config"
 
         # Attempt the connection using persistent session for connection reuse
         try:
@@ -430,8 +437,19 @@ class RetrieveHass:
     ) -> None:
         """Internal method to handle REST API data retrieval."""
         self.logger.info("Retrieve hass get data method initiated...")
+        # Resolve the token to use for authentication.
+        # If long_lived_token is empty or not set, fall back to the SUPERVISOR_TOKEN
+        # environment variable injected by Home Assistant when running as an addon.
+        token = self.long_lived_token
+        if not token or token == "empty":
+            token = os.getenv("SUPERVISOR_TOKEN", "")
+            if token:
+                self.logger.debug("Using SUPERVISOR_TOKEN from environment for REST API authentication.")
+            else:
+                self.logger.error("No valid authentication token found. Set a long_lived_token or run as a HA addon.")
+                return False
         headers = {
-            "Authorization": header_auth + " " + self.long_lived_token,
+            "Authorization": header_auth + " " + token,
             "content-type": header_accept,
         }
         var_list = [var for var in var_list if var != ""]


### PR DESCRIPTION
# Fix: REST API authentication fails when token is set to "empty" in addon mode

## Problem

When running EMHASS as a Home Assistant addon with `hass_url` and `long_lived_token` 
both set to `"empty"` (the documented default for addon users), the REST API calls 
fail with a **401 Unauthorized** error.

### Root Cause

In `retrieve_hass.py`, the `get_ha_config()` method correctly checks for `"empty"` 
token and skips HA — but `_get_data_rest_api()` does **not** perform this check. 
It blindly uses `self.long_lived_token` directly in the Authorization header:

```python
# BEFORE (broken) - sends "Bearer empty" as the auth header
headers = {
    "Authorization": header_auth + " " + self.long_lived_token,
    ...
}
```

This results in `Authorization: Bearer empty` being sent to the HA API, causing a 
401 Unauthorized rejection every time.

Additionally, `get_ha_config()` would skip HA entirely when token is `"empty"`, 
rather than falling back to the `SUPERVISOR_TOKEN` environment variable that 
Home Assistant injects automatically into addon containers.

## Fix

Both `get_ha_config()` and `_get_data_rest_api()` now:

1. Check if `long_lived_token` is `None`, empty, or `"empty"`
2. If so, fall back to the `SUPERVISOR_TOKEN` environment variable 
   (automatically injected by HA supervisor into addon containers)
3. Only skip HA entirely if no valid token can be found from either source

```python
# AFTER (fixed) - correctly uses SUPERVISOR_TOKEN when long_lived_token is "empty"
token = self.long_lived_token
if not token or token == "empty":
    token = os.getenv("SUPERVISOR_TOKEN", "")
    if token:
        self.logger.debug("Using SUPERVISOR_TOKEN from environment for REST API authentication.")
    else:
        self.logger.error("No valid authentication token found.")
        return False
headers = {
    "Authorization": header_auth + " " + token,
    ...
}
```

## Impact

- Fixes addon users who follow the documented setup of leaving `hass_url` and 
  `long_lived_token` as `"empty"` — this is the default recommended configuration
- No impact on users who provide explicit tokens (those still work as before)
- No impact on Docker standalone users (SUPERVISOR_TOKEN won't exist, so explicit 
  token is still required)

## Testing

Tested on Home Assistant OS 2026.3.1 with EMHASS addon v0.17.0 running as a 
supervised addon with both `hass_url` and `long_lived_token` left at default `"empty"`.

## Summary by Sourcery

Handle Home Assistant addon authentication correctly when long-lived tokens are unset or configured as "empty" by falling back to supervisor-provided credentials instead of sending invalid REST headers.

Bug Fixes:
- Prevent REST API requests from using an invalid "Bearer empty" authorization header when no explicit long-lived token is configured.
- Allow Home Assistant config retrieval and REST data fetching to fall back to the SUPERVISOR_TOKEN environment variable when the long-lived token or hass_url are unset or set to "empty".
- Ensure HA config retrieval is skipped only when no usable authentication token can be resolved from either configuration or environment.