### PR TITLE
fix(forecast): clamp adjusted PV forecast to >= 0 (fixes #521)

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -1030,6 +1030,10 @@ class Forecast:
                 return row["adjusted_forecast"]
 
         forecast_data["adjusted_forecast"] = forecast_data.apply(apply_weighting, axis=1)
+        # Clamp to non-negative: PV power is physically >= 0, but the daytime branch
+        # above returns the raw regression output (e.g. Lasso is unconstrained and can
+        # extrapolate below zero on cloudy days after sunny training history). See #521.
+        forecast_data["adjusted_forecast"] = forecast_data["adjusted_forecast"].clip(lower=0)
         # If using validation data, calculate validation metrics
         if forecasted_pv is None:
             y_true = self.p_pv_validation.values

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -231,6 +231,24 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
         # )
         # fig.show()
 
+    # Regression test for #521: daytime branch of apply_weighting returns the raw
+    # regression output, which can be negative (e.g. LassoRegression extrapolating
+    # on a cloudy day after sunny training history). Result must be clamped to >= 0.
+    async def test_pv_forecast_adjust_clamps_negative(self):
+        idx = pd.date_range("2026-04-19 10:00:00", periods=4, freq="15min", tz=self.fcst.time_zone)
+        forecasted_pv = pd.DataFrame({"forecast": [500.0, 600.0, 700.0, 800.0]}, index=idx)
+
+        class _NegativePredictModel:
+            def predict(self, X):
+                return np.full(len(X), -150.0)
+
+        self.fcst.model_adjust_pv = _NegativePredictModel()
+        result = self.fcst.adjust_pv_forecast_predict(forecasted_pv=forecasted_pv)
+        self.assertTrue(
+            (result["adjusted_forecast"] >= 0).all(),
+            f"Adjusted forecast must be >= 0, got: {result['adjusted_forecast'].tolist()}",
+        )
+
     # Test output weather forecast using openmeteo with mock get request data
     async def test_get_weather_forecast_openmeteo_method_mock(self):
         test_data_path = emhass_conf["data_path"] / "test_response_openmeteo_get_method.pbz2"


### PR DESCRIPTION
## What

Clamp `adjusted_forecast` to `>= 0` in `Forecast.adjust_pv_forecast_predict` after `apply_weighting`. Fixes #521.

## Why

The nighttime and low-elevation branches of `apply_weighting` already clamp via `max(..., 0)`, but the daytime branch (`solar_elevation >= threshold`, default 10°) returns the raw regression output with no floor.

`LassoRegression` (the default `adjusted_pv_regression_model`) is unconstrained by design and can extrapolate below zero on a cloudy day after sunny training history. PV power is physically `>= 0`, so negative values are unsafe input to any downstream optimization.

@paulhomes originally reported this in #521 with an open-meteo-based setup (April 2025). Reproduced again on `sha-56a88d4` (post-v0.17.1, PR #771 merged) on 2026-04-17 with `weather_forecast_method: csv`: 20 consecutive quarters with negative `P_PV` values peaking at -193.66 W around noon on a forecast day, despite the raw input CSV being strictly non-negative.

The downstream effect in my setup was significant — the negative PV made the hybrid-inverter MILP infeasible, and the relaxed-retry path then returned a degenerate max-export schedule with `optim_status = "Optimal"`. That retry-path issue is orthogonal to this fix and I'll file it separately.

## Change

One line, column-level `.clip(lower=0)` after `apply_weighting`. Extends the same physical invariant the low-elevation branch already uses.

## Test

Adds `test_pv_forecast_adjust_clamps_negative` which injects a mock model returning `-150.0` for daytime timestamps and asserts the output is `>= 0`. Verified to fail against current `master` and pass with this fix.

Full `tests/test_forecast.py` suite (29 tests) passes locally.

## Alternatives considered

- Wrap the daytime branch of `apply_weighting` in `max(..., 0)` — same outcome, slightly more intrusive. Column-level clip is cleaner.
- Switch to a non-negative regressor (NNLS, monotonic GBM) — bigger behaviour change, worth considering separately but not a prerequisite for closing the correctness gap.
- Quality-gate the Lasso output (e.g. fall back to unadjusted forecast if negative-fraction > threshold) — orthogonal to this fix.

Happy to adjust to whichever direction you prefer.

## Summary by Sourcery

Clamp adjusted PV power forecasts to be non-negative after applying regression-based adjustments.

Bug Fixes:
- Prevent negative adjusted PV forecast values when the daytime weighting branch returns unconstrained regression outputs.

Tests:
- Add a regression test ensuring adjusted PV forecasts are clamped to values greater than or equal to zero.