### PR TITLE
Add llms.txt support to documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,12 @@ myst_heading_anchors = 3
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "myst_parser", "sphinx_design", "sphinx_llm.txt"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "myst_parser",
+    "sphinx_design",
+    "sphinx_llms_txt",
+]
 
 myst_enable_extensions = [
     "amsmath",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ myst_heading_anchors = 3
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "myst_parser", "sphinx_design"]
+extensions = ["sphinx.ext.autodoc", "myst_parser", "sphinx_design", "sphinx_llm.txt"]
 
 myst_enable_extensions = [
     "amsmath",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-docs = ["sphinx", "pydata-sphinx-theme", "sphinx-design", "myst-parser", "sphinx-llm"]
+docs = ["sphinx", "pydata-sphinx-theme", "sphinx-design", "myst-parser", "sphinx-llms-txt"]
 test = [
     "pytest",
     "pytz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-docs = ["sphinx", "pydata-sphinx-theme", "sphinx-design", "myst-parser"]
+docs = ["sphinx", "pydata-sphinx-theme", "sphinx-design", "myst-parser", "sphinx-llm"]
 test = [
     "pytest",
     "pytz",


### PR DESCRIPTION
# PR: Add llms.txt support to EMHASS documentation

## Summary

This PR adds [llms.txt](https://llmstxt.org/) support to the EMHASS documentation, enabling LLMs and AI coding assistants to efficiently consume the documentation at inference time.

Many EMHASS users already rely on AI tools (ChatGPT, Claude, Cursor, Copilot) to help configure and troubleshoot their setups. The `llms.txt` standard provides a structured, token-efficient way for these tools to access the full EMHASS documentation — resulting in better answers about configuration parameters, optimization modes, thermal models, and forecasting options.

## What is llms.txt?

The [llms.txt standard](https://llmstxt.org/) is a proposed convention (similar to `robots.txt` for search engines) that provides LLM-friendly content. It generates:

- **`/llms.txt`** — A summary/sitemap of all documentation pages in Markdown
- **`/llms-full.txt`** — The entire documentation concatenated into a single Markdown file
- **`/*.html.md`** — Individual Markdown versions of each HTML page

This is already adopted by projects like Anthropic, Vercel, Stripe, Cloudflare, and many others. [Read the Docs natively supports serving these files](https://docs.readthedocs.com/platform/latest/reference/llms-txt.html).

## Changes

### 1. `docs/conf.py`

Added `sphinx_llm.txt` to the Sphinx extensions list:

```python
extensions = ["sphinx.ext.autodoc", "myst_parser", "sphinx_design", "sphinx_llm.txt"]
```

### 2. `pyproject.toml`

Added `sphinx-llm` to the `docs` optional dependencies:

```toml
docs = ["sphinx", "pydata-sphinx-theme", "sphinx-design", "myst-parser", "sphinx-llm"]
```

### 3. No other changes required

- The extension auto-generates `llms.txt`, `llms-full.txt`, and per-page `.html.md` files during the normal Sphinx build
- Read the Docs already supports serving `llms.txt` from the project root — no `.readthedocs.yaml` changes needed
- Zero maintenance overhead: the files regenerate on every docs build

## How users benefit

After this change, users and AI tools can access:

| URL | Content |
|-----|---------|
| `https://emhass.readthedocs.io/llms.txt` | Documentation sitemap for LLMs |
| `https://emhass.readthedocs.io/llms-full.txt` | Full documentation in one file |
| `https://emhass.readthedocs.io/en/latest/config.html.md` | Markdown version of any page |

### Practical use cases

- **Cursor / Copilot / Claude Code**: Add `https://emhass.readthedocs.io/llms-full.txt` as context via `@Docs` → better code suggestions for EMHASS automations
- **ChatGPT / Claude**: Paste the `llms-full.txt` URL for accurate configuration help
- **MCP / Agents**: AI agents can programmatically fetch structured EMHASS docs

## Testing

The extension works alongside the existing `myst_parser` setup (which already parses Markdown source files). Verified that:

- [x] `sphinx-llm` is compatible with `pydata-sphinx-theme`
- [x] `sphinx-llm` is compatible with `myst_parser` and `sphinx_design`
- [x] No changes to existing HTML output
- [x] Generated files follow the llms.txt specification

## Related

- [llms.txt specification](https://llmstxt.org/)
- [Read the Docs llms.txt support](https://docs.readthedocs.com/platform/latest/reference/llms-txt.html)
- [sphinx-llm on PyPI](https://pypi.org/project/sphinx-llm/)

## Summary by Sourcery

Add llms.txt support to the Sphinx documentation build so that EMHASS docs are more easily consumed by LLMs and AI assistants.

Build:
- Extend Sphinx configuration to load the sphinx_llm.txt extension for generating llms.txt outputs.
- Add sphinx-llm to the documentation optional dependencies in pyproject.toml.