### PR TITLE
fix: clean session closure to prevent aiohttp timeouts

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -146,7 +146,8 @@ class RetrieveHass:
         """
         async with self._session_lock:
             if self._session is None or self._session.closed:
-                self._session = aiohttp.ClientSession()
+                connector = aiohttp.TCPConnector(force_close=True)
+                self._session = aiohttp.ClientSession(connector=connector)
             return self._session
 
     async def close(self) -> None:
@@ -1297,6 +1298,9 @@ class RetrieveHass:
                     data=orjson.dumps(data).decode("utf-8"),
                     ssl=self.ssl_verify,
                 ) as response:
+                    # Read response body to explicitly release connection immediately
+                    await response.read()
+
                     # Store response data since we need to access it after the context manager
                     response_ok = response.ok
                     response_status_code = response.status


### PR DESCRIPTION
## Description
This PR fixes OS-level socket errors (e.g., `Operation not permitted`) and timeouts that occur during the `continual_publish` loop. 

Keeping inactive TCP sessions open is bad practice, especially during the 60-second `asyncio.sleep` between publish batches. Stringent network environments (like Kubernetes with Cilium, proxies, or hardware firewalls) often drop idle TCP connections after 60 seconds. When the `aiohttp` connection pool attempts to reuse the dropped socket, the application crashes.

## Changes
* Added `aiohttp.TCPConnector(force_close=True)` to the publishing session pool. This ensures connections are explicitly closed after each payload rather than being held open during long idle sleep periods.
* Added `await response.read()` inside the POST context manager to ensure the payload is fully consumed, cleanly releasing the underlying socket back to the async event loop to prevent resource leaks.

## Summary by Sourcery

Ensure HTTP client sessions close connections cleanly to avoid timeouts and socket errors during long-running publish loops.

Bug Fixes:
- Force aiohttp HTTP connections to close after each request to prevent reuse of dropped idle sockets.
- Fully consume HTTP responses before exiting the context manager to reliably release underlying connections.