### PR TITLE
Pin currently-running single-constant loads to start of horizon

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -230,6 +230,20 @@ class Optimization:
             p.value = 0.0
             self.param_def_current_state.append(p)
 
+        # Running lower-bound masks for single-constant loads that are currently running.
+        # param_running_lb[k][t] = 1 forces p_def_bin2[k][t] = 1 (load must stay on).
+        # param_already_running_sc[k] = 1 suppresses the mandatory startup event so the
+        # solver doesn't try to turn the load off and back on to satisfy sum(starts)==1.
+        self.param_running_lb = []
+        self.param_already_running_sc = []
+        for k in range(num_def_loads):
+            lb = cp.Parameter(n, nonneg=True, name=f"running_lb_{k}")
+            lb.value = np.zeros(n)
+            self.param_running_lb.append(lb)
+            ar = cp.Parameter(nonneg=True, name=f"already_running_sc_{k}")
+            ar.value = 0.0
+            self.param_already_running_sc.append(ar)
+
         # Load active parameters: allows deactivating non-thermal loads with 0 operating
         # timesteps without rebuilding the problem. When param_load_active[k] = 0, all
         # binary variables for load k are forced to 0 by constraints, letting the solver
@@ -2025,10 +2039,24 @@ class Optimization:
                 if not is_sequence_load:
                     # Single Constant Start
                     if is_single_const:
-                        # Use param_load_active so inactive loads require 0 starts
-                        # (avoids solver branching on where to place a meaningless startup)
+                        # Force ON for the initial run when the load is already running.
+                        # param_running_lb[k][t] = 1 for t in [0, remaining_steps).
+                        if k < len(self.param_running_lb):
+                            constraints.append(p_def_bin2[k] >= self.param_running_lb[k])
+
+                        # Startup count: normally exactly 1 per active load.
+                        # Subtract param_already_running_sc so a currently-running load
+                        # requires 0 new starts (it never turned off within the horizon).
                         if k < len(self.param_load_active):
-                            constraints.append(cp.sum(p_def_start[k]) == self.param_load_active[k])
+                            already_running = (
+                                self.param_already_running_sc[k]
+                                if k < len(self.param_already_running_sc)
+                                else 0
+                            )
+                            constraints.append(
+                                cp.sum(p_def_start[k])
+                                == self.param_load_active[k] - already_running
+                            )
                         else:
                             constraints.append(cp.sum(p_def_start[k]) == 1)
 
@@ -2422,6 +2450,10 @@ class Optimization:
                 if params["type"] == "thermal_battery":
                     self.heating_demands[k] = params["heating_demand"].value
 
+        # Update def_current_state parameters before the per-load loop so that
+        # param_def_current_state[k].value is current when the pinning block reads it.
+        self._update_def_current_state_params(num_deferrable_loads)
+
         # Update Energy Constraint Parameters for Deferrable Loads
         # These control the Big-M relaxation of energy/timestep constraints
         for k in range(min(num_deferrable_loads, len(self.param_target_energy))):
@@ -2468,6 +2500,68 @@ class Optimization:
                 self.param_required_timesteps[k].value = 0.0
                 self.param_timesteps_active[k].value = 0.0  # Constraint is relaxed (Big-M)
 
+            # Pin currently-running single-constant loads to ON for their remaining timesteps.
+            # If the load is already on and single-constant, force p_def_bin2[k] = 1 for
+            # the first required_timesteps slots and suppress the startup event (already on).
+            # Also widen the window mask so the forced-on period is never blocked.
+            if k < len(self.param_running_lb):
+                current_state = (
+                    self.param_def_current_state[k].value > 0.5
+                    if k < len(self.param_def_current_state)
+                    else False
+                )
+                if (
+                    is_single_const
+                    and current_state
+                    and constraint_active
+                    and required_timesteps > 0
+                ):
+                    # Re-derive the configured window end so we respect def_end_timestep.
+                    if def_total_timestep and def_total_timestep[k] > 0:
+                        _, cfg_end, _ = Optimization.validate_def_timewindow(
+                            def_start_timestep[k],
+                            def_end_timestep[k],
+                            ceil(def_total_timestep[k]),
+                            n,
+                        )
+                    else:
+                        _, cfg_end, _ = Optimization.validate_def_timewindow(
+                            def_start_timestep[k],
+                            def_end_timestep[k],
+                            ceil(def_total_hours[k] / self.time_step)
+                            if def_total_hours[k] > 0
+                            else 0,
+                            n,
+                        )
+                    # cfg_end == 0 means no window restriction → treat as full horizon.
+                    effective_end = cfg_end if cfg_end > 0 else n
+                    pinned_steps = min(required_timesteps, effective_end, n)
+
+                    lb_mask = np.zeros(n)
+                    lb_mask[:pinned_steps] = 1.0
+                    self.param_running_lb[k].value = lb_mask
+                    self.param_already_running_sc[k].value = 1.0
+
+                    # Widen the window mask's start to 0 (load is running now),
+                    # but never extend past the configured end timestep.
+                    if k < len(self.param_window_masks):
+                        wm = self.param_window_masks[k].value.copy()
+                        wm[:pinned_steps] = 1.0
+                        self.param_window_masks[k].value = wm
+
+                    self.logger.debug(
+                        "Deferrable load %d: currently running, pinning %d timesteps ON "
+                        "(requested %d, window end %d, horizon %d)",
+                        k,
+                        pinned_steps,
+                        required_timesteps,
+                        effective_end,
+                        n,
+                    )
+                else:
+                    self.param_running_lb[k].value = np.zeros(n)
+                    self.param_already_running_sc[k].value = 0.0
+
         # Update load active parameters: deactivate non-thermal loads with 0 operating timesteps
         # Thermal loads (thermal_config, thermal_battery) are always active since they're
         # driven by temperature constraints, not operating timesteps.
@@ -2484,8 +2578,6 @@ class Optimization:
                     f"Deferrable load {k}: deactivated (no operating timesteps, not thermal)"
                 )
 
-        # Update def_current_state parameters for deferrable loads
-        self._update_def_current_state_params(num_deferrable_loads)
         # Initialize stress config variables (needed by retry path even when
         # self.prob is cached from a previous call, see #770)
         inv_stress_conf = None

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1396,6 +1396,132 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             check_names=False,
         )
 
+    def test_running_single_const_pinned_from_start(self):
+        """A running single-constant load is pinned ON from t=0 regardless of cost."""
+        # Cheap at t=5..9, expensive at t=0..4 — without pinning the solver would defer.
+        self.fcst.params["passed_data"]["load_cost_forecast"] = [
+            2,
+            2,
+            2,
+            2,
+            2,
+            1,
+            1,
+            1,
+            1,
+            1,
+        ]
+        self.optim_conf.update(
+            {
+                "set_deferrable_load_single_constant": [True],
+                "def_current_state": [True],
+            }
+        )
+
+        self.run_penalty_test_forecast()  # 5-step load, no window restriction
+
+        nominal = self.optim_conf["nominal_power_of_deferrable_loads"][0]
+        assert_series_equal(
+            self.opt_res_dayahead["P_deferrable0"],
+            nominal * pd.Series([1, 1, 1, 1, 1, 0, 0, 0, 0, 0], index=self.opt_res_dayahead.index),
+            check_names=False,
+        )
+        self.assertTrue(np.all(self.opt.param_running_lb[0].value[:5] == 1.0))
+        self.assertTrue(np.all(self.opt.param_running_lb[0].value[5:] == 0.0))
+        self.assertEqual(self.opt.param_already_running_sc[0].value, 1.0)
+
+    def test_not_running_single_const_not_pinned(self):
+        """A single-constant load that is NOT currently running is freely scheduled."""
+        self.fcst.params["passed_data"]["load_cost_forecast"] = [
+            2,
+            2,
+            2,
+            2,
+            2,
+            1,
+            1,
+            1,
+            1,
+            1,
+        ]
+        self.optim_conf.update(
+            {
+                "set_deferrable_load_single_constant": [True],
+                "def_current_state": [False],
+            }
+        )
+
+        self.run_penalty_test_forecast()
+
+        nominal = self.optim_conf["nominal_power_of_deferrable_loads"][0]
+        assert_series_equal(
+            self.opt_res_dayahead["P_deferrable0"],
+            nominal * pd.Series([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], index=self.opt_res_dayahead.index),
+            check_names=False,
+        )
+        self.assertTrue(np.all(self.opt.param_running_lb[0].value == 0.0))
+        self.assertEqual(self.opt.param_already_running_sc[0].value, 0.0)
+
+    def _run_single_const_with_window(
+        self, def_total_timestep, def_end_timestep, current_state=True
+    ):
+        """Helper: run a single-constant load optimization with explicit window bounds."""
+        self.optim_conf.update(
+            {
+                "set_deferrable_load_single_constant": [True],
+                "def_current_state": [current_state],
+                "number_of_deferrable_loads": 1,
+            }
+        )
+        self.opt = self.create_optimization()
+        prediction_horizon = 10
+        attributes = vars(self.fcst).copy()
+        attributes["params"]["passed_data"]["load_cost_forecast"] = [1] * prediction_horizon
+        attributes["params"]["passed_data"]["prod_price_forecast"] = [0] * prediction_horizon
+        attributes["params"]["passed_data"]["solar_forecast_kwp"] = [0] * prediction_horizon
+        attributes["params"]["passed_data"]["prediction_horizon"] = prediction_horizon
+        fcst = Forecast(
+            self.retrieve_hass_conf,
+            self.optim_conf,
+            self.plant_conf,
+            attributes["params"],
+            emhass_conf,
+            logger,
+            get_data_from_file=True,
+        )
+        df = fcst.get_load_cost_forecast(self.df_input_data_dayahead, method="list")
+        df = fcst.get_prod_price_forecast(df, method="list")
+        return self.opt.perform_naive_mpc_optim(
+            df,
+            self.p_pv_forecast,
+            self.p_load_forecast,
+            prediction_horizon,
+            def_total_hours=None,
+            def_total_timestep=[def_total_timestep],
+            def_start_timestep=[0],
+            def_end_timestep=[def_end_timestep],
+        )
+
+    def test_running_single_const_window_end_caps_pinning(self):
+        """param_running_lb stops at def_end_timestep, not at required_timesteps."""
+        # 3-step load, window ends at t=6 → pinned_steps = min(3, 6, 10) = 3
+        self._run_single_const_with_window(def_total_timestep=3, def_end_timestep=6)
+
+        self.assertTrue(np.all(self.opt.param_running_lb[0].value[:3] == 1.0))
+        self.assertTrue(np.all(self.opt.param_running_lb[0].value[3:] == 0.0))
+        # Window mask must cover [0, 3) but must not extend past step 6
+        wm = self.opt.param_window_masks[0].value
+        self.assertTrue(np.all(wm[:3] == 1.0))
+        self.assertEqual(wm[6], 0.0)
+
+    def test_running_single_const_required_exceeds_window_is_infeasible(self):
+        """required_timesteps=8 with window end=4 → solver reports infeasible."""
+        opt_res = self._run_single_const_with_window(def_total_timestep=8, def_end_timestep=4)
+        # Window admits only 4 slots; sum(p_def_bin2)==8 cannot be satisfied.
+        # On total failure perform_naive_mpc_optim returns a single-column DataFrame
+        # with only 'optim_status'.
+        self.assertNotIn("P_deferrable0", opt_res.columns)
+
     def test_perform_naive_mpc_optim_def_total_timestep(self):
         """Test operating_timesteps_of_each_deferrable_load parameter.
 


### PR DESCRIPTION
When a deferrable load has set_deferrable_load_single_constant=True and def_current_state=True, force it ON for the first min(remaining, window_end) timesteps and suppress the startup event so the solver does not try to turn it off and back on.

This avoids having to manually update start/end times in HA if a load is already running, and might partially help with #605.

NOTE: I don't have much context in this area, created this PR using claude code and tested it for a couple of weeks locally

## Details

- Add param_running_lb (vector) and param_already_running_sc (scalar) CVXPY parameters per load to carry the pinning state across warm-start cycles.
- Widen the window mask's start to t=0 (load is running now) without extending past the configured def_end_timestep.
- Subtract param_already_running_sc from the startup-count equality so a currently-running load requires 0 new starts instead of 1.
- Add four tests covering: forced start despite higher cost, non-running load is unaffected, window-end caps the pinned range, and infeasibility when required_timesteps exceeds the window length.

## Summary by Sourcery

Pin currently running single-constant deferrable loads to remain on from the start of the horizon and adjust startup constraints so already-running loads do not require an additional start.

New Features:
- Introduce per-load parameters to enforce a running lower bound and track already-running single-constant loads across optimization warm starts.

Bug Fixes:
- Prevent the optimizer from turning an already-running single-constant load off and back on to satisfy startup-count constraints.
- Ensure window masks and pinning respect configured deferrable load end timesteps, making problems infeasible when required runtime exceeds the allowed window.

Enhancements:
- Update deferrable load state parameters earlier in the optimization update flow so pinning logic sees the current running state.

Tests:
- Add tests covering pinned behavior of running single-constant loads, non-pinning when loads are not running, interaction with window end bounds, and infeasibility when required timesteps exceed the window.