### PR TITLE
fix: add state_class to published sensors and prevent ML crash on short history

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -620,7 +620,8 @@ async def adjust_pv_forecast(
             test_df_literal,
         )
         if not success:
-            return False
+            logger.warning("Could not train adjusted PV model, falling back to unadjusted PV forecast.")
+            return p_pv_forecast
     else:
         # Load existing model
         logger.info("Loading existing adjusted PV model from file")
@@ -644,15 +645,15 @@ async def adjust_pv_forecast(
                 test_df_literal,
             )
             if not success:
-                logger.error("Failed to retrieve data for model re-fit after load error")
-                return False
+                logger.error("Failed to retrieve data for model re-fit after load error. Falling back to unadjusted forecast.")
+                return p_pv_forecast
             logger.info("Successfully re-fitted model after load failure")
         except Exception as e:
             logger.error(
                 f"Unexpected error loading adjusted PV model: {type(e).__name__}: {str(e)}"
             )
-            logger.error("Cannot recover from this error")
-            return False
+            logger.error("Cannot recover from this error. Falling back to unadjusted forecast.")
+            return p_pv_forecast
     # Call the predict method
     p_pv_forecast = p_pv_forecast.rename("forecast").to_frame()
     p_pv_forecast = fcst.adjust_pv_forecast_predict(forecasted_pv=p_pv_forecast)

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -556,9 +556,18 @@ async def _retrieve_and_fit_pv_model(
         return False
     # Call data preparation method
     fcst.adjust_pv_forecast_data_prep(df_input_data)
+    
+    n_splits = 5
+    if len(fcst.x_adjust_pv) <= n_splits:
+        fcst.logger.warning(
+            f"Not enough data to fit the PV model (found {len(fcst.x_adjust_pv)} samples, "
+            f"require > {n_splits}). Falling back to unadjusted PV forecast."
+        )
+        return False
+
     # Call the fit method
     await fcst.adjust_pv_forecast_fit(
-        n_splits=5,
+        n_splits=n_splits,
         regression_model=optim_conf["adjusted_pv_regression_model"],
     )
     return True

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -681,8 +681,8 @@ async def adjust_pv_forecast(
             logger.error(
                 f"Unexpected error loading adjusted PV model: {type(e).__name__}: {str(e)}"
             )
-            logger.error("Cannot recover from this error")
-            return False
+            logger.error("Cannot recover from this error. Falling back to unadjusted forecast.")
+            return p_pv_forecast
     # Call the predict method
     p_pv_forecast = p_pv_forecast.rename("forecast").to_frame()
     p_pv_forecast = fcst.adjust_pv_forecast_predict(forecasted_pv=p_pv_forecast)

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -583,7 +583,7 @@ async def _retrieve_and_fit_pv_model(
         return False
     # Call the fit method
     await fcst.adjust_pv_forecast_fit(
-        n_splits=5,
+        n_splits=n_splits,
         regression_model=optim_conf["adjusted_pv_regression_model"],
     )
     return True
@@ -681,8 +681,8 @@ async def adjust_pv_forecast(
             logger.error(
                 f"Unexpected error loading adjusted PV model: {type(e).__name__}: {str(e)}"
             )
-            logger.error("Cannot recover from this error. Falling back to unadjusted forecast.")
-            return p_pv_forecast
+            logger.error("Cannot recover from this error")
+            return False
     # Call the predict method
     p_pv_forecast = p_pv_forecast.rename("forecast").to_frame()
     p_pv_forecast = fcst.adjust_pv_forecast_predict(forecasted_pv=p_pv_forecast)

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -2278,13 +2278,18 @@ class Optimization:
     ):
         """Build the final results DataFrame (Vectorized extraction)."""
         opt_tp = pd.DataFrame(index=data_opt.index)
+        solver_zero_tol = 1e-9
 
         # Helper to safely get value or zeroes
         def get_val(var):
             if var is None:
                 return np.zeros(self.num_timesteps)
             val = var.value
-            return val if val is not None else np.zeros(self.num_timesteps)
+            if val is None:
+                return np.zeros(self.num_timesteps)
+            arr = np.array(val, copy=True)
+            arr[np.isclose(arr, 0.0, atol=solver_zero_tol, rtol=0.0)] = 0.0
+            return arr
 
         # Main Power Variables
         opt_tp["P_PV"] = p_pv

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1079,7 +1079,15 @@ class RetrieveHass:
         }
 
         # Add state_class to ensure HA tracks long-term statistics
-        if device_class in ["power", "temperature", "voltage", "current", "battery", "monetary", "power_factor"]:
+        if device_class in [
+            "power",
+            "temperature",
+            "voltage",
+            "current",
+            "battery",
+            "monetary",
+            "power_factor",
+        ]:
             attributes["state_class"] = "measurement"
         elif device_class == "energy":
             attributes["state_class"] = "total"
@@ -1275,7 +1283,15 @@ class RetrieveHass:
                 "unit_of_measurement": unit_of_measurement,
                 "friendly_name": friendly_name,
             }
-            if device_class in ["power", "temperature", "voltage", "current", "battery", "monetary", "power_factor"]:
+            if device_class in [
+                "power",
+                "temperature",
+                "voltage",
+                "current",
+                "battery",
+                "monetary",
+                "power_factor",
+            ]:
                 attributes["state_class"] = "measurement"
             elif device_class == "energy":
                 attributes["state_class"] = "total"
@@ -1289,7 +1305,15 @@ class RetrieveHass:
                 "unit_of_measurement": unit_of_measurement,
                 "friendly_name": friendly_name,
             }
-            if device_class in ["power", "temperature", "voltage", "current", "battery", "monetary", "power_factor"]:
+            if device_class in [
+                "power",
+                "temperature",
+                "voltage",
+                "current",
+                "battery",
+                "monetary",
+                "power_factor",
+            ]:
                 attributes["state_class"] = "measurement"
             elif device_class == "energy":
                 attributes["state_class"] = "total"

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1070,14 +1070,23 @@ class RetrieveHass:
             datum["date"] = ts
             datum[entity_id.split(sensor_prefix)[1]] = vals_list[i]
             forecast_list.append(datum)
+
+        attributes = {
+            "device_class": device_class,
+            "unit_of_measurement": unit_of_measurement,
+            "friendly_name": friendly_name,
+            list_name: forecast_list,
+        }
+
+        # Add state_class to ensure HA tracks long-term statistics
+        if device_class in ["power", "temperature", "voltage", "current", "battery", "monetary", "power_factor"]:
+            attributes["state_class"] = "measurement"
+        elif device_class == "energy":
+            attributes["state_class"] = "total"
+
         data = {
             "state": f"{state:.{decimals}f}",
-            "attributes": {
-                "device_class": device_class,
-                "unit_of_measurement": unit_of_measurement,
-                "friendly_name": friendly_name,
-                list_name: forecast_list,
-            },
+            "attributes": attributes,
         }
         return data
 
@@ -1261,22 +1270,32 @@ class RetrieveHass:
                 },
             }
         elif type_var == "mlregressor":
+            attributes = {
+                "device_class": device_class,
+                "unit_of_measurement": unit_of_measurement,
+                "friendly_name": friendly_name,
+            }
+            if device_class in ["power", "temperature", "voltage", "current", "battery", "monetary", "power_factor"]:
+                attributes["state_class"] = "measurement"
+            elif device_class == "energy":
+                attributes["state_class"] = "total"
             data = {
                 "state": state,
-                "attributes": {
-                    "device_class": device_class,
-                    "unit_of_measurement": unit_of_measurement,
-                    "friendly_name": friendly_name,
-                },
+                "attributes": attributes,
             }
         else:
+            attributes = {
+                "device_class": device_class,
+                "unit_of_measurement": unit_of_measurement,
+                "friendly_name": friendly_name,
+            }
+            if device_class in ["power", "temperature", "voltage", "current", "battery", "monetary", "power_factor"]:
+                attributes["state_class"] = "measurement"
+            elif device_class == "energy":
+                attributes["state_class"] = "total"
             data = {
                 "state": f"{state:.2f}",
-                "attributes": {
-                    "device_class": device_class,
-                    "unit_of_measurement": unit_of_measurement,
-                    "friendly_name": friendly_name,
-                },
+                "attributes": attributes,
             }
         # Actually post the data
         if self.get_data_from_file or dont_post:

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1069,14 +1069,23 @@ class RetrieveHass:
             datum["date"] = ts
             datum[entity_id.split(sensor_prefix)[1]] = vals_list[i]
             forecast_list.append(datum)
+            
+        attributes = {
+            "device_class": device_class,
+            "unit_of_measurement": unit_of_measurement,
+            "friendly_name": friendly_name,
+            list_name: forecast_list,
+        }
+        
+        # Add state_class to ensure HA tracks long-term statistics
+        if device_class in ["power", "temperature", "voltage", "current", "battery", "monetary", "power_factor"]:
+            attributes["state_class"] = "measurement"
+        elif device_class == "energy":
+            attributes["state_class"] = "total"
+            
         data = {
             "state": f"{state:.{decimals}f}",
-            "attributes": {
-                "device_class": device_class,
-                "unit_of_measurement": unit_of_measurement,
-                "friendly_name": friendly_name,
-                list_name: forecast_list,
-            },
+            "attributes": attributes,
         }
         return data
 
@@ -1260,22 +1269,32 @@ class RetrieveHass:
                 },
             }
         elif type_var == "mlregressor":
+            attributes = {
+                "device_class": device_class,
+                "unit_of_measurement": unit_of_measurement,
+                "friendly_name": friendly_name,
+            }
+            if device_class in ["power", "temperature", "voltage", "current", "battery", "monetary", "power_factor"]:
+                attributes["state_class"] = "measurement"
+            elif device_class == "energy":
+                attributes["state_class"] = "total"
             data = {
                 "state": state,
-                "attributes": {
-                    "device_class": device_class,
-                    "unit_of_measurement": unit_of_measurement,
-                    "friendly_name": friendly_name,
-                },
+                "attributes": attributes,
             }
         else:
+            attributes = {
+                "device_class": device_class,
+                "unit_of_measurement": unit_of_measurement,
+                "friendly_name": friendly_name,
+            }
+            if device_class in ["power", "temperature", "voltage", "current", "battery", "monetary", "power_factor"]:
+                attributes["state_class"] = "measurement"
+            elif device_class == "energy":
+                attributes["state_class"] = "total"
             data = {
                 "state": f"{state:.2f}",
-                "attributes": {
-                    "device_class": device_class,
-                    "unit_of_measurement": unit_of_measurement,
-                    "friendly_name": friendly_name,
-                },
+                "attributes": attributes,
             }
         # Actually post the data
         if self.get_data_from_file or dont_post:


### PR DESCRIPTION
This PR introduces two fixes:

1. **HA Statistics tracked correctly:** Adds `state_class` to the sensors published back to Home Assistant. Without this, Home Assistant refuses to store the data in its long-term statistics database, which EMHASS relies on for fetching historical data via WebSockets.
2. **Graceful ML fallback:** If the historical PV forecast data retrieved is too short to fulfill the required cross-validation folds (e.g. `< 6` samples when history is just enabled/cleared), it gracefully falls back to the unadjusted PV forecast rather than crashing scikit-learn with a `ValueError`.

## Summary by Sourcery

Ensure Home Assistant sensors publish long-term statistics-compatible attributes and make PV forecast adjustment more robust when historical data is insufficient.

Bug Fixes:
- Add appropriate state_class to published sensor attributes so Home Assistant stores long-term statistics used by EMHASS.
- Prevent PV model training from failing when historical data is too short by falling back to the unadjusted PV forecast instead of raising errors.

Enhancements:
- Centralize construction of sensor attributes, including device_class, units, friendly name, and forecast payload, for different sensor types.