### PR TITLE
fix: resolve UnboundLocalError for inv_stress_conf on infeasible retry

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -2389,16 +2389,17 @@ class Optimization:
 
         # Update def_current_state parameters for deferrable loads
         self._update_def_current_state_params(num_deferrable_loads)
+        # Initialize stress config variables (needed by retry path even when
+        # self.prob is cached from a previous call, see #770)
+        inv_stress_conf = None
+        batt_stress_conf = None
+
         # Build Problem (Lazy Construction)
         if self.prob is None:
             self.logger.info("Building CVXPY problem structure...")
 
             # Start with bound constraints
             constraints = self.constraints[:]
-
-            # Setup Stress Costs
-            inv_stress_conf = None
-            batt_stress_conf = None
 
             if self.optim_conf["set_use_battery"]:
                 p_batt_max = max(


### PR DESCRIPTION
## Summary

Fixes #770.

`inv_stress_conf` and `batt_stress_conf` are initialized inside the lazy construction guard (`if self.prob is None:`), but the infeasible-retry path (line ~2490) references them **outside** this block. In MPC mode, when `self.prob` is cached from a previous call and the optimization becomes infeasible, the retry path accesses these never-assigned local variables:

```
UnboundLocalError: cannot access local variable 'inv_stress_conf'
where it is not associated with a value
```

### Root cause (code trace, v0.17.1)

| Line | Code | Scope |
|------|------|-------|
| 2315 | `if self.prob is None:` | Lazy construction guard |
| 2322 | `inv_stress_conf = None` | **Only** inside guard |
| 2323 | `batt_stress_conf = None` | **Only** inside guard |
| 2386 | `self.prob = cp.Problem(...)` | Problem gets cached |
| 2490 | `if inv_stress_conf:` | **Outside** guard (retry path) |
| 2519 | `_build_objective_function(batt_stress_conf, inv_stress_conf)` | **Outside** guard |

**MPC call 1** → `self.prob is None` → guard block runs → variables defined → works fine.
**MPC call 2** (same `prediction_horizon`) → `self.prob is not None` → guard block **skipped** → variables never assigned → infeasible → retry → 💥 `UnboundLocalError`

### Fix

Move both initializations before the guard block so they are always defined, regardless of whether the problem is rebuilt or reused from cache.

### Disclosure

This is my first contribution to this codebase. I'm running EMHASS with a Tecalor THZ 5.5 eco heat pump using the thermal battery model in MPC mode. All data gets provided to EMHASS using node-red as I'm not running Homeassistant.
I used Claude Code to help trace through the code. I've reviewed the fix myself and it looks correct to me — the moved lines are simple `None` initializations with no side effects, but I'd appreciate a maintainer double-checking this before merge.

### Personal

Finally, I’d just like to say a big thank you for this project! It’s taken me many hours (and days), but it feels great to be as sustainable as possible and save money at the same time. That’s what a true smart home is all about.


## Summary by Sourcery

Bug Fixes:
- Prevent UnboundLocalError when accessing inv_stress_conf and batt_stress_conf in the infeasible retry path by initializing them prior to the lazy construction guard.