### PR TITLE
Update optimization.py Fix logic flaw in grid/battery interaction constraints.

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -1149,9 +1149,9 @@ class Optimization:
 
         # Grid Interaction Constraints
 
-        # No charge from grid: Battery cannot charge (E=0) while grid is importing (D=1)
+        # No charge from grid: The battery charge power cannot exceed the PV production
         if self.optim_conf["set_nocharge_from_grid"]:
-            constraints.append(D <= E)
+            constraints.append(p_sto_neg + p_pv >= 0)
 
         # No discharge to grid: Battery cannot discharge (E=1) while grid is exporting (D=0)
         if self.optim_conf["set_nodischarge_to_grid"]:

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -1126,6 +1126,7 @@ class Optimization:
         p_sto_neg = self.vars["p_sto_neg"]
         p_grid_neg = self.vars["p_grid_neg"]
         E = self.vars["E"]  # Binary: 1=Discharge, 0=Charge
+        D = self.vars["D"]  # Binary: 1=Import, 0=Export
         p_pv = self.param_pv_forecast
 
         # Parameters (Scalars)
@@ -1148,13 +1149,13 @@ class Optimization:
 
         # Grid Interaction Constraints
 
-        # No charge from grid: Charging power (neg) + PV must be positive (net surplus)
+        # No charge from grid: Battery cannot charge (E=0) while grid is importing (D=1)
         if self.optim_conf["set_nocharge_from_grid"]:
-            constraints.append(p_sto_neg + p_pv >= 0)
+            constraints.append(D <= E)
 
-        # No discharge to grid: Grid Export (neg) + PV must be positive
+        # No discharge to grid: Battery cannot discharge (E=1) while grid is exporting (D=0)
         if self.optim_conf["set_nodischarge_to_grid"]:
-            constraints.append(p_grid_neg + p_pv >= 0)
+            constraints.append(E <= D)
 
         # Dynamic Power Limits (Ramp Rate)
         if self.optim_conf["set_battery_dynamic"]:


### PR DESCRIPTION
### Description
This PR addresses a logic flaw in the `set_nodischarge_to_grid` and `set_nocharge_from_grid` constraints, as discussed in issue #795.

The previous implementation allowed the battery to discharge to cover the house load while simultaneously exporting 100% of PV production to the grid. While mathematically "correct" under the constraint $P_{export} \le P_{pv}$, it is physically impossible for most hybrid inverters (like Deye) which prioritize PV to Load. This led to a desynchronization between EMHASS plans and real-world execution, especially critical during negative price periods.

### Changes
* Updated `src/emhass/optimization.py`: Loaded the grid direction binary variable `D` into the `_add_battery_constraints` function.
* **No discharge to grid:** Replaced the previous power-balance check with a strict binary constraint: `E <= D`. This ensures the battery cannot discharge ($E=1$) if the grid is exporting ($D=0$).
* **No charge from grid:** Replaced the check with `D <= E`. This ensures the battery cannot charge ($E=0$) if the grid is importing ($D=1$).

### Testing Performed
* Validated the logic by running the full optimization test suite: `pytest tests/test_optimization.py`.
* **Result:** 81 passed.
* *Note:* I have verified that the mathematical model is consistent with existing test cases. I have not performed extensive live production testing over several weeks, but the change directly aligns the model with the physical behavior of hybrid inverters.

Fixes #795

## Summary by Sourcery

Bug Fixes:
- Prevent the optimizer from planning simultaneous PV export and battery discharge or charge states that are infeasible for typical hybrid inverters by tightening grid/battery interaction constraints.