### PR TITLE
fix: support out-of-band initial SOC recovery in naive MPC

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -1103,8 +1103,9 @@ class Optimization:
         soc_high_recovered = self.vars["soc_high_recovered"]
         min_energy = self.plant_conf["battery_minimum_state_of_charge"] * cap
         max_energy = self.plant_conf["battery_maximum_state_of_charge"] * cap
-        recovery_big_m = cap
         recovery_margin = max(cap * 1e-6, 1e-3)
+        recovery_big_m_low = cap - min_energy + recovery_margin
+        recovery_big_m_high = max_energy + recovery_margin
 
         # Grid Interaction Constraints
 
@@ -1162,8 +1163,12 @@ class Optimization:
         # Min/Max SOC bounds with a single recovery transition.
         # Before recovery the trajectory stays on the initial out-of-band side.
         # After recovery the usual hard SOC limits apply and cannot be violated again.
-        constraints.append(current_stored_energy >= min_energy - self.param_soc_low_gap * (1 - soc_low_recovered))
-        constraints.append(current_stored_energy <= max_energy + self.param_soc_high_gap * (1 - soc_high_recovered))
+        constraints.append(
+            current_stored_energy >= min_energy - self.param_soc_low_gap * (1 - soc_low_recovered)
+        )
+        constraints.append(
+            current_stored_energy <= max_energy + self.param_soc_high_gap * (1 - soc_high_recovered)
+        )
         constraints.append(soc_low_recovered[1:] >= soc_low_recovered[:-1])
         constraints.append(soc_high_recovered[1:] >= soc_high_recovered[:-1])
         constraints.append(soc_low_recovered <= self.param_soc_low_required)
@@ -1173,28 +1178,26 @@ class Optimization:
         constraints.append(
             current_stored_energy[1:]
             >= current_stored_energy[:-1]
-            - recovery_big_m
-            * (soc_low_recovered[:-1] + (1 - self.param_soc_low_required))
+            - recovery_big_m_low * (soc_low_recovered[:-1] + (1 - self.param_soc_low_required))
         )
         constraints.append(
             current_stored_energy[1:]
             <= current_stored_energy[:-1]
-            + recovery_big_m
-            * (soc_high_recovered[:-1] + (1 - self.param_soc_high_required))
+            + recovery_big_m_high * (soc_high_recovered[:-1] + (1 - self.param_soc_high_required))
         )
         constraints.append(
             current_stored_energy
             <= min_energy
             - recovery_margin
-            + recovery_big_m * soc_low_recovered
-            + recovery_big_m * (1 - self.param_soc_low_required)
+            + recovery_big_m_low * soc_low_recovered
+            + recovery_big_m_low * (1 - self.param_soc_low_required)
         )
         constraints.append(
             current_stored_energy
             >= max_energy
             + recovery_margin
-            - recovery_big_m * soc_high_recovered
-            - recovery_big_m * (1 - self.param_soc_high_required)
+            - recovery_big_m_high * soc_high_recovered
+            - recovery_big_m_high * (1 - self.param_soc_high_required)
         )
 
         # Final SOC Constraint

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -1171,6 +1171,18 @@ class Optimization:
         constraints.append(soc_low_recovered[-1] == self.param_soc_low_required)
         constraints.append(soc_high_recovered[-1] == self.param_soc_high_required)
         constraints.append(
+            current_stored_energy[1:]
+            >= current_stored_energy[:-1]
+            - recovery_big_m
+            * (soc_low_recovered[:-1] + (1 - self.param_soc_low_required))
+        )
+        constraints.append(
+            current_stored_energy[1:]
+            <= current_stored_energy[:-1]
+            + recovery_big_m
+            * (soc_high_recovered[:-1] + (1 - self.param_soc_high_required))
+        )
+        constraints.append(
             current_stored_energy
             <= min_energy
             - recovery_margin

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -140,6 +140,9 @@ class Optimization:
         self.param_soc_init = cp.Parameter(nonneg=True, name="soc_init")
         self.param_soc_final = cp.Parameter(nonneg=True, name="soc_final")
 
+        # SOC recovery parameters
+        self._init_soc_recovery_params()
+
         # Initialize deferrable load parameters (window masks and energy constraints)
         self._init_deferrable_load_params()
 
@@ -148,6 +151,17 @@ class Optimization:
 
         # Note: The self.prob object will be constructed in a subsequent step
         self.prob = None
+
+    def _init_soc_recovery_params(self) -> None:
+        """Initialize CVXPY parameters used for out-of-band SOC recovery."""
+        self.param_soc_low_gap = cp.Parameter(nonneg=True, name="soc_low_gap")
+        self.param_soc_high_gap = cp.Parameter(nonneg=True, name="soc_high_gap")
+        self.param_soc_low_required = cp.Parameter(nonneg=True, name="soc_low_required")
+        self.param_soc_high_required = cp.Parameter(nonneg=True, name="soc_high_required")
+        self.param_soc_low_gap.value = 0.0
+        self.param_soc_high_gap.value = 0.0
+        self.param_soc_low_required.value = 0.0
+        self.param_soc_high_required.value = 0.0
 
     def _init_deferrable_load_params(self) -> None:
         """
@@ -755,12 +769,20 @@ class Optimization:
             constraints.append(
                 vars_dict["p_sto_neg"] >= -np.abs(self.plant_conf["battery_charge_power_max"])
             )
+            vars_dict["soc_low_recovered"] = cp.Variable(n, boolean=True, name="soc_low_recovered")
+            vars_dict["soc_high_recovered"] = cp.Variable(
+                n, boolean=True, name="soc_high_recovered"
+            )
         else:
             # Create dummy zero variables to preserve logic structure without conditional checks everywhere
             vars_dict["p_sto_pos"] = cp.Variable(n, name="p_sto_pos_dummy")
             vars_dict["p_sto_neg"] = cp.Variable(n, name="p_sto_neg_dummy")
             constraints.append(vars_dict["p_sto_pos"] == 0)
             constraints.append(vars_dict["p_sto_neg"] == 0)
+            vars_dict["soc_low_recovered"] = cp.Variable(n, name="soc_low_recovered_dummy")
+            vars_dict["soc_high_recovered"] = cp.Variable(n, name="soc_high_recovered_dummy")
+            constraints.append(vars_dict["soc_low_recovered"] == 0)
+            constraints.append(vars_dict["soc_high_recovered"] == 0)
 
         # Self-consumption variable
         if self.costfun == "self-consumption":
@@ -1077,6 +1099,12 @@ class Optimization:
         eff_chg = self.plant_conf["battery_charge_efficiency"]
         max_dis = self.plant_conf["battery_discharge_power_max"]
         max_chg = self.plant_conf["battery_charge_power_max"]  # This is usually positive in config
+        soc_low_recovered = self.vars["soc_low_recovered"]
+        soc_high_recovered = self.vars["soc_high_recovered"]
+        min_energy = self.plant_conf["battery_minimum_state_of_charge"] * cap
+        max_energy = self.plant_conf["battery_maximum_state_of_charge"] * cap
+        recovery_big_m = cap
+        recovery_margin = max(cap * 1e-6, 1e-3)
 
         # Grid Interaction Constraints
 
@@ -1131,12 +1159,30 @@ class Optimization:
         # (Subtracting because positive flow is Discharge/Depletion)
         current_stored_energy = (soc_init * cap) - cumulative_energy
 
-        # Min/Max SOC Bounds for all t
+        # Min/Max SOC bounds with a single recovery transition.
+        # Before recovery the trajectory stays on the initial out-of-band side.
+        # After recovery the usual hard SOC limits apply and cannot be violated again.
+        constraints.append(current_stored_energy >= min_energy - self.param_soc_low_gap * (1 - soc_low_recovered))
+        constraints.append(current_stored_energy <= max_energy + self.param_soc_high_gap * (1 - soc_high_recovered))
+        constraints.append(soc_low_recovered[1:] >= soc_low_recovered[:-1])
+        constraints.append(soc_high_recovered[1:] >= soc_high_recovered[:-1])
+        constraints.append(soc_low_recovered <= self.param_soc_low_required)
+        constraints.append(soc_high_recovered <= self.param_soc_high_required)
+        constraints.append(soc_low_recovered[-1] == self.param_soc_low_required)
+        constraints.append(soc_high_recovered[-1] == self.param_soc_high_required)
         constraints.append(
-            current_stored_energy <= self.plant_conf["battery_maximum_state_of_charge"] * cap
+            current_stored_energy
+            <= min_energy
+            - recovery_margin
+            + recovery_big_m * soc_low_recovered
+            + recovery_big_m * (1 - self.param_soc_low_required)
         )
         constraints.append(
-            current_stored_energy >= self.plant_conf["battery_minimum_state_of_charge"] * cap
+            current_stored_energy
+            >= max_energy
+            + recovery_margin
+            - recovery_big_m * soc_high_recovered
+            - recovery_big_m * (1 - self.param_soc_high_required)
         )
 
         # Final SOC Constraint
@@ -2135,6 +2181,9 @@ class Optimization:
             self.param_load_cost = cp.Parameter(current_n, name="load_cost")
             self.param_prod_price = cp.Parameter(current_n, name="prod_price")
 
+            # Re-initialize SOC recovery parameters with the new horizon
+            self._init_soc_recovery_params()
+
             # Re-initialize deferrable load parameters (window masks and energy constraints)
             self._init_deferrable_load_params()
 
@@ -2205,6 +2254,20 @@ class Optimization:
         if self.optim_conf["set_use_battery"]:
             self.param_soc_init.value = soc_init
             self.param_soc_final.value = soc_final
+            low_gap_wh = max(
+                0.0,
+                (self.plant_conf["battery_minimum_state_of_charge"] - soc_init)
+                * self.plant_conf["battery_nominal_energy_capacity"],
+            )
+            high_gap_wh = max(
+                0.0,
+                (soc_init - self.plant_conf["battery_maximum_state_of_charge"])
+                * self.plant_conf["battery_nominal_energy_capacity"],
+            )
+            self.param_soc_low_gap.value = low_gap_wh
+            self.param_soc_high_gap.value = high_gap_wh
+            self.param_soc_low_required.value = 1.0 if low_gap_wh > 0 else 0.0
+            self.param_soc_high_required.value = 1.0 if high_gap_wh > 0 else 0.0
 
         # Update Window Mask Parameters for Deferrable Loads
         # This allows warm-starting even when time windows change

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -934,14 +934,12 @@ async def treat_runtimeparams(
                 soc_init = runtimeparams["soc_init"]
             if soc_init < params["plant_conf"]["battery_minimum_state_of_charge"]:
                 logger.warning(
-                    f"Passed soc_init={soc_init} is lower than soc_min={params['plant_conf']['battery_minimum_state_of_charge']}, setting soc_init=soc_min"
+                    f"Passed soc_init={soc_init} is lower than soc_min={params['plant_conf']['battery_minimum_state_of_charge']}, keeping real initial SOC for optimization recovery"
                 )
-                soc_init = params["plant_conf"]["battery_minimum_state_of_charge"]
             if soc_init > params["plant_conf"]["battery_maximum_state_of_charge"]:
                 logger.warning(
-                    f"Passed soc_init={soc_init} is greater than soc_max={params['plant_conf']['battery_maximum_state_of_charge']}, setting soc_init=soc_max"
+                    f"Passed soc_init={soc_init} is greater than soc_max={params['plant_conf']['battery_maximum_state_of_charge']}, keeping real initial SOC for optimization recovery"
                 )
-                soc_init = params["plant_conf"]["battery_maximum_state_of_charge"]
             params["passed_data"]["soc_init"] = soc_init
             if "soc_final" not in runtimeparams.keys():
                 soc_final = params["plant_conf"]["battery_target_state_of_charge"]

--- a/tests/test_soc_recovery_prototype.py
+++ b/tests/test_soc_recovery_prototype.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+
+import logging
+import pathlib
+
+import pandas as pd
+
+from emhass.optimization import Optimization
+
+
+def build_optimization() -> Optimization:
+    logger = logging.getLogger("soc_recovery_test")
+    logger.handlers = []
+    logger.addHandler(logging.NullHandler())
+
+    retrieve_hass_conf = {
+        "optimization_time_step": pd.to_timedelta(30, "minutes"),
+        "time_zone": "Europe/Tallinn",
+        "sensor_power_photovoltaics": "pv",
+        "sensor_power_load_no_var_loads": "load",
+    }
+    optim_conf = {
+        "delta_forecast_daily": pd.Timedelta(hours=5),
+        "num_threads": 0,
+        "set_use_battery": True,
+        "set_use_pv": True,
+        "set_total_pv_sell": False,
+        "set_nocharge_from_grid": False,
+        "set_nodischarge_to_grid": False,
+        "set_battery_dynamic": False,
+        "battery_dynamic_max": 0.9,
+        "battery_dynamic_min": -0.9,
+        "weight_battery_discharge": 0.0,
+        "weight_battery_charge": 0.0,
+        "number_of_deferrable_loads": 0,
+        "nominal_power_of_deferrable_loads": [],
+        "treat_deferrable_load_as_semi_cont": [],
+        "set_deferrable_load_single_constant": [],
+        "set_deferrable_startup_penalty": [],
+        "operating_hours_of_each_deferrable_load": [],
+        "start_timesteps_of_each_deferrable_load": [],
+        "end_timesteps_of_each_deferrable_load": [],
+        "lp_solver_timeout": 45,
+        "lp_solver_mip_rel_gap": 0,
+    }
+    plant_conf = {
+        "inverter_is_hybrid": False,
+        "compute_curtailment": False,
+        "maximum_power_from_grid": 50000,
+        "maximum_power_to_grid": 50000,
+        "battery_discharge_power_max": 5000,
+        "battery_charge_power_max": 5000,
+        "battery_minimum_state_of_charge": 0.3,
+        "battery_maximum_state_of_charge": 0.8,
+        "battery_target_state_of_charge": 0.6,
+        "battery_nominal_energy_capacity": 10000,
+        "battery_discharge_efficiency": 1.0,
+        "battery_charge_efficiency": 1.0,
+        "battery_stress_cost": 0.0,
+        "battery_stress_segments": 10,
+    }
+    emhass_conf = {
+        "root_path": pathlib.Path("/Users/martinarva/dev/EMHASS_DEV/src/emhass"),
+        "data_path": pathlib.Path("/Users/martinarva/dev/EMHASS_DEV/data"),
+    }
+    return Optimization(
+        retrieve_hass_conf,
+        optim_conf,
+        plant_conf,
+        "unit_load_cost",
+        "unit_prod_price",
+        "profit",
+        emhass_conf,
+        logger,
+        opt_time_delta=5,
+    )
+
+
+def test_low_soc_recovery_waits_for_pv_when_grid_is_expensive():
+    opt = build_optimization()
+    index = pd.date_range("2026-01-01", periods=10, freq="30min", tz="Europe/Tallinn")
+
+    p_pv = pd.Series([0, 0, 0, 0, 0, 6000, 6000, 0, 0, 0], index=index)
+    p_load = pd.Series([0] * 10, index=index)
+    df_input = pd.DataFrame(index=index)
+    df_input["unit_load_cost"] = [0.40] * 10
+    df_input["unit_prod_price"] = [0.0] * 10
+
+    opt_res = opt.perform_naive_mpc_optim(
+        df_input,
+        p_pv,
+        p_load,
+        10,
+        soc_init=0.1,
+        soc_final=0.4,
+        def_total_hours=[],
+        def_total_timestep=[],
+        def_start_timestep=[],
+        def_end_timestep=[],
+    )
+
+    assert opt.optim_status == "Optimal"
+    assert (opt_res["P_batt"].iloc[:5] > -100).all(), opt_res["P_batt"].tolist()
+    assert opt_res["P_batt"].iloc[5:7].min() < -1000
+    assert abs(opt_res["SOC_opt"].iloc[-1] - 0.4) < 1e-3
+
+
+def test_high_soc_recovery_waits_for_load_instead_of_immediate_export():
+    opt = build_optimization()
+    index = pd.date_range("2026-01-01", periods=10, freq="30min", tz="Europe/Tallinn")
+
+    p_pv = pd.Series([0] * 10, index=index)
+    p_load = pd.Series([0, 0, 0, 0, 5000, 5000, 0, 0, 0, 0], index=index)
+    df_input = pd.DataFrame(index=index)
+    df_input["unit_load_cost"] = [0.40] * 10
+    df_input["unit_prod_price"] = [0.0] * 10
+
+    opt_res = opt.perform_naive_mpc_optim(
+        df_input,
+        p_pv,
+        p_load,
+        10,
+        soc_init=0.9,
+        soc_final=0.6,
+        def_total_hours=[],
+        def_total_timestep=[],
+        def_start_timestep=[],
+        def_end_timestep=[],
+    )
+
+    assert opt.optim_status == "Optimal"
+    assert (opt_res["P_batt"].iloc[:4] < 100).all(), opt_res["P_batt"].tolist()
+    assert opt_res["P_batt"].iloc[4:6].max() > 1000
+    assert abs(opt_res["SOC_opt"].iloc[-1] - 0.6) < 1e-3
+
+
+def test_low_soc_stays_above_min_once_back_inside_band():
+    opt = build_optimization()
+    index = pd.date_range("2026-01-01", periods=14, freq="30min", tz="Europe/Tallinn")
+
+    p_pv = pd.Series([0, 0, 0, 0, 0, 6000, 6000, 0, 0, 0, 0, 0, 6000, 6000], index=index)
+    p_load = pd.Series([0, 0, 0, 0, 0, 0, 0, 5000, 5000, 5000, 0, 0, 0, 0], index=index)
+    df_input = pd.DataFrame(index=index)
+    df_input["unit_load_cost"] = [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 5.0, 5.0, 5.0, 0.2, 0.2, 0.2, 0.2]
+    df_input["unit_prod_price"] = [0.0] * 14
+
+    opt_res = opt.perform_naive_mpc_optim(
+        df_input,
+        p_pv,
+        p_load,
+        14,
+        soc_init=0.1,
+        soc_final=0.3,
+        def_total_hours=[],
+        def_total_timestep=[],
+        def_start_timestep=[],
+        def_end_timestep=[],
+    )
+
+    first_inside = opt_res.index[opt_res["SOC_opt"] > 0.30001][0]
+    assert opt.optim_status == "Optimal"
+    assert opt_res.loc[first_inside:, "SOC_opt"].min() >= 0.3 - 1e-4
+
+
+def test_high_soc_stays_below_max_once_back_inside_band():
+    opt = build_optimization()
+    index = pd.date_range("2026-01-01", periods=14, freq="30min", tz="Europe/Tallinn")
+
+    p_pv = pd.Series([0, 0, 0, 0, 0, 6000, 6000, 0, 0, 0, 0, 0, 0, 0], index=index)
+    p_load = pd.Series([2000, 0, 0, 0, 0, 0, 0, 5000, 5000, 0, 0, 0, 0, 0], index=index)
+    df_input = pd.DataFrame(index=index)
+    df_input["unit_load_cost"] = [0.2] * 14
+    df_input["unit_prod_price"] = [0.0] * 14
+
+    opt_res = opt.perform_naive_mpc_optim(
+        df_input,
+        p_pv,
+        p_load,
+        14,
+        soc_init=0.9,
+        soc_final=0.6,
+        def_total_hours=[],
+        def_total_timestep=[],
+        def_start_timestep=[],
+        def_end_timestep=[],
+    )
+
+    first_inside = opt_res.index[opt_res["SOC_opt"] < 0.79999][0]
+    assert opt.optim_status == "Optimal"
+    assert opt_res.loc[first_inside:, "SOC_opt"].max() <= 0.8 + 1e-4

--- a/tests/test_soc_recovery_prototype.py
+++ b/tests/test_soc_recovery_prototype.py
@@ -8,7 +8,10 @@ import pandas as pd
 from emhass.optimization import Optimization
 
 
-def build_optimization() -> Optimization:
+TEST_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def build_optimization(optim_overrides=None, plant_overrides=None) -> Optimization:
     logger = logging.getLogger("soc_recovery_test")
     logger.handlers = []
     logger.addHandler(logging.NullHandler())
@@ -43,6 +46,9 @@ def build_optimization() -> Optimization:
         "lp_solver_timeout": 45,
         "lp_solver_mip_rel_gap": 0,
     }
+    if optim_overrides:
+        optim_conf.update(optim_overrides)
+
     plant_conf = {
         "inverter_is_hybrid": False,
         "compute_curtailment": False,
@@ -59,9 +65,12 @@ def build_optimization() -> Optimization:
         "battery_stress_cost": 0.0,
         "battery_stress_segments": 10,
     }
+    if plant_overrides:
+        plant_conf.update(plant_overrides)
+
     emhass_conf = {
-        "root_path": pathlib.Path("/Users/martinarva/dev/EMHASS_DEV/src/emhass"),
-        "data_path": pathlib.Path("/Users/martinarva/dev/EMHASS_DEV/data"),
+        "root_path": TEST_ROOT / "src" / "emhass",
+        "data_path": TEST_ROOT / "data",
     }
     return Optimization(
         retrieve_hass_conf,
@@ -192,3 +201,41 @@ def test_high_soc_stays_below_max_once_back_inside_band():
     assert opt.optim_status == "Optimal"
     assert (recovery_prefix.diff().fillna(0) <= 1e-4).all(), recovery_prefix.tolist()
     assert opt_res.loc[first_inside:, "SOC_opt"].max() <= 0.8 + 1e-4
+
+
+def test_low_soc_recovery_with_non_ideal_efficiency_remains_monotonic():
+    opt = build_optimization(
+        plant_overrides={
+            "battery_discharge_efficiency": 0.92,
+            "battery_charge_efficiency": 0.88,
+            "battery_charge_power_max": 4000,
+            "battery_discharge_power_max": 4000,
+        }
+    )
+    index = pd.date_range("2026-01-01", periods=16, freq="30min", tz="Europe/Tallinn")
+
+    p_pv = pd.Series([0, 0, 0, 0, 0, 0, 4500, 4500, 4500, 4500, 0, 0, 0, 0, 0, 0], index=index)
+    p_load = pd.Series([0] * 16, index=index)
+    df_input = pd.DataFrame(index=index)
+    df_input["unit_load_cost"] = [0.35] * 16
+    df_input["unit_prod_price"] = [0.0] * 16
+
+    opt_res = opt.perform_naive_mpc_optim(
+        df_input,
+        p_pv,
+        p_load,
+        16,
+        soc_init=0.1,
+        soc_final=0.4,
+        def_total_hours=[],
+        def_total_timestep=[],
+        def_start_timestep=[],
+        def_end_timestep=[],
+    )
+
+    first_inside = opt_res.index[opt_res["SOC_opt"] > 0.30001][0]
+    recovery_prefix = opt_res.loc[:first_inside, "SOC_opt"]
+    assert opt.optim_status == "Optimal"
+    assert (recovery_prefix.diff().fillna(0) >= -1e-4).all(), recovery_prefix.tolist()
+    assert opt_res.loc[first_inside:, "SOC_opt"].min() >= 0.3 - 1e-4
+    assert abs(opt_res["SOC_opt"].iloc[-1] - 0.4) < 1e-3

--- a/tests/test_soc_recovery_prototype.py
+++ b/tests/test_soc_recovery_prototype.py
@@ -150,7 +150,22 @@ def test_low_soc_stays_above_min_once_back_inside_band():
     p_pv = pd.Series([0, 0, 0, 0, 0, 6000, 6000, 0, 0, 0, 0, 0, 6000, 6000], index=index)
     p_load = pd.Series([0, 0, 0, 0, 0, 0, 0, 5000, 5000, 5000, 0, 0, 0, 0], index=index)
     df_input = pd.DataFrame(index=index)
-    df_input["unit_load_cost"] = [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 5.0, 5.0, 5.0, 0.2, 0.2, 0.2, 0.2]
+    df_input["unit_load_cost"] = [
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        5.0,
+        5.0,
+        5.0,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+    ]
     df_input["unit_prod_price"] = [0.0] * 14
 
     opt_res = opt.perform_naive_mpc_optim(

--- a/tests/test_soc_recovery_prototype.py
+++ b/tests/test_soc_recovery_prototype.py
@@ -158,7 +158,9 @@ def test_low_soc_stays_above_min_once_back_inside_band():
     )
 
     first_inside = opt_res.index[opt_res["SOC_opt"] > 0.30001][0]
+    recovery_prefix = opt_res.loc[:first_inside, "SOC_opt"]
     assert opt.optim_status == "Optimal"
+    assert (recovery_prefix.diff().fillna(0) >= -1e-4).all(), recovery_prefix.tolist()
     assert opt_res.loc[first_inside:, "SOC_opt"].min() >= 0.3 - 1e-4
 
 
@@ -186,5 +188,7 @@ def test_high_soc_stays_below_max_once_back_inside_band():
     )
 
     first_inside = opt_res.index[opt_res["SOC_opt"] < 0.79999][0]
+    recovery_prefix = opt_res.loc[:first_inside, "SOC_opt"]
     assert opt.optim_status == "Optimal"
+    assert (recovery_prefix.diff().fillna(0) <= 1e-4).all(), recovery_prefix.tolist()
     assert opt_res.loc[first_inside:, "SOC_opt"].max() <= 0.8 + 1e-4

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1252,6 +1252,34 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(params_out["passed_data"]["soc_init"], 0.05)
         self.assertEqual(params_out["passed_data"]["soc_final"], 0.6)
 
+    async def test_treat_runtimeparams_preserves_high_out_of_band_soc_init(self):
+        """Naive MPC should preserve a high initial SOC that starts above soc_max."""
+        params = await TestUtils.get_test_params()
+        params_json = orjson.dumps(params).decode("utf-8")
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+
+        runtimeparams = {
+            "prediction_horizon": 10,
+            "soc_init": 0.95,
+            "soc_final": 0.6,
+        }
+        runtimeparams_json = orjson.dumps(runtimeparams).decode("utf-8")
+
+        params_out, _, _, _ = await treat_runtimeparams(
+            runtimeparams_json,
+            params_json,
+            retrieve_hass_conf,
+            optim_conf,
+            plant_conf,
+            "naive-mpc-optim",
+            logger,
+            emhass_conf,
+        )
+        params_out = orjson.loads(params_out)
+
+        self.assertEqual(params_out["passed_data"]["soc_init"], 0.95)
+        self.assertEqual(params_out["passed_data"]["soc_final"], 0.6)
+
     def test_param_to_config(self):
         """Test converting built params back to a flat config dictionary and masking secrets."""
         # Create a mock parameter dictionary with the required categories

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1224,6 +1224,34 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
         # Verify it fell back to default or kept original value (depending on logic, usually implies no change)
         self.assertEqual(plant_conf_out["maximum_power_from_grid"], default_from_grid)
 
+    async def test_treat_runtimeparams_preserves_out_of_band_soc_init(self):
+        """Naive MPC should preserve the real initial SOC even if it is out of bounds."""
+        params = await TestUtils.get_test_params()
+        params_json = orjson.dumps(params).decode("utf-8")
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+
+        runtimeparams = {
+            "prediction_horizon": 10,
+            "soc_init": 0.05,
+            "soc_final": 0.6,
+        }
+        runtimeparams_json = orjson.dumps(runtimeparams).decode("utf-8")
+
+        params_out, _, _, _ = await treat_runtimeparams(
+            runtimeparams_json,
+            params_json,
+            retrieve_hass_conf,
+            optim_conf,
+            plant_conf,
+            "naive-mpc-optim",
+            logger,
+            emhass_conf,
+        )
+        params_out = orjson.loads(params_out)
+
+        self.assertEqual(params_out["passed_data"]["soc_init"], 0.05)
+        self.assertEqual(params_out["passed_data"]["soc_final"], 0.6)
+
     def test_param_to_config(self):
         """Test converting built params back to a flat config dictionary and masking secrets."""
         # Create a mock parameter dictionary with the required categories


### PR DESCRIPTION
## Summary
- preserve the real `soc_init` even when it starts outside the configured SOC limits
- allow temporary out-of-band initial SOC in naive MPC and enforce recovery back into the valid SOC band
- keep recovery monotonic before first re-entry and prevent going out of bounds again within the same optimization horizon
- add targeted regression tests for low/high SOC recovery and runtime parameter handling

## Motivation
This addresses the feature request and discussion here:
- https://github.com/davidusb-geek/emhass/issues/585

The main goal is to let EMHASS work with the real battery SOC even when the current SOC is temporarily below `battery_minimum_state_of_charge` or above `battery_maximum_state_of_charge`, instead of clipping `soc_init` before optimization.

## What Changed
- stop clamping `soc_init` to `soc_min/soc_max` in runtime parameter handling
- add recovery-aware SOC constraints in the optimizer
- require SOC to move only toward the valid band until first re-entry
- once SOC is back inside the configured band, enforce the normal hard SOC bounds again
- add regression tests for:
  - preserving out-of-band `soc_init`
  - low-SOC recovery
  - high-SOC recovery
  - monotonic recovery before re-entry
  - non-ideal battery efficiency case

## Testing
- ran targeted SOC recovery tests locally
- tested against a real Home Assistant setup with real runtime payloads
- verified both:
  - `soc_init > soc_max`
  - `soc_init < soc_min`

## Summary by Sourcery

Support temporary out-of-band initial battery SOC in naive MPC while enforcing controlled recovery back into configured SOC limits.

Bug Fixes:
- Preserve out-of-band initial SOC from runtime parameters instead of clamping it to configured minimum/maximum limits.

Enhancements:
- Add recovery-aware SOC constraints and state tracking to ensure monotonic SOC movement back into the valid band and prevent further violations within the same optimization horizon.

Tests:
- Add regression and integration-style tests covering low/high SOC recovery, monotonic behavior with and without non-ideal efficiencies, and preservation of out-of-band soc_init in runtime parameter handling.