### PR TITLE
feat: Support arithmetic expressions in InfluxDB var_list entries

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1,8 +1,10 @@
 import asyncio
+import ast
 import copy
 import logging
 import os
 import pathlib
+import re
 import time
 from datetime import datetime, timezone
 from typing import Any, Self
@@ -647,18 +649,51 @@ class RetrieveHass:
         if end_time < requested_end:
             self.logger.debug(f"End time capped at current time (requested: {requested_end})")
 
-        # Collect sensor dataframes
+        # Collect sensor dataframes (raw sensors and expression outputs)
         sensor_dfs = []
+        sensor_cache: dict[str, pd.DataFrame | None] = {}
         global_min_time = None
         global_max_time = None
 
-        for sensor in filter(None, var_list):
-            df_sensor = self._fetch_sensor_data(client, sensor, start_time, end_time)
-            if df_sensor is not None:
-                sensor_dfs.append(df_sensor)
+        for variable in filter(None, var_list):
+            df_variable = None
+
+            if self._is_influx_expression(variable):
+                try:
+                    parsed_expression, entities, token_to_entity = self._extract_influx_expression_entities(variable)
+                    series_mapping: dict[str, pd.Series] = {}
+
+                    for token, entity in token_to_entity.items():
+                        if entity not in sensor_cache:
+                            sensor_cache[entity] = self._fetch_sensor_data(
+                                client, entity, start_time, end_time
+                            )
+                        df_entity = sensor_cache[entity]
+                        if df_entity is None:
+                            raise ValueError(f"No data available for entity '{entity}'")
+                        series_mapping[token] = df_entity[entity]
+
+                    expression_result = self._evaluate_influx_expression(
+                        parsed_expression, series_mapping
+                    )
+                    df_variable = pd.DataFrame({variable: expression_result})
+                    self.logger.debug(
+                        f"Evaluated InfluxDB expression '{variable}' with entities: {entities}"
+                    )
+                except Exception as e:
+                    self.logger.error(f"Failed to evaluate InfluxDB expression '{variable}': {e}")
+            else:
+                if variable not in sensor_cache:
+                    sensor_cache[variable] = self._fetch_sensor_data(
+                        client, variable, start_time, end_time
+                    )
+                df_variable = sensor_cache[variable]
+
+            if df_variable is not None and not df_variable.empty:
+                sensor_dfs.append(df_variable)
                 # Track global time range
-                sensor_min = df_sensor.index.min()
-                sensor_max = df_sensor.index.max()
+                sensor_min = df_variable.index.min()
+                sensor_max = df_variable.index.max()
                 global_min_time = min(global_min_time or sensor_min, sensor_min)
                 global_max_time = max(global_max_time or sensor_max, sensor_max)
 
@@ -694,6 +729,68 @@ class RetrieveHass:
         self.var_list = var_list
         self.logger.info(f"InfluxDB data retrieval completed: {self.df_final.shape}")
         return True
+
+    def _is_influx_expression(self, variable: str) -> bool:
+        """Check if variable uses arithmetic expression syntax: {{ ... }}."""
+        stripped = variable.strip() if isinstance(variable, str) else ""
+        return stripped.startswith("{{") and stripped.endswith("}}")
+
+    def _extract_influx_expression_entities(self, expression: str) -> tuple[str, list[str], dict[str, str]]:
+        """
+        Replace quoted entity IDs in an expression with safe variable tokens.
+
+        Example:
+        "{{'sensor.a' - 'sensor.b' * 1000}}" -> ("_v0 - _v1 * 1000", ["sensor.a", "sensor.b"], {"_v0": "sensor.a", ...})
+        """
+        expression_body = expression.strip()[2:-2].strip()
+        matches = list(re.finditer(r"'([^']+)'|\"([^\"]+)\"", expression_body))
+        if not matches:
+            raise ValueError("Expression does not contain quoted entity IDs.")
+
+        entities: list[str] = []
+        token_to_entity: dict[str, str] = {}
+        entity_to_token: dict[str, str] = {}
+
+        def replace_entity(match: re.Match[str]) -> str:
+            entity = match.group(1) or match.group(2)
+            if entity not in entity_to_token:
+                token = f"_v{len(entity_to_token)}"
+                entity_to_token[entity] = token
+                token_to_entity[token] = entity
+                entities.append(entity)
+            return entity_to_token[entity]
+
+        parsed_expression = re.sub(r"'([^']+)'|\"([^\"]+)\"", replace_entity, expression_body)
+        return parsed_expression, entities, token_to_entity
+
+    def _evaluate_influx_expression(
+        self, parsed_expression: str, series_mapping: dict[str, pd.Series]
+    ) -> pd.Series:
+        """Safely evaluate arithmetic expression using pandas Series and constants."""
+        allowed_nodes = (
+            ast.Expression,
+            ast.BinOp,
+            ast.UnaryOp,
+            ast.Add,
+            ast.Sub,
+            ast.Mult,
+            ast.Div,
+            ast.Pow,
+            ast.Mod,
+            ast.USub,
+            ast.UAdd,
+            ast.Name,
+            ast.Load,
+            ast.Constant,
+        )
+        tree = ast.parse(parsed_expression, mode="eval")
+        for node in ast.walk(tree):
+            if not isinstance(node, allowed_nodes):
+                raise ValueError(f"Unsupported expression element: {type(node).__name__}")
+            if isinstance(node, ast.Name) and node.id not in series_mapping:
+                raise ValueError(f"Unknown entity token in expression: {node.id}")
+
+        return eval(compile(tree, "<influx_expression>", "eval"), {"__builtins__": {}}, series_mapping)
 
     def _init_influx_client(self):
         """Initialize InfluxDB client connection."""

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1,6 +1,7 @@
 import asyncio
 import ast
 import copy
+import operator
 import logging
 import os
 import pathlib
@@ -652,6 +653,7 @@ class RetrieveHass:
         # Collect sensor dataframes (raw sensors and expression outputs)
         sensor_dfs = []
         sensor_cache: dict[str, pd.DataFrame | None] = {}
+        failed_variables: list[str] = []
         global_min_time = None
         global_max_time = None
 
@@ -680,14 +682,19 @@ class RetrieveHass:
                     self.logger.debug(
                         f"Evaluated InfluxDB expression '{variable}' with entities: {entities}"
                     )
-                except Exception as e:
-                    self.logger.error(f"Failed to evaluate InfluxDB expression '{variable}': {e}")
+                except Exception:
+                    self.logger.exception(
+                        f"Failed to evaluate InfluxDB expression '{variable}'"
+                    )
+                    failed_variables.append(variable)
             else:
                 if variable not in sensor_cache:
                     sensor_cache[variable] = self._fetch_sensor_data(
                         client, variable, start_time, end_time
                     )
                 df_variable = sensor_cache[variable]
+                if df_variable is None:
+                    failed_variables.append(variable)
 
             if df_variable is not None and not df_variable.empty:
                 sensor_dfs.append(df_variable)
@@ -698,6 +705,12 @@ class RetrieveHass:
                 global_max_time = max(global_max_time or sensor_max, sensor_max)
 
         client.close()
+
+        if failed_variables:
+            self.logger.error(
+                f"InfluxDB retrieval failed for variables: {sorted(set(failed_variables))}"
+            )
+            return False
 
         if not sensor_dfs:
             self.logger.error("No data retrieved from InfluxDB")
@@ -767,30 +780,50 @@ class RetrieveHass:
         self, parsed_expression: str, series_mapping: dict[str, pd.Series]
     ) -> pd.Series:
         """Safely evaluate arithmetic expression using pandas Series and constants."""
-        allowed_nodes = (
-            ast.Expression,
-            ast.BinOp,
-            ast.UnaryOp,
-            ast.Add,
-            ast.Sub,
-            ast.Mult,
-            ast.Div,
-            ast.Pow,
-            ast.Mod,
-            ast.USub,
-            ast.UAdd,
-            ast.Name,
-            ast.Load,
-            ast.Constant,
-        )
         tree = ast.parse(parsed_expression, mode="eval")
-        for node in ast.walk(tree):
-            if not isinstance(node, allowed_nodes):
-                raise ValueError(f"Unsupported expression element: {type(node).__name__}")
-            if isinstance(node, ast.Name) and node.id not in series_mapping:
-                raise ValueError(f"Unknown entity token in expression: {node.id}")
 
-        return eval(compile(tree, "<influx_expression>", "eval"), {"__builtins__": {}}, series_mapping)
+        binary_operators = {
+            ast.Add: operator.add,
+            ast.Sub: operator.sub,
+            ast.Mult: operator.mul,
+            ast.Div: operator.truediv,
+            ast.Pow: operator.pow,
+            ast.Mod: operator.mod,
+        }
+        unary_operators = {
+            ast.UAdd: operator.pos,
+            ast.USub: operator.neg,
+        }
+        numeric_nodes = (ast.Constant, ast.Num) if hasattr(ast, "Num") else (ast.Constant,)
+
+        def eval_node(node):
+            if isinstance(node, ast.Expression):
+                return eval_node(node.body)
+            if isinstance(node, ast.BinOp):
+                op_type = type(node.op)
+                if op_type not in binary_operators:
+                    raise ValueError(f"Unsupported binary operator: {op_type.__name__}")
+                return binary_operators[op_type](eval_node(node.left), eval_node(node.right))
+            if isinstance(node, ast.UnaryOp):
+                op_type = type(node.op)
+                if op_type not in unary_operators:
+                    raise ValueError(f"Unsupported unary operator: {op_type.__name__}")
+                return unary_operators[op_type](eval_node(node.operand))
+            if isinstance(node, ast.Name):
+                if node.id not in series_mapping:
+                    raise ValueError(f"Unknown entity token in expression: {node.id}")
+                return series_mapping[node.id]
+            if isinstance(node, numeric_nodes):
+                value = node.n if hasattr(node, "n") else node.value
+                if not isinstance(value, int | float):
+                    raise ValueError(f"Unsupported constant type: {type(value).__name__}")
+                return value
+            raise ValueError(f"Unsupported expression element: {type(node).__name__}")
+
+        result = eval_node(tree)
+        if not isinstance(result, pd.Series):
+            raise ValueError("Expression must produce a pandas Series result.")
+        return result
 
     def _init_influx_client(self):
         """Initialize InfluxDB client connection."""

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -682,7 +682,7 @@ class RetrieveHass:
                     self.logger.debug(
                         f"Evaluated InfluxDB expression '{variable}' with entities: {entities}"
                     )
-                except Exception:
+                except (ValueError, SyntaxError):
                     self.logger.exception(
                         f"Failed to evaluate InfluxDB expression '{variable}'"
                     )

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1,8 +1,8 @@
-import asyncio
 import ast
+import asyncio
 import copy
-import operator
 import logging
+import operator
 import os
 import pathlib
 import re
@@ -606,7 +606,14 @@ class RetrieveHass:
 
         :param days_list: A list of days to retrieve data for
         :type days_list: pandas.date_range
-        :param var_list: List of sensor entity IDs to retrieve
+        :param var_list: List of variables to retrieve. Each entry is either a
+            plain sensor entity id (e.g. ``'sensor.power_a'``) or an arithmetic
+            expression combining several timeseries using the ``{{ ... }}``
+            syntax, for example ``"{{'sensor.power_a' - 'sensor.power_b' * 1000}}"``.
+            For an expression, every referenced entity is queried separately from
+            InfluxDB and the operation (``+``, ``-``, ``*``, ``/``, ``**``, ``%``,
+            unary ``+``/``-`` and numeric constants are supported) is applied
+            element-wise on the corresponding values of the returned timeseries.
         :type var_list: list
         :return: Success status of data retrieval
         :rtype: bool
@@ -663,7 +670,9 @@ class RetrieveHass:
 
             if self._is_influx_expression(variable):
                 try:
-                    parsed_expression, entities, token_to_entity = self._extract_influx_expression_entities(variable)
+                    parsed_expression, entities, token_to_entity = (
+                        self._extract_influx_expression_entities(variable)
+                    )
                     series_mapping: dict[str, pd.Series] = {}
 
                     for token, entity in token_to_entity.items():
@@ -684,9 +693,7 @@ class RetrieveHass:
                         f"Evaluated InfluxDB expression '{variable}' with entities: {entities}"
                     )
                 except (ValueError, SyntaxError):
-                    self.logger.exception(
-                        f"Failed to evaluate InfluxDB expression '{variable}'"
-                    )
+                    self.logger.exception(f"Failed to evaluate InfluxDB expression '{variable}'")
                     failed_variables.append(variable)
             else:
                 if variable not in sensor_cache:
@@ -749,7 +756,9 @@ class RetrieveHass:
         stripped = variable.strip() if isinstance(variable, str) else ""
         return stripped.startswith("{{") and stripped.endswith("}}")
 
-    def _extract_influx_expression_entities(self, expression: str) -> tuple[str, list[str], dict[str, str]]:
+    def _extract_influx_expression_entities(
+        self, expression: str
+    ) -> tuple[str, list[str], dict[str, str]]:
         """
         Replace quoted entity IDs in an expression with safe variable tokens.
 

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -434,6 +434,232 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
             450.0,
         )
 
+    # ------------------------------------------------------------------
+    # InfluxDB arithmetic expression support in var_list
+    # ------------------------------------------------------------------
+    # In addition to a plain entity id, an entry of var_list may use the
+    # alternative syntax "{{ ... }}" to combine several timeseries with simple
+    # arithmetic, e.g. "{{'sensor.power_a' - 'sensor.power_b' * 1000}}". Each
+    # entity taking part in the expression is queried separately from InfluxDB
+    # and the operation is applied element-wise on the aligned series.
+
+    def _make_influxdb_rh(self):
+        """Build a RetrieveHass instance configured to use InfluxDB."""
+        params_influx = {
+            "retrieve_hass_conf": {
+                "use_influxdb": True,
+                "influxdb_host": "fake-host",
+                "influxdb_port": 8086,
+                "influxdb_username": "fake-user",
+                "influxdb_password": "fake-pass",  # pragma: allowlist secret
+                "influxdb_database": "fake-db",
+                "influxdb_measurement": "W",
+            }
+        }
+        return RetrieveHass(
+            self.retrieve_hass_conf["hass_url"],
+            self.retrieve_hass_conf["long_lived_token"],
+            self.retrieve_hass_conf["optimization_time_step"],
+            self.retrieve_hass_conf["time_zone"],
+            params_influx,
+            emhass_conf,
+            logger,
+            get_data_from_file=False,
+        )
+
+    @staticmethod
+    def _influx_query_side_effect(entity_data, tag_values=None):
+        """Build a client.query side_effect that serves discovery and data queries.
+
+        :param entity_data: mapping of InfluxDB entity_id -> list of points
+            (each point being a dict with "time" and "mean_value"). An empty
+            list emulates a sensor that exists but returns no data.
+        :param tag_values: entity_ids advertised by "SHOW TAG VALUES".
+            Defaults to the keys of entity_data.
+        """
+        if tag_values is None:
+            tag_values = list(entity_data)
+
+        def query_side_effect(query):
+            mock_result = MagicMock()
+            if "SHOW MEASUREMENTS" in query:
+                mock_result.get_points.return_value = [{"name": "W"}]
+            elif "SHOW TAG VALUES" in query:
+                mock_result.get_points.return_value = [{"value": value} for value in tag_values]
+            else:
+                # Data query: find which entity_id it targets
+                points = []
+                for entity_id, data in entity_data.items():
+                    if f"'{entity_id}'" in query:
+                        points = data
+                        break
+                mock_result.get_points.return_value = points
+            return mock_result
+
+        return query_side_effect
+
+    def test_influx_is_expression(self):
+        """_is_influx_expression detects the {{ ... }} arithmetic syntax."""
+        self.assertTrue(self.rh._is_influx_expression("{{'sensor.a' - 'sensor.b'}}"))
+        # Surrounding whitespace is tolerated
+        self.assertTrue(self.rh._is_influx_expression("  {{ 'sensor.a' * 2 }}  "))
+        # Plain sensors and malformed strings are not expressions
+        self.assertFalse(self.rh._is_influx_expression("sensor.power_a"))
+        self.assertFalse(self.rh._is_influx_expression("{{ not closed"))
+        self.assertFalse(self.rh._is_influx_expression("not opened }}"))
+        self.assertFalse(self.rh._is_influx_expression(""))
+
+    def test_influx_extract_expression_entities(self):
+        """Quoted entity IDs are replaced by safe tokens and de-duplicated."""
+        expr = "{{'sensor.power_a' - 'sensor.power_b' * 1000}}"
+        parsed, entities, token_to_entity = self.rh._extract_influx_expression_entities(expr)
+        self.assertEqual(parsed, "_v0 - _v1 * 1000")
+        self.assertEqual(entities, ["sensor.power_a", "sensor.power_b"])
+        self.assertEqual(token_to_entity, {"_v0": "sensor.power_a", "_v1": "sensor.power_b"})
+        # Double quotes are accepted as well
+        parsed2, entities2, _ = self.rh._extract_influx_expression_entities(
+            '{{"sensor.a" + "sensor.b"}}'
+        )
+        self.assertEqual(parsed2, "_v0 + _v1")
+        self.assertEqual(entities2, ["sensor.a", "sensor.b"])
+        # A repeated entity reuses the same token (a single query is enough)
+        parsed3, entities3, _ = self.rh._extract_influx_expression_entities(
+            "{{'sensor.a' + 'sensor.a' / 2}}"
+        )
+        self.assertEqual(entities3, ["sensor.a"])
+        self.assertEqual(parsed3, "_v0 + _v0 / 2")
+        # An expression without any entity is rejected
+        with self.assertRaises(ValueError):
+            self.rh._extract_influx_expression_entities("{{1 + 2}}")
+
+    def test_influx_evaluate_expression(self):
+        """Arithmetic is applied element-wise with standard operator precedence."""
+        idx = pd.date_range("2023-04-01 10:00", periods=3, freq="30min", tz="UTC")
+        series_a = pd.Series([1500.0, 1800.0, 2000.0], index=idx)
+        series_b = pd.Series([0.5, 0.3, 1.0], index=idx)
+        mapping = {"_v0": series_a, "_v1": series_b}
+        # Multiplication binds tighter than subtraction: a - (b * 1000)
+        result = self.rh._evaluate_influx_expression("_v0 - _v1 * 1000", mapping)
+        pd.testing.assert_series_equal(result, series_a - series_b * 1000, check_names=False)
+        # Division combined with a unary minus
+        result_div = self.rh._evaluate_influx_expression("-_v0 / _v1", mapping)
+        pd.testing.assert_series_equal(result_div, -series_a / series_b, check_names=False)
+        # An unknown token raises (no silent zero-fill)
+        with self.assertRaises(ValueError):
+            self.rh._evaluate_influx_expression("_v0 + _v9", mapping)
+        # Arbitrary code such as a function call is rejected
+        with self.assertRaises(ValueError):
+            self.rh._evaluate_influx_expression("__import__('os')", mapping)
+        # A malformed expression surfaces a SyntaxError
+        with self.assertRaises(SyntaxError):
+            self.rh._evaluate_influx_expression("_v0 +", mapping)
+        # An expression that does not yield a Series is rejected
+        with self.assertRaises(ValueError):
+            self.rh._evaluate_influx_expression("1 + 2", {})
+
+    @patch("influxdb.InfluxDBClient", autospec=True)
+    async def test_get_data_influxdb_expression(self, mock_influx_client_class):
+        """get_data_influxdb evaluates an arithmetic expression across sensors."""
+        rh_influx = self._make_influxdb_rh()
+        mock_client_instance = mock_influx_client_class.return_value
+        mock_client_instance.query.side_effect = self._influx_query_side_effect(
+            {
+                "power_a": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 1500.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 1800.0},
+                ],
+                "power_b": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 0.5},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 0.3},
+                ],
+            }
+        )
+
+        days_list = pd.date_range(start="2023-04-01", periods=1, freq="D", tz="UTC")
+        expression = "{{'sensor.power_a' - 'sensor.power_b' * 1000}}"
+        success = await rh_influx.get_data(days_list, [expression])
+        self.assertTrue(success)
+
+        df = rh_influx.df_final
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(list(df.columns), [expression])
+        # a - b * 1000 computed element-wise on the aligned timestamps
+        self.assertAlmostEqual(df.loc["2023-04-01 10:00:00+00:00"][expression], 1500.0 - 0.5 * 1000)
+        self.assertAlmostEqual(df.loc["2023-04-01 10:30:00+00:00"][expression], 1800.0 - 0.3 * 1000)
+
+        # One data query was issued per entity taking part in the expression
+        data_queries = [
+            call.args[0]
+            for call in mock_client_instance.query.call_args_list
+            if 'AND "entity_id"=' in call.args[0]
+        ]
+        self.assertTrue(any("'power_a'" in q for q in data_queries))
+        self.assertTrue(any("'power_b'" in q for q in data_queries))
+        mock_client_instance.close.assert_called_once()
+
+    @patch("influxdb.InfluxDBClient", autospec=True)
+    async def test_get_data_influxdb_expression_mixed(self, mock_influx_client_class):
+        """var_list may mix plain sensors and expressions, reusing cached queries."""
+        rh_influx = self._make_influxdb_rh()
+        mock_client_instance = mock_influx_client_class.return_value
+        mock_client_instance.query.side_effect = self._influx_query_side_effect(
+            {
+                "power_a": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 1500.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 1800.0},
+                ],
+                "power_b": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 500.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 450.0},
+                ],
+            }
+        )
+
+        days_list = pd.date_range(start="2023-04-01", periods=1, freq="D", tz="UTC")
+        expression = "{{'sensor.power_a' + 'sensor.power_b'}}"
+        var_list = ["sensor.power_a", expression]
+        success = await rh_influx.get_data(days_list, var_list)
+        self.assertTrue(success)
+
+        df = rh_influx.df_final
+        self.assertEqual(list(df.columns), var_list)
+        # The plain sensor keeps its raw values
+        self.assertAlmostEqual(df.loc["2023-04-01 10:00:00+00:00"]["sensor.power_a"], 1500.0)
+        # The expression column holds the element-wise sum
+        self.assertAlmostEqual(df.loc["2023-04-01 10:00:00+00:00"][expression], 2000.0)
+        self.assertAlmostEqual(df.loc["2023-04-01 10:30:00+00:00"][expression], 2250.0)
+
+        # power_a feeds both entries but is only queried once (cached)
+        power_a_queries = [
+            call.args[0]
+            for call in mock_client_instance.query.call_args_list
+            if 'AND "entity_id"=' in call.args[0] and "'power_a'" in call.args[0]
+        ]
+        self.assertEqual(len(power_a_queries), 1)
+
+    @patch("influxdb.InfluxDBClient", autospec=True)
+    async def test_get_data_influxdb_expression_missing_entity(self, mock_influx_client_class):
+        """An expression referencing a sensor with no data fails cleanly."""
+        rh_influx = self._make_influxdb_rh()
+        mock_client_instance = mock_influx_client_class.return_value
+        # power_missing exists in entity_data with no points (no data returned),
+        # while only power_a is advertised by SHOW TAG VALUES.
+        mock_client_instance.query.side_effect = self._influx_query_side_effect(
+            {
+                "power_a": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 1500.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 1800.0},
+                ],
+                "power_missing": [],
+            },
+            tag_values=["power_a"],
+        )
+
+        days_list = pd.date_range(start="2023-04-01", periods=1, freq="D", tz="UTC")
+        expression = "{{'sensor.power_a' + 'sensor.power_missing'}}"
+        success = await rh_influx.get_data(days_list, [expression])
+        self.assertFalse(success)
+
     # Test publish data
     async def test_publish_data(self):
         response, data = await self.rh.post_data(


### PR DESCRIPTION
Original Pull with full Sorcery review and diagrams in: https://github.com/dewi-ny-je/emhass/pull/1

**NOT TESTED YET, ONLY PROPOSAL FOR MAINTAINER**
It looks quite reasonable though!

Also, **test files not updated**, to be done at later stage.

### Motivation

- Enable `var_list` entries to express simple arithmetic between multiple InfluxDB time series (e.g. `{{'sensor.a' - 'sensor.b' * 1000}}`) so arithmetic can be performed server-side while retrieving data. 

### Description

- Added expression detection and parsing utilities: `_is_influx_expression`, `_extract_influx_expression_entities`, and `_evaluate_influx_expression` to detect `{{ ... }}` entries, extract quoted entity IDs, map them to safe tokens, and evaluate arithmetic over pandas `Series` using a restricted AST whitelist. 
- Updated `get_data_influxdb` to fetch each referenced entity once (per-entry caching via `sensor_cache`), build a `series_mapping` of tokens to fetched `Series`, evaluate expressions into a `DataFrame` column, and keep backward compatibility for plain sensor strings. 
- Added imports for `ast` and `re` and guarded expression evaluation to allow only arithmetic and numeric constants for safety. 

### Testing

- Ran a compilation check with `python -m compileall src/emhass/retrieve_hass.py`, which completed successfully. 
- No additional automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cb833f8e988332a115406855de727b)

## Summary by Sourcery

Support arithmetic expressions in InfluxDB variable definitions when retrieving data from InfluxDB and ensure failures are surfaced cleanly.

New Features:
- Allow InfluxDB var_list entries to be defined as arithmetic expressions over multiple time series using a {{ ... }} syntax.
- Introduce helpers to detect, parse, and safely evaluate arithmetic expressions that reference quoted entity IDs and operate on pandas Series.

Bug Fixes:
- Report and abort InfluxDB retrieval when any requested variables (sensors or expressions) fail to return data.

Enhancements:
- Cache InfluxDB sensor queries per entity to avoid redundant fetches when the same entity is used multiple times or across expressions.

## Summary by Sourcery

Support arithmetic expressions in InfluxDB variable retrieval and ensure retrieval fails cleanly when any requested variable has no data.

New Features:
- Allow InfluxDB var_list entries to be defined as arithmetic expressions over multiple time series using a {{ ... }} syntax.
- Provide helpers to detect, parse, and safely evaluate arithmetic expressions over pandas Series when fetching InfluxDB data.

Bug Fixes:
- Abort InfluxDB retrieval and log an error when any requested variables, including expressions, return no data.

Enhancements:
- Cache InfluxDB sensor queries per entity to avoid redundant fetches when entities are reused across variables and expressions.