### PR TITLE
fix: prevent thermal battery infeasibility when q_input_start is zero

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -351,6 +351,22 @@ class Optimization:
                     new_q_start,
                 )
                 params["q_input_start"].value = new_q_start
+            else:
+                # prev_q is None (e.g. after infeasible solve) -- estimate
+                # q_input_start from heating demand to avoid persisting 0.0
+                # which would cause a permanent infeasibility loop.
+                demand = params.get("heating_demand")
+                if demand is not None and hasattr(demand, "value") and demand.value is not None:
+                    fallback = float(max(demand.value[0], 0.0))
+                else:
+                    fallback = 0.0
+                if fallback > 0.0 or params["q_input_start"].value == 0.0:
+                    self.logger.warning(
+                        "Load %s: q_input solve result is None (infeasible?), "
+                        "resetting q_input_start from %.4f to heating demand estimate %.4f",
+                        k, params["q_input_start"].value, fallback,
+                    )
+                    params["q_input_start"].value = fallback
         elif tau_hours == 0 and "q_input_var" in params:
             # Inertia was disabled — clear stale variable reference
             del params["q_input_var"]
@@ -1632,7 +1648,21 @@ class Optimization:
             # Initialize Q_input[0] from CVXPY Parameter (enables warm-start updates)
             params = self.param_thermal.get(k, {})
             q_input_start = params.get("q_input_start", 0.0)
-            constraints.append(q_input[0] == q_input_start)
+            # Extract the scalar value for comparison (cp.Parameter or float)
+            q_start_val = float(q_input_start.value) if hasattr(q_input_start, "value") else float(q_input_start)
+            min_temp_0 = float(min_temperatures_list[0]) if min_temperatures_list else 18.0
+            # When q_input_start is zero and the initial temperature is at or below
+            # the minimum, hard-constraining q_input[0] == 0 would force zero heating
+            # at t=0 causing the temperature at t=1 to drop below min_temperatures,
+            # making the problem infeasible.  Release q_input[0] as a free (nonneg)
+            # variable so the optimizer can choose the initial heat input.
+            if q_start_val == 0.0 and start_temp_float <= min_temp_0:
+                self.logger.info(
+                    "Load %s: Releasing q_input[0] (q_input_start=0, start_temp=%.2f <= min_temp=%.2f)",
+                    k, start_temp_float, min_temp_0,
+                )
+            else:
+                constraints.append(q_input[0] == q_input_start)
 
             # Raw heat input: COP * P_hp / 1000 * dt (kWh thermal per timestep)
             raw_heat = cp.multiply(heatpump_cops[:-1], p_deferrable[:-1]) / 1000 * self.time_step


### PR DESCRIPTION
## Summary

- **Release `q_input[0]` constraint** when `q_input_start == 0` and `start_temperature <= min_temperatures[0]`, allowing the optimizer to choose the initial heat input instead of forcing zero heating that causes infeasibility
- **Reset `q_input_start` after infeasible solve** to a heating demand estimate instead of leaving it at 0.0, preventing a permanent infeasibility loop across MPC iterations

## Problem

When `q_input_start` is 0 (e.g. after a failed optimization or cold start), the hard constraint `q_input[0] == 0` forces zero heating at t=0. With `start_temperature == min_temperatures`, the temperature at t=1 drops below `min_temperatures` due to thermal losses and heating demand, making the problem infeasible.

After an infeasible solve, `q_input_var.value` is `None`, so the auto-persistence logic skips the update and `q_input_start` remains at 0.0 — creating a permanent infeasibility loop.

## Fix

1. In `_add_thermal_battery_constraints()`: when `q_input_start == 0.0` and `start_temp_float <= min_temp_0`, skip the equality constraint so `q_input[0]` remains a free variable (bounded only by `nonneg=True`)
2. In `_persist_thermal_inertia_state()`: when `prev_q` is `None` (infeasible solve), estimate `q_input_start` from `heating_demand[0]` instead of leaving it at 0.0

## Test plan

- [ ] Verify optimization succeeds when `start_temperature == min_temperatures[0]` and `q_input_start == 0`
- [ ] Verify that after an infeasible run, the next MPC iteration recovers instead of staying infeasible
- [ ] Verify normal operation (q_input_start > 0) is unchanged — constraint still applied

Fixes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent thermal battery infeasibility loops by relaxing the initial heat input constraint in edge cases and resetting the initial heat input after infeasible solves.

Bug Fixes:
- Allow the optimizer to freely choose q_input[0] when the stored initial heat input is zero and the starting temperature is at or below the minimum temperature, avoiding infeasible zero-heating situations.
- Reset q_input_start to a non-negative estimate based on the first-step heating demand after an infeasible solve instead of persisting a zero value that would cause repeated infeasibility.