### PR TITLE
Fix sticky header horizontal scroll position on initial show

### DIFF
--- a/src/emhass/static/script.js
+++ b/src/emhass/static/script.js
@@ -287,7 +287,7 @@ function initStickyTables() {
         table.getBoundingClientRect().bottom > 0;
       if (shouldShow !== shown) {
         shown = shouldShow;
-        wrapper.style.display = shouldShow ? "block" : "none";
+        wrapper.style.visibility = shouldShow ? "visible" : "hidden";
       }
     };
     window.addEventListener("scroll", updateVisibility, { passive: true });

--- a/src/emhass/static/style.css
+++ b/src/emhass/static/style.css
@@ -722,7 +722,7 @@ th {
   top: 0;
   overflow: hidden;
   z-index: 100;
-  display: none;
+  visibility: hidden;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
Small follow-up on #800:
When the table was scrolled horizontally while the header was still in the viewport (not sticky), and then the page was scrolled further down until the sticky header appeared, the horizontal scroll position of the sticky header was wrong. Scrolling a bit left or right immediately fixed it, but the experience wasn't smooth.

This PR fixes that and makes sure the initial scroll position of the sticky header is correct when the table was horizontally scrolled beforehand.

Root cause: display:none removes an element from layout, causing the browser to discard its scrollLeft. Switching to visibility:hidden keeps the wrapper in the DOM so its scrollLeft is always updated by the existing container scroll listener, even while hidden.

## Summary by Sourcery

Bug Fixes:
- Preserve the sticky header wrapper in the layout using visibility toggling so its horizontal scroll position stays in sync with the table before it becomes visible.