### PR TITLE
feat(logging): runtime banner + per-stage timings (closes #793)

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -854,25 +854,43 @@ async def _get_naive_mpc_pv_forecast(ctx: SetupContext, set_mix_forecast, df_inp
     return p_pv_forecast, df_weather
 
 
-async def _prepare_naive_mpc_optim(ctx: SetupContext):
-    """Helper to prepare data for Naive MPC optimization."""
+async def _prepare_naive_mpc_optim(ctx: SetupContext, stage_times: dict | None = None):
+    """Helper to prepare data for Naive MPC optimization.
+
+    :param stage_times: Optional dict to record per-stage elapsed times (seconds).
+    :type stage_times: dict, optional
+    """
+    if stage_times is None:
+        stage_times = {}
     # Retrieve Historical Data
     success, df_input_data, days_list, set_mix_forecast = await _get_naive_mpc_history(ctx)
     if not success:
         return None
     # Get PV Forecast
-    p_pv_forecast, df_weather = await _get_naive_mpc_pv_forecast(
-        ctx, set_mix_forecast, df_input_data
-    )
+    _t0 = time.perf_counter()
+    try:
+        p_pv_forecast, df_weather = await _get_naive_mpc_pv_forecast(
+            ctx, set_mix_forecast, df_input_data
+        )
+    finally:
+        _dt = time.perf_counter() - _t0
+        stage_times["pv_forecast"] = _dt
+        ctx.logger.debug(f"Stage [pv_forecast] completed in {_dt:.3f}s")
     if p_pv_forecast is None:
         return None
     # Get Load Forecast
-    p_load_forecast = await ctx.fcst.get_load_forecast(
-        days_min_load_forecast=ctx.optim_conf["delta_forecast_daily"].days,
-        method=ctx.optim_conf["load_forecast_method"],
-        set_mix_forecast=set_mix_forecast,
-        df_now=df_input_data,
-    )
+    _t0 = time.perf_counter()
+    try:
+        p_load_forecast = await ctx.fcst.get_load_forecast(
+            days_min_load_forecast=ctx.optim_conf["delta_forecast_daily"].days,
+            method=ctx.optim_conf["load_forecast_method"],
+            set_mix_forecast=set_mix_forecast,
+            df_now=df_input_data,
+        )
+    finally:
+        _dt = time.perf_counter() - _t0
+        stage_times["load_forecast"] = _dt
+        ctx.logger.debug(f"Stage [load_forecast] completed in {_dt:.3f}s")
     if isinstance(p_load_forecast, bool) and not p_load_forecast:
         return None
     # Build and Format Input DataFrame
@@ -1134,29 +1152,24 @@ async def set_input_data_dict(
         # Perfect uses historical HA data; no input_data stage timing —
         # price_prep / optim_solve / publish are timed inside perfect_forecast_optim.
         result = await _prepare_perfect_optim(ctx)
+    elif set_type == "naive-mpc-optim":
+        # Naive MPC uses granular per-stage timing inside _prepare_naive_mpc_optim;
+        # no coarse outer wrap here to avoid double-counting.
+        result = await _prepare_naive_mpc_optim(ctx, stage_times=stage_times)
+    elif set_type in ["forecast-model-fit", "forecast-model-predict", "forecast-model-tune"]:
+        result = await _prepare_ml_fit_predict(ctx)
+    elif set_type == "regressor-model-fit":
+        result = _prepare_regressor_fit(ctx)
+    elif set_type == "regressor-model-predict":
+        if get_data_from_file:
+            result = _prepare_regressor_fit(ctx)
+        else:
+            result = {}
+    elif set_type == "publish-data" or set_type == "export-influxdb-to-csv":
+        result = {}
     else:
-        _t0_input_data = time.perf_counter()
-        try:
-            if set_type == "naive-mpc-optim":
-                result = await _prepare_naive_mpc_optim(ctx)
-            elif set_type in ["forecast-model-fit", "forecast-model-predict", "forecast-model-tune"]:
-                result = await _prepare_ml_fit_predict(ctx)
-            elif set_type == "regressor-model-fit":
-                result = _prepare_regressor_fit(ctx)
-            elif set_type == "regressor-model-predict":
-                if get_data_from_file:
-                    result = _prepare_regressor_fit(ctx)
-                else:
-                    result = {}
-            elif set_type == "publish-data" or set_type == "export-influxdb-to-csv":
-                result = {}
-            else:
-                logger.error(f"The passed action set_type parameter '{set_type}' is not valid")
-                result = {}
-        finally:
-            _dt_input_data = time.perf_counter() - _t0_input_data
-            stage_times["input_data"] = _dt_input_data
-            logger.debug(f"Stage [input_data] completed in {_dt_input_data:.3f}s")
+        logger.error(f"The passed action set_type parameter '{set_type}' is not valid")
+        result = {}
     if result is None:
         return False
     data_results.update(result)
@@ -1576,9 +1589,15 @@ async def naive_mpc_optim(
     """
     logger.info("Performing naive MPC optimization")
     # Prepare forecast data with costs, prices, outdoor temp, and GHI (with resolution warning)
-    df_input_data_dayahead = prepare_forecast_and_weather_data(
-        input_data_dict, logger, warn_on_resolution=True
-    )
+    _t0 = time.perf_counter()
+    try:
+        df_input_data_dayahead = prepare_forecast_and_weather_data(
+            input_data_dict, logger, warn_on_resolution=True
+        )
+    finally:
+        _dt = time.perf_counter() - _t0
+        input_data_dict["stage_times"]["price_prep"] = _dt
+        logger.debug(f"Stage [price_prep] completed in {_dt:.3f}s")
     if isinstance(df_input_data_dayahead, bool) and not df_input_data_dayahead:
         return False
     # The specifics params for the MPC at runtime
@@ -1600,18 +1619,24 @@ async def naive_mpc_optim(
     def_end_timestep = input_data_dict["params"]["optim_conf"][
         "end_timesteps_of_each_deferrable_load"
     ]
-    opt_res_naive_mpc = input_data_dict["opt"].perform_naive_mpc_optim(
-        df_input_data_dayahead,
-        input_data_dict["p_pv_forecast"],
-        input_data_dict["p_load_forecast"],
-        prediction_horizon,
-        soc_init,
-        soc_final,
-        def_total_hours,
-        def_total_timestep,
-        def_start_timestep,
-        def_end_timestep,
-    )
+    _t0 = time.perf_counter()
+    try:
+        opt_res_naive_mpc = input_data_dict["opt"].perform_naive_mpc_optim(
+            df_input_data_dayahead,
+            input_data_dict["p_pv_forecast"],
+            input_data_dict["p_load_forecast"],
+            prediction_horizon,
+            soc_init,
+            soc_final,
+            def_total_hours,
+            def_total_timestep,
+            def_start_timestep,
+            def_end_timestep,
+        )
+    finally:
+        _dt = time.perf_counter() - _t0
+        input_data_dict["stage_times"]["optim_solve"] = _dt
+        logger.debug(f"Stage [optim_solve] completed in {_dt:.3f}s")
     # Save CSV file for publish_data
     if save_data_to_file:
         today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1633,8 +1658,24 @@ async def naive_mpc_optim(
     if input_data_dict["retrieve_hass_conf"].get("continual_publish", False) or params[
         "passed_data"
     ].get("entity_save", False):
-        # Trigger the publish function, save entity data and not post to HA
-        await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
+        _t0 = time.perf_counter()
+        try:
+            # Trigger the publish function, save entity data and not post to HA
+            await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
+        finally:
+            _dt = time.perf_counter() - _t0
+            input_data_dict["stage_times"]["publish"] = _dt
+            logger.debug(f"Stage [publish] completed in {_dt:.3f}s")
+
+    stage_times = input_data_dict.get("stage_times", {})
+    if stage_times:
+        total = sum(stage_times.values())
+        top_name, top_s = max(stage_times.items(), key=lambda x: x[1])
+        pct = int(100 * top_s / total) if total > 0 else 0
+        logger.info(
+            f"Optimization completed in {total:.1f}s "
+            f"(top: {top_name}={top_s:.1f}s, {pct}%)"
+        )
 
     return opt_res_naive_mpc
 

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -1233,10 +1233,7 @@ def _log_optimization_summary(input_data_dict: dict, logger: logging.Logger) -> 
     total = sum(stage_times.values())
     top_name, top_s = max(stage_times.items(), key=lambda x: x[1])
     pct = int(100 * top_s / total) if total > 0 else 0
-    logger.info(
-        f"Optimization completed in {total:.1f}s "
-        f"(top: {top_name}={top_s:.1f}s, {pct}%)"
-    )
+    logger.info(f"Optimization completed in {total:.1f}s (top: {top_name}={top_s:.1f}s, {pct}%)")
 
 
 async def perfect_forecast_optim(

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -8,7 +8,6 @@ import os
 import pathlib
 import pickle
 import threading
-import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from importlib.metadata import version
@@ -19,7 +18,7 @@ import orjson
 import pandas as pd
 
 from emhass import utils
-from emhass.utils import log_runtime_banner
+from emhass.utils import log_runtime_banner, stage_timer
 from emhass.forecast import Forecast
 from emhass.machine_learning_forecaster import MLForecaster
 from emhass.machine_learning_regressor import MLRegressor
@@ -755,26 +754,16 @@ async def _prepare_dayahead_optim(ctx: SetupContext, stage_times: dict | None = 
     if stage_times is None:
         stage_times = {}
     # Get PV Forecast
-    _t0 = time.perf_counter()
-    try:
+    with stage_timer(stage_times, "pv_forecast", ctx.logger):
         p_pv_forecast, df_weather = await _get_dayahead_pv_forecast(ctx)
-    finally:
-        _dt = time.perf_counter() - _t0
-        stage_times["pv_forecast"] = _dt
-        ctx.logger.debug(f"Stage [pv_forecast] completed in {_dt:.3f}s")
     if p_pv_forecast is None:
         return None
     # Get Load Forecast
-    _t0 = time.perf_counter()
-    try:
+    with stage_timer(stage_times, "load_forecast", ctx.logger):
         p_load_forecast = await ctx.fcst.get_load_forecast(
             days_min_load_forecast=ctx.optim_conf["delta_forecast_daily"].days,
             method=ctx.optim_conf["load_forecast_method"],
         )
-    finally:
-        _dt = time.perf_counter() - _t0
-        stage_times["load_forecast"] = _dt
-        ctx.logger.debug(f"Stage [load_forecast] completed in {_dt:.3f}s")
     if isinstance(p_load_forecast, bool) and not p_load_forecast:
         ctx.logger.error("Unable to get load forecast.")
         return None
@@ -867,30 +856,20 @@ async def _prepare_naive_mpc_optim(ctx: SetupContext, stage_times: dict | None =
     if not success:
         return None
     # Get PV Forecast
-    _t0 = time.perf_counter()
-    try:
+    with stage_timer(stage_times, "pv_forecast", ctx.logger):
         p_pv_forecast, df_weather = await _get_naive_mpc_pv_forecast(
             ctx, set_mix_forecast, df_input_data
         )
-    finally:
-        _dt = time.perf_counter() - _t0
-        stage_times["pv_forecast"] = _dt
-        ctx.logger.debug(f"Stage [pv_forecast] completed in {_dt:.3f}s")
     if p_pv_forecast is None:
         return None
     # Get Load Forecast
-    _t0 = time.perf_counter()
-    try:
+    with stage_timer(stage_times, "load_forecast", ctx.logger):
         p_load_forecast = await ctx.fcst.get_load_forecast(
             days_min_load_forecast=ctx.optim_conf["delta_forecast_daily"].days,
             method=ctx.optim_conf["load_forecast_method"],
             set_mix_forecast=set_mix_forecast,
             df_now=df_input_data,
         )
-    finally:
-        _dt = time.perf_counter() - _t0
-        stage_times["load_forecast"] = _dt
-        ctx.logger.debug(f"Stage [load_forecast] completed in {_dt:.3f}s")
     if isinstance(p_load_forecast, bool) and not p_load_forecast:
         return None
     # Build and Format Input DataFrame
@@ -1283,8 +1262,7 @@ async def perfect_forecast_optim(
     """
     logger.info("Performing perfect forecast optimization")
     # Load cost and prod price forecast
-    _t0 = time.perf_counter()
-    try:
+    with stage_timer(input_data_dict["stage_times"], "price_prep", logger):
         df_input_data = input_data_dict["fcst"].get_load_cost_forecast(
             input_data_dict["df_input_data"],
             method=input_data_dict["fcst"].optim_conf["load_cost_forecast_method"],
@@ -1297,21 +1275,12 @@ async def perfect_forecast_optim(
             method=input_data_dict["fcst"].optim_conf["production_price_forecast_method"],
             list_and_perfect=True,
         )
-    finally:
-        _dt = time.perf_counter() - _t0
-        input_data_dict["stage_times"]["price_prep"] = _dt
-        logger.debug(f"Stage [price_prep] completed in {_dt:.3f}s")
     if isinstance(df_input_data, bool) and not df_input_data:
         return False
-    _t0 = time.perf_counter()
-    try:
+    with stage_timer(input_data_dict["stage_times"], "optim_solve", logger):
         opt_res = input_data_dict["opt"].perform_perfect_forecast_optim(
             df_input_data, input_data_dict["days_list"]
         )
-    finally:
-        _dt = time.perf_counter() - _t0
-        input_data_dict["stage_times"]["optim_solve"] = _dt
-        logger.debug(f"Stage [optim_solve] completed in {_dt:.3f}s")
     # Save CSV file for analysis
     if save_data_to_file:
         filename = "opt_res_perfect_optim_" + input_data_dict["costfun"] + ".csv"
@@ -1331,14 +1300,9 @@ async def perfect_forecast_optim(
     if input_data_dict["retrieve_hass_conf"].get("continual_publish", False) or params[
         "passed_data"
     ].get("entity_save", False):
-        _t0 = time.perf_counter()
-        try:
+        with stage_timer(input_data_dict["stage_times"], "publish", logger):
             # Trigger the publish function, save entity data and not post to HA
             await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
-        finally:
-            _dt = time.perf_counter() - _t0
-            input_data_dict["stage_times"]["publish"] = _dt
-            logger.debug(f"Stage [publish] completed in {_dt:.3f}s")
 
     _log_optimization_summary(input_data_dict, logger)
 
@@ -1511,28 +1475,18 @@ async def dayahead_forecast_optim(
     """
     logger.info("Performing day-ahead forecast optimization")
     # Prepare forecast data with costs, prices, outdoor temp, and GHI
-    _t0 = time.perf_counter()
-    try:
+    with stage_timer(input_data_dict["stage_times"], "price_prep", logger):
         df_input_data_dayahead = prepare_forecast_and_weather_data(
             input_data_dict, logger, warn_on_resolution=False
         )
-    finally:
-        _dt = time.perf_counter() - _t0
-        input_data_dict["stage_times"]["price_prep"] = _dt
-        logger.debug(f"Stage [price_prep] completed in {_dt:.3f}s")
     if isinstance(df_input_data_dayahead, bool) and not df_input_data_dayahead:
         return False
-    _t0 = time.perf_counter()
-    try:
+    with stage_timer(input_data_dict["stage_times"], "optim_solve", logger):
         opt_res_dayahead = input_data_dict["opt"].perform_dayahead_forecast_optim(
             df_input_data_dayahead,
             input_data_dict["p_pv_forecast"],
             input_data_dict["p_load_forecast"],
         )
-    finally:
-        _dt = time.perf_counter() - _t0
-        input_data_dict["stage_times"]["optim_solve"] = _dt
-        logger.debug(f"Stage [optim_solve] completed in {_dt:.3f}s")
     # Save CSV file for publish_data
     if save_data_to_file:
         today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1554,14 +1508,9 @@ async def dayahead_forecast_optim(
     if input_data_dict["retrieve_hass_conf"].get("continual_publish", False) or params[
         "passed_data"
     ].get("entity_save", False):
-        _t0 = time.perf_counter()
-        try:
+        with stage_timer(input_data_dict["stage_times"], "publish", logger):
             # Trigger the publish function, save entity data and not post to HA
             await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
-        finally:
-            _dt = time.perf_counter() - _t0
-            input_data_dict["stage_times"]["publish"] = _dt
-            logger.debug(f"Stage [publish] completed in {_dt:.3f}s")
 
     _log_optimization_summary(input_data_dict, logger)
 
@@ -1591,15 +1540,10 @@ async def naive_mpc_optim(
     """
     logger.info("Performing naive MPC optimization")
     # Prepare forecast data with costs, prices, outdoor temp, and GHI (with resolution warning)
-    _t0 = time.perf_counter()
-    try:
+    with stage_timer(input_data_dict["stage_times"], "price_prep", logger):
         df_input_data_dayahead = prepare_forecast_and_weather_data(
             input_data_dict, logger, warn_on_resolution=True
         )
-    finally:
-        _dt = time.perf_counter() - _t0
-        input_data_dict["stage_times"]["price_prep"] = _dt
-        logger.debug(f"Stage [price_prep] completed in {_dt:.3f}s")
     if isinstance(df_input_data_dayahead, bool) and not df_input_data_dayahead:
         return False
     # The specifics params for the MPC at runtime
@@ -1621,8 +1565,7 @@ async def naive_mpc_optim(
     def_end_timestep = input_data_dict["params"]["optim_conf"][
         "end_timesteps_of_each_deferrable_load"
     ]
-    _t0 = time.perf_counter()
-    try:
+    with stage_timer(input_data_dict["stage_times"], "optim_solve", logger):
         opt_res_naive_mpc = input_data_dict["opt"].perform_naive_mpc_optim(
             df_input_data_dayahead,
             input_data_dict["p_pv_forecast"],
@@ -1635,10 +1578,6 @@ async def naive_mpc_optim(
             def_start_timestep,
             def_end_timestep,
         )
-    finally:
-        _dt = time.perf_counter() - _t0
-        input_data_dict["stage_times"]["optim_solve"] = _dt
-        logger.debug(f"Stage [optim_solve] completed in {_dt:.3f}s")
     # Save CSV file for publish_data
     if save_data_to_file:
         today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1660,14 +1599,9 @@ async def naive_mpc_optim(
     if input_data_dict["retrieve_hass_conf"].get("continual_publish", False) or params[
         "passed_data"
     ].get("entity_save", False):
-        _t0 = time.perf_counter()
-        try:
+        with stage_timer(input_data_dict["stage_times"], "publish", logger):
             # Trigger the publish function, save entity data and not post to HA
             await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
-        finally:
-            _dt = time.perf_counter() - _t0
-            input_data_dict["stage_times"]["publish"] = _dt
-            logger.debug(f"Stage [publish] completed in {_dt:.3f}s")
 
     _log_optimization_summary(input_data_dict, logger)
 

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -746,17 +746,35 @@ def _apply_df_freq_horizon(
     return df
 
 
-async def _prepare_dayahead_optim(ctx: SetupContext):
-    """Helper to prepare data for day-ahead optimization."""
+async def _prepare_dayahead_optim(ctx: SetupContext, stage_times: dict | None = None):
+    """Helper to prepare data for day-ahead optimization.
+
+    :param stage_times: Optional dict to record per-stage elapsed times (seconds).
+    :type stage_times: dict, optional
+    """
+    if stage_times is None:
+        stage_times = {}
     # Get PV Forecast
-    p_pv_forecast, df_weather = await _get_dayahead_pv_forecast(ctx)
+    _t0 = time.perf_counter()
+    try:
+        p_pv_forecast, df_weather = await _get_dayahead_pv_forecast(ctx)
+    finally:
+        _dt = time.perf_counter() - _t0
+        stage_times["pv_forecast"] = _dt
+        ctx.logger.debug(f"Stage [pv_forecast] completed in {_dt:.3f}s")
     if p_pv_forecast is None:
         return None
     # Get Load Forecast
-    p_load_forecast = await ctx.fcst.get_load_forecast(
-        days_min_load_forecast=ctx.optim_conf["delta_forecast_daily"].days,
-        method=ctx.optim_conf["load_forecast_method"],
-    )
+    _t0 = time.perf_counter()
+    try:
+        p_load_forecast = await ctx.fcst.get_load_forecast(
+            days_min_load_forecast=ctx.optim_conf["delta_forecast_daily"].days,
+            method=ctx.optim_conf["load_forecast_method"],
+        )
+    finally:
+        _dt = time.perf_counter() - _t0
+        stage_times["load_forecast"] = _dt
+        ctx.logger.debug(f"Stage [load_forecast] completed in {_dt:.3f}s")
     if isinstance(p_load_forecast, bool) and not p_load_forecast:
         ctx.logger.error("Unable to get load forecast.")
         return None
@@ -1108,32 +1126,35 @@ async def set_input_data_dict(
     }
     # Delegate to Helpers based on set_type
     result = None
-    _t0_input_data = time.perf_counter()
-    try:
-        if set_type == "perfect-optim":
-            result = await _prepare_perfect_optim(ctx)
-        elif set_type == "dayahead-optim":
-            result = await _prepare_dayahead_optim(ctx)
-        elif set_type == "naive-mpc-optim":
-            result = await _prepare_naive_mpc_optim(ctx)
-        elif set_type in ["forecast-model-fit", "forecast-model-predict", "forecast-model-tune"]:
-            result = await _prepare_ml_fit_predict(ctx)
-        elif set_type == "regressor-model-fit":
-            result = _prepare_regressor_fit(ctx)
-        elif set_type == "regressor-model-predict":
-            if get_data_from_file:
+    if set_type == "dayahead-optim":
+        # Dayahead uses granular per-stage timing inside _prepare_dayahead_optim;
+        # no coarse outer wrap here to avoid double-counting.
+        result = await _prepare_dayahead_optim(ctx, stage_times=stage_times)
+    else:
+        _t0_input_data = time.perf_counter()
+        try:
+            if set_type == "perfect-optim":
+                result = await _prepare_perfect_optim(ctx)
+            elif set_type == "naive-mpc-optim":
+                result = await _prepare_naive_mpc_optim(ctx)
+            elif set_type in ["forecast-model-fit", "forecast-model-predict", "forecast-model-tune"]:
+                result = await _prepare_ml_fit_predict(ctx)
+            elif set_type == "regressor-model-fit":
                 result = _prepare_regressor_fit(ctx)
-            else:
+            elif set_type == "regressor-model-predict":
+                if get_data_from_file:
+                    result = _prepare_regressor_fit(ctx)
+                else:
+                    result = {}
+            elif set_type == "publish-data" or set_type == "export-influxdb-to-csv":
                 result = {}
-        elif set_type == "publish-data" or set_type == "export-influxdb-to-csv":
-            result = {}
-        else:
-            logger.error(f"The passed action set_type parameter '{set_type}' is not valid")
-            result = {}
-    finally:
-        _dt_input_data = time.perf_counter() - _t0_input_data
-        stage_times["input_data"] = _dt_input_data
-        logger.debug(f"Stage [input_data] completed in {_dt_input_data:.3f}s")
+            else:
+                logger.error(f"The passed action set_type parameter '{set_type}' is not valid")
+                result = {}
+        finally:
+            _dt_input_data = time.perf_counter() - _t0_input_data
+            stage_times["input_data"] = _dt_input_data
+            logger.debug(f"Stage [input_data] completed in {_dt_input_data:.3f}s")
     if result is None:
         return False
     data_results.update(result)
@@ -1437,16 +1458,28 @@ async def dayahead_forecast_optim(
     """
     logger.info("Performing day-ahead forecast optimization")
     # Prepare forecast data with costs, prices, outdoor temp, and GHI
-    df_input_data_dayahead = prepare_forecast_and_weather_data(
-        input_data_dict, logger, warn_on_resolution=False
-    )
+    _t0 = time.perf_counter()
+    try:
+        df_input_data_dayahead = prepare_forecast_and_weather_data(
+            input_data_dict, logger, warn_on_resolution=False
+        )
+    finally:
+        _dt = time.perf_counter() - _t0
+        input_data_dict["stage_times"]["price_prep"] = _dt
+        logger.debug(f"Stage [price_prep] completed in {_dt:.3f}s")
     if isinstance(df_input_data_dayahead, bool) and not df_input_data_dayahead:
         return False
-    opt_res_dayahead = input_data_dict["opt"].perform_dayahead_forecast_optim(
-        df_input_data_dayahead,
-        input_data_dict["p_pv_forecast"],
-        input_data_dict["p_load_forecast"],
-    )
+    _t0 = time.perf_counter()
+    try:
+        opt_res_dayahead = input_data_dict["opt"].perform_dayahead_forecast_optim(
+            df_input_data_dayahead,
+            input_data_dict["p_pv_forecast"],
+            input_data_dict["p_load_forecast"],
+        )
+    finally:
+        _dt = time.perf_counter() - _t0
+        input_data_dict["stage_times"]["optim_solve"] = _dt
+        logger.debug(f"Stage [optim_solve] completed in {_dt:.3f}s")
     # Save CSV file for publish_data
     if save_data_to_file:
         today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1468,8 +1501,24 @@ async def dayahead_forecast_optim(
     if input_data_dict["retrieve_hass_conf"].get("continual_publish", False) or params[
         "passed_data"
     ].get("entity_save", False):
-        # Trigger the publish function, save entity data and not post to HA
-        await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
+        _t0 = time.perf_counter()
+        try:
+            # Trigger the publish function, save entity data and not post to HA
+            await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
+        finally:
+            _dt = time.perf_counter() - _t0
+            input_data_dict["stage_times"]["publish"] = _dt
+            logger.debug(f"Stage [publish] completed in {_dt:.3f}s")
+
+    stage_times = input_data_dict.get("stage_times", {})
+    if stage_times:
+        total = sum(stage_times.values())
+        top_name, top_s = max(stage_times.items(), key=lambda x: x[1])
+        pct = int(100 * top_s / total) if total > 0 else 0
+        logger.info(
+            f"Optimization completed in {total:.1f}s "
+            f"(top: {top_name}={top_s:.1f}s, {pct}%)"
+        )
 
     return opt_res_dayahead
 

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -1130,12 +1130,14 @@ async def set_input_data_dict(
         # Dayahead uses granular per-stage timing inside _prepare_dayahead_optim;
         # no coarse outer wrap here to avoid double-counting.
         result = await _prepare_dayahead_optim(ctx, stage_times=stage_times)
+    elif set_type == "perfect-optim":
+        # Perfect uses historical HA data; no input_data stage timing —
+        # price_prep / optim_solve / publish are timed inside perfect_forecast_optim.
+        result = await _prepare_perfect_optim(ctx)
     else:
         _t0_input_data = time.perf_counter()
         try:
-            if set_type == "perfect-optim":
-                result = await _prepare_perfect_optim(ctx)
-            elif set_type == "naive-mpc-optim":
+            if set_type == "naive-mpc-optim":
                 result = await _prepare_naive_mpc_optim(ctx)
             elif set_type in ["forecast-model-fit", "forecast-model-predict", "forecast-model-tune"]:
                 result = await _prepare_ml_fit_predict(ctx)
@@ -1250,23 +1252,35 @@ async def perfect_forecast_optim(
     """
     logger.info("Performing perfect forecast optimization")
     # Load cost and prod price forecast
-    df_input_data = input_data_dict["fcst"].get_load_cost_forecast(
-        input_data_dict["df_input_data"],
-        method=input_data_dict["fcst"].optim_conf["load_cost_forecast_method"],
-        list_and_perfect=True,
-    )
+    _t0 = time.perf_counter()
+    try:
+        df_input_data = input_data_dict["fcst"].get_load_cost_forecast(
+            input_data_dict["df_input_data"],
+            method=input_data_dict["fcst"].optim_conf["load_cost_forecast_method"],
+            list_and_perfect=True,
+        )
+        if isinstance(df_input_data, bool) and not df_input_data:
+            return False
+        df_input_data = input_data_dict["fcst"].get_prod_price_forecast(
+            df_input_data,
+            method=input_data_dict["fcst"].optim_conf["production_price_forecast_method"],
+            list_and_perfect=True,
+        )
+    finally:
+        _dt = time.perf_counter() - _t0
+        input_data_dict["stage_times"]["price_prep"] = _dt
+        logger.debug(f"Stage [price_prep] completed in {_dt:.3f}s")
     if isinstance(df_input_data, bool) and not df_input_data:
         return False
-    df_input_data = input_data_dict["fcst"].get_prod_price_forecast(
-        df_input_data,
-        method=input_data_dict["fcst"].optim_conf["production_price_forecast_method"],
-        list_and_perfect=True,
-    )
-    if isinstance(df_input_data, bool) and not df_input_data:
-        return False
-    opt_res = input_data_dict["opt"].perform_perfect_forecast_optim(
-        df_input_data, input_data_dict["days_list"]
-    )
+    _t0 = time.perf_counter()
+    try:
+        opt_res = input_data_dict["opt"].perform_perfect_forecast_optim(
+            df_input_data, input_data_dict["days_list"]
+        )
+    finally:
+        _dt = time.perf_counter() - _t0
+        input_data_dict["stage_times"]["optim_solve"] = _dt
+        logger.debug(f"Stage [optim_solve] completed in {_dt:.3f}s")
     # Save CSV file for analysis
     if save_data_to_file:
         filename = "opt_res_perfect_optim_" + input_data_dict["costfun"] + ".csv"
@@ -1286,8 +1300,24 @@ async def perfect_forecast_optim(
     if input_data_dict["retrieve_hass_conf"].get("continual_publish", False) or params[
         "passed_data"
     ].get("entity_save", False):
-        # Trigger the publish function, save entity data and not post to HA
-        await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
+        _t0 = time.perf_counter()
+        try:
+            # Trigger the publish function, save entity data and not post to HA
+            await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
+        finally:
+            _dt = time.perf_counter() - _t0
+            input_data_dict["stage_times"]["publish"] = _dt
+            logger.debug(f"Stage [publish] completed in {_dt:.3f}s")
+
+    stage_times = input_data_dict.get("stage_times", {})
+    if stage_times:
+        total = sum(stage_times.values())
+        top_name, top_s = max(stage_times.items(), key=lambda x: x[1])
+        pct = int(100 * top_s / total) if total > 0 else 0
+        logger.info(
+            f"Optimization completed in {total:.1f}s "
+            f"(top: {top_name}={top_s:.1f}s, {pct}%)"
+        )
 
     return opt_res
 

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -1242,6 +1242,24 @@ async def weather_forecast_cache(
     return True
 
 
+def _log_optimization_summary(input_data_dict: dict, logger: logging.Logger) -> None:
+    """Emit the one-line optimization summary (total elapsed + top stage).
+
+    Reads per-stage timings recorded by the orchestrators in ``input_data_dict["stage_times"]``.
+    No-op if no stages were recorded.
+    """
+    stage_times = input_data_dict.get("stage_times", {})
+    if not stage_times:
+        return
+    total = sum(stage_times.values())
+    top_name, top_s = max(stage_times.items(), key=lambda x: x[1])
+    pct = int(100 * top_s / total) if total > 0 else 0
+    logger.info(
+        f"Optimization completed in {total:.1f}s "
+        f"(top: {top_name}={top_s:.1f}s, {pct}%)"
+    )
+
+
 async def perfect_forecast_optim(
     input_data_dict: dict,
     logger: logging.Logger,
@@ -1322,15 +1340,7 @@ async def perfect_forecast_optim(
             input_data_dict["stage_times"]["publish"] = _dt
             logger.debug(f"Stage [publish] completed in {_dt:.3f}s")
 
-    stage_times = input_data_dict.get("stage_times", {})
-    if stage_times:
-        total = sum(stage_times.values())
-        top_name, top_s = max(stage_times.items(), key=lambda x: x[1])
-        pct = int(100 * top_s / total) if total > 0 else 0
-        logger.info(
-            f"Optimization completed in {total:.1f}s "
-            f"(top: {top_name}={top_s:.1f}s, {pct}%)"
-        )
+    _log_optimization_summary(input_data_dict, logger)
 
     return opt_res
 
@@ -1553,15 +1563,7 @@ async def dayahead_forecast_optim(
             input_data_dict["stage_times"]["publish"] = _dt
             logger.debug(f"Stage [publish] completed in {_dt:.3f}s")
 
-    stage_times = input_data_dict.get("stage_times", {})
-    if stage_times:
-        total = sum(stage_times.values())
-        top_name, top_s = max(stage_times.items(), key=lambda x: x[1])
-        pct = int(100 * top_s / total) if total > 0 else 0
-        logger.info(
-            f"Optimization completed in {total:.1f}s "
-            f"(top: {top_name}={top_s:.1f}s, {pct}%)"
-        )
+    _log_optimization_summary(input_data_dict, logger)
 
     return opt_res_dayahead
 
@@ -1667,15 +1669,7 @@ async def naive_mpc_optim(
             input_data_dict["stage_times"]["publish"] = _dt
             logger.debug(f"Stage [publish] completed in {_dt:.3f}s")
 
-    stage_times = input_data_dict.get("stage_times", {})
-    if stage_times:
-        total = sum(stage_times.values())
-        top_name, top_s = max(stage_times.items(), key=lambda x: x[1])
-        pct = int(100 * top_s / total) if total > 0 else 0
-        logger.info(
-            f"Optimization completed in {total:.1f}s "
-            f"(top: {top_name}={top_s:.1f}s, {pct}%)"
-        )
+    _log_optimization_summary(input_data_dict, logger)
 
     return opt_res_naive_mpc
 

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import pickle
 import threading
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from importlib.metadata import version
@@ -18,6 +19,7 @@ import orjson
 import pandas as pd
 
 from emhass import utils
+from emhass.utils import log_runtime_banner
 from emhass.forecast import Forecast
 from emhass.machine_learning_forecaster import MLForecaster
 from emhass.machine_learning_regressor import MLRegressor
@@ -966,6 +968,8 @@ async def set_input_data_dict(
     :rtype: dict
 
     """
+    log_runtime_banner(logger)
+    stage_times = {}
     logger.info("Setting up needed data")
     # Parse Parameters
     if (params is not None) and (params != "null"):
@@ -1104,26 +1108,32 @@ async def set_input_data_dict(
     }
     # Delegate to Helpers based on set_type
     result = None
-    if set_type == "perfect-optim":
-        result = await _prepare_perfect_optim(ctx)
-    elif set_type == "dayahead-optim":
-        result = await _prepare_dayahead_optim(ctx)
-    elif set_type == "naive-mpc-optim":
-        result = await _prepare_naive_mpc_optim(ctx)
-    elif set_type in ["forecast-model-fit", "forecast-model-predict", "forecast-model-tune"]:
-        result = await _prepare_ml_fit_predict(ctx)
-    elif set_type == "regressor-model-fit":
-        result = _prepare_regressor_fit(ctx)
-    elif set_type == "regressor-model-predict":
-        if get_data_from_file:
+    _t0_input_data = time.perf_counter()
+    try:
+        if set_type == "perfect-optim":
+            result = await _prepare_perfect_optim(ctx)
+        elif set_type == "dayahead-optim":
+            result = await _prepare_dayahead_optim(ctx)
+        elif set_type == "naive-mpc-optim":
+            result = await _prepare_naive_mpc_optim(ctx)
+        elif set_type in ["forecast-model-fit", "forecast-model-predict", "forecast-model-tune"]:
+            result = await _prepare_ml_fit_predict(ctx)
+        elif set_type == "regressor-model-fit":
             result = _prepare_regressor_fit(ctx)
-        else:
+        elif set_type == "regressor-model-predict":
+            if get_data_from_file:
+                result = _prepare_regressor_fit(ctx)
+            else:
+                result = {}
+        elif set_type == "publish-data" or set_type == "export-influxdb-to-csv":
             result = {}
-    elif set_type == "publish-data" or set_type == "export-influxdb-to-csv":
-        result = {}
-    else:
-        logger.error(f"The passed action set_type parameter '{set_type}' is not valid")
-        result = {}
+        else:
+            logger.error(f"The passed action set_type parameter '{set_type}' is not valid")
+            result = {}
+    finally:
+        _dt_input_data = time.perf_counter() - _t0_input_data
+        stage_times["input_data"] = _dt_input_data
+        logger.debug(f"Stage [input_data] completed in {_dt_input_data:.3f}s")
     if result is None:
         return False
     data_results.update(result)
@@ -1138,6 +1148,7 @@ async def set_input_data_dict(
         "fcst": fcst,
         "costfun": costfun,
         "params": params,
+        "stage_times": stage_times,
         **data_results,
     }
     return input_data_dict

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -1004,7 +1004,6 @@ async def set_input_data_dict(
     :rtype: dict
 
     """
-    log_runtime_banner(logger)
     stage_times = {}
     logger.info("Setting up needed data")
     # Parse Parameters
@@ -1031,6 +1030,7 @@ async def set_input_data_dict(
         logger,
         emhass_conf,
     )
+    log_runtime_banner(logger, optim_conf=optim_conf)
     if isinstance(params, str):
         params = dict(orjson.loads(params))
     # Initialize Core Objects

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -2635,16 +2635,31 @@ def resample_and_filter_data(
         return False
 
 
-def log_runtime_banner(logger):
-    """Log a single INFO line with EMHASS/Python/CVXPY/platform info for bug-report reproducibility."""
+def log_runtime_banner(logger, optim_conf: dict | None = None):
+    """Log a single INFO line with EMHASS/Python/CVXPY/platform info for bug-report reproducibility.
+
+    When ``optim_conf`` is provided and contains an ``lp_solver`` key, the
+    configured solver is shown (this is the one actually used by the LP).
+    Otherwise falls back to ``cvxpy.installed_solvers()[0]`` — useful for
+    early-fail paths where config is not yet available.
+    """
     try:
         import platform as _plat
         import cvxpy as _cvx
         from importlib.metadata import version as _pkg_version
 
         _ver = _pkg_version("emhass")
-        solvers = _cvx.installed_solvers()
-        solver = solvers[0] if solvers else "none"
+        active = None
+        try:
+            if isinstance(optim_conf, dict) and "lp_solver" in optim_conf:
+                active = str(optim_conf["lp_solver"])
+        except Exception:
+            active = None
+        if active:
+            solver = active
+        else:
+            solvers = _cvx.installed_solvers()
+            solver = solvers[0] if solvers else "none"
         logger.info(
             f"EMHASS {_ver} | Python {_plat.python_version()} | "
             f"CVXPY {_cvx.__version__} ({solver}) | "

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -7,6 +7,8 @@ import logging
 import os
 import pathlib
 import shutil
+import time
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -2633,6 +2635,23 @@ def resample_and_filter_data(
     except Exception as e:
         logger.error(f"Error during resampling: {e}")
         return False
+
+
+@contextmanager
+def stage_timer(stage_times: dict, name: str, logger: logging.Logger | None = None):
+    """Record wall-clock elapsed time of a block in ``stage_times[name]``.
+
+    Emits one DEBUG line per stage when ``logger`` is provided. Works across
+    ``await`` because ``time.perf_counter()`` is a plain monotonic read.
+    """
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        dt = time.perf_counter() - t0
+        stage_times[name] = dt
+        if logger is not None:
+            logger.debug(f"Stage [{name}] completed in {dt:.3f}s")
 
 
 def log_runtime_banner(logger, optim_conf: dict | None = None):

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -2682,6 +2682,7 @@ def log_runtime_banner(logger, optim_conf: dict | None = None):
     except Exception as err:
         try:
             from importlib.metadata import version as _pkg_version
+
             _ver = _pkg_version("emhass")
             logger.info(f"EMHASS {_ver} (runtime info unavailable: {err})")
         except Exception:

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -2633,3 +2633,27 @@ def resample_and_filter_data(
     except Exception as e:
         logger.error(f"Error during resampling: {e}")
         return False
+
+
+def log_runtime_banner(logger):
+    """Log a single INFO line with EMHASS/Python/CVXPY/platform info for bug-report reproducibility."""
+    try:
+        import platform as _plat
+        import cvxpy as _cvx
+        from importlib.metadata import version as _pkg_version
+
+        _ver = _pkg_version("emhass")
+        solvers = _cvx.installed_solvers()
+        solver = solvers[0] if solvers else "none"
+        logger.info(
+            f"EMHASS {_ver} | Python {_plat.python_version()} | "
+            f"CVXPY {_cvx.__version__} ({solver}) | "
+            f"{_plat.system()}-{_plat.machine()}"
+        )
+    except Exception as err:
+        try:
+            from importlib.metadata import version as _pkg_version
+            _ver = _pkg_version("emhass")
+            logger.info(f"EMHASS {_ver} (runtime info unavailable: {err})")
+        except Exception:
+            logger.info("EMHASS (runtime info unavailable)")

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -2657,10 +2657,11 @@ def stage_timer(stage_times: dict, name: str, logger: logging.Logger | None = No
 def log_runtime_banner(logger, optim_conf: dict | None = None):
     """Log a single INFO line with EMHASS/Python/CVXPY/platform info for bug-report reproducibility.
 
-    When ``optim_conf`` is provided and contains an ``lp_solver`` key, the
-    configured solver is shown (this is the one actually used by the LP).
-    Otherwise falls back to ``cvxpy.installed_solvers()[0]`` — useful for
-    early-fail paths where config is not yet available.
+    When ``optim_conf`` is provided, the configured solver (or the EMHASS
+    default ``Highs`` when the key is absent) is shown — this matches the
+    solver the LP actually uses (see ``optimization.py`` constructor).
+    When ``optim_conf`` is missing entirely (early-fail paths), falls back
+    to ``cvxpy.installed_solvers()[0]``.
     """
     try:
         import platform as _plat
@@ -2668,8 +2669,8 @@ def log_runtime_banner(logger, optim_conf: dict | None = None):
         from importlib.metadata import version as _pkg_version
 
         _ver = _pkg_version("emhass")
-        if isinstance(optim_conf, dict) and "lp_solver" in optim_conf:
-            solver = str(optim_conf["lp_solver"])
+        if isinstance(optim_conf, dict):
+            solver = str(optim_conf.get("lp_solver", "Highs"))
         else:
             solvers = _cvx.installed_solvers()
             solver = solvers[0] if solvers else "none"

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -2649,14 +2649,8 @@ def log_runtime_banner(logger, optim_conf: dict | None = None):
         from importlib.metadata import version as _pkg_version
 
         _ver = _pkg_version("emhass")
-        active = None
-        try:
-            if isinstance(optim_conf, dict) and "lp_solver" in optim_conf:
-                active = str(optim_conf["lp_solver"])
-        except Exception:
-            active = None
-        if active:
-            solver = active
+        if isinstance(optim_conf, dict) and "lp_solver" in optim_conf:
+            solver = str(optim_conf["lp_solver"])
         else:
             solvers = _cvx.installed_solvers()
             solver = solvers[0] if solvers else "none"

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -346,12 +346,18 @@ class TestCommandLineAsyncUtils(unittest.IsolatedAsyncioTestCase):
             logger,
             get_data_from_file=True,
         )
-        opt_res = await perfect_forecast_optim(input_data_dict, logger, debug=True)
+        with self.assertLogs(logger, level="INFO") as cm:
+            opt_res = await perfect_forecast_optim(input_data_dict, logger, debug=True)
         self.assertIsInstance(opt_res, pd.DataFrame)
         self.assertEqual(opt_res.isnull().sum().sum(), 0)
         self.assertIsInstance(opt_res.index, pd.core.indexes.datetimes.DatetimeIndex)
         self.assertIsInstance(opt_res.index.dtype, pd.core.dtypes.dtypes.DatetimeTZDtype)
         self.assertIn("cost_fun_" + input_data_dict["costfun"], opt_res.columns)
+        self.assertIn(
+            "Optimization completed in",
+            "\n".join(cm.output),
+            "Summary line missing — expected one INFO record from orchestrator",
+        )
 
     # Test naive mpc optimization
     async def test_naive_mpc_optim(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import json
+import logging
 import pathlib
 import unittest
 from copy import deepcopy
@@ -2329,6 +2330,31 @@ class TestHeatingDemand(unittest.TestCase):
         # Manual verification for outdoor_temp = 22°C (>= 20°C indoor)
         loss_manual_warm = base_loss * (1 - 2 * 1)
         self.assertAlmostEqual(loss_manual_warm, -base_loss, places=6)
+
+    def test_log_runtime_banner_logs_info(self):
+        from emhass.utils import log_runtime_banner
+
+        test_logger = logging.getLogger("emhass-test-banner")
+        with self.assertLogs("emhass-test-banner", level="INFO") as cm:
+            log_runtime_banner(test_logger)
+        self.assertEqual(len(cm.output), 1, f"Expected one INFO record, got {len(cm.output)}")
+        msg = cm.records[0].getMessage()
+        self.assertRegex(
+            msg,
+            r"^EMHASS \S+ \| Python \S+ \| CVXPY \S+ \(\S+\) \| \S+-\S+$",
+            f"Banner format mismatch: {msg!r}",
+        )
+
+    def test_log_runtime_banner_survives_introspection_failure(self):
+        import unittest.mock
+        from emhass.utils import log_runtime_banner
+
+        test_logger = logging.getLogger("emhass-test-banner-fail")
+        with unittest.mock.patch("cvxpy.installed_solvers", side_effect=RuntimeError("simulated solver-introspection failure")):
+            with self.assertLogs("emhass-test-banner-fail", level="INFO") as cm:
+                log_runtime_banner(test_logger)  # must not raise
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("runtime info unavailable", cm.records[0].getMessage())
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2388,6 +2388,26 @@ class TestRuntimeBanner(unittest.TestCase):
         msg = cm.records[0].getMessage()
         self.assertIn("Highs", msg, f"Expected default Highs in banner: {msg!r}")
 
+    def test_log_runtime_banner_double_fallback_when_version_lookup_fails(self):
+        # Covers the inner except: outer introspection AND importlib.metadata.version
+        # both fail. Banner must still emit one INFO and not raise.
+        import unittest.mock
+        from emhass.utils import log_runtime_banner
+
+        test_logger = logging.getLogger("emhass-test-banner-double-fail")
+        with unittest.mock.patch(
+            "cvxpy.installed_solvers",
+            side_effect=RuntimeError("primary failure"),
+        ):
+            with unittest.mock.patch(
+                "importlib.metadata.version",
+                side_effect=RuntimeError("version lookup failure"),
+            ):
+                with self.assertLogs("emhass-test-banner-double-fail", level="INFO") as cm:
+                    log_runtime_banner(test_logger)  # must not raise
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("runtime info unavailable", cm.records[0].getMessage())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2352,7 +2352,10 @@ class TestRuntimeBanner(unittest.TestCase):
         from emhass.utils import log_runtime_banner
 
         test_logger = logging.getLogger("emhass-test-banner-fail")
-        with unittest.mock.patch("cvxpy.installed_solvers", side_effect=RuntimeError("simulated solver-introspection failure")):
+        with unittest.mock.patch(
+            "cvxpy.installed_solvers",
+            side_effect=RuntimeError("simulated solver-introspection failure"),
+        ):
             with self.assertLogs("emhass-test-banner-fail", level="INFO") as cm:
                 log_runtime_banner(test_logger)  # must not raise
         self.assertEqual(len(cm.output), 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2331,6 +2331,8 @@ class TestHeatingDemand(unittest.TestCase):
         loss_manual_warm = base_loss * (1 - 2 * 1)
         self.assertAlmostEqual(loss_manual_warm, -base_loss, places=6)
 
+
+class TestRuntimeBanner(unittest.TestCase):
     def test_log_runtime_banner_logs_info(self):
         from emhass.utils import log_runtime_banner
 
@@ -2355,6 +2357,21 @@ class TestHeatingDemand(unittest.TestCase):
                 log_runtime_banner(test_logger)  # must not raise
         self.assertEqual(len(cm.output), 1)
         self.assertIn("runtime info unavailable", cm.records[0].getMessage())
+
+    def test_log_runtime_banner_uses_active_solver_from_optim_conf(self):
+        from emhass.utils import log_runtime_banner
+
+        test_logger = logging.getLogger("emhass-test-banner-active")
+        with self.assertLogs("emhass-test-banner-active", level="INFO") as cm:
+            log_runtime_banner(test_logger, optim_conf={"lp_solver": "COIN_CMD"})
+        self.assertEqual(len(cm.output), 1, f"Expected one INFO record, got {len(cm.output)}")
+        msg = cm.records[0].getMessage()
+        self.assertIn("COIN_CMD", msg, f"Expected active solver in banner: {msg!r}")
+        self.assertRegex(
+            msg,
+            r"^EMHASS \S+ \| Python \S+ \| CVXPY \S+ \(COIN_CMD\) \| \S+-\S+$",
+            f"Banner format mismatch: {msg!r}",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2373,6 +2373,18 @@ class TestRuntimeBanner(unittest.TestCase):
             f"Banner format mismatch: {msg!r}",
         )
 
+    def test_log_runtime_banner_defaults_to_highs_when_key_missing(self):
+        # Mirrors optimization.py default: when lp_solver is not set in optim_conf,
+        # the LP uses "Highs". Banner must match reality.
+        from emhass.utils import log_runtime_banner
+
+        test_logger = logging.getLogger("emhass-test-banner-default")
+        with self.assertLogs("emhass-test-banner-default", level="INFO") as cm:
+            log_runtime_banner(test_logger, optim_conf={})
+        self.assertEqual(len(cm.output), 1, f"Expected one INFO record, got {len(cm.output)}")
+        msg = cm.records[0].getMessage()
+        self.assertIn("Highs", msg, f"Expected default Highs in banner: {msg!r}")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #793 — maintainer-approved 2026-04-23 ("happily accepted").

## What

Adds two small diagnostic additions to every optimization run:

1. **Runtime banner (INFO, once per run)** — EMHASS version, Python, CVXPY + active solver, platform/arch. Lets bug reports be reproduced without asking reporters for environment details.
2. **Per-stage timings (DEBUG) + summary line (INFO)** — wall-clock duration of each pipeline stage (`input_data`, `pv_forecast`, `load_forecast`, `price_prep`, `optim_solve`, `publish`), plus one INFO line showing total runtime and the dominant stage. Makes it obvious whether a slow run is data fetch, solver, or publish.

No new dependencies. No config flag (2 INFO lines/run). Default log level stays clean (`log_level: DEBUG` reveals per-stage lines).

## Why 5 stages, not finer

The pipeline in `perform_optimization` interleaves LP construction with a relaxed-fallback solver retry — build and solve can't be cleanly separated without restructuring that function, which is out of scope for a logging PR. So `optim_solve` is one fused stage. The 5 orchestrator stages reflect the actual pipeline shape in `command_line.py`.

`publish` is only recorded when the conditional publish branch executes — missing keys gracefully drop out of the summary total.

## Implementation

- New `stage_timer` contextmanager in `utils.py` — records `time.perf_counter()` delta into a dict, emits DEBUG line. Works across `await` because `perf_counter` is a plain monotonic read.
- New `log_runtime_banner` in `utils.py` — reads active solver from `optim_conf["lp_solver"]` (default `"Highs"`, mirroring `Optimization.__init__`), with try/except fallback so introspection errors never abort a run.
- Wrap sites in `command_line.py`: `set_input_data_dict`, `_prepare_dayahead_optim`, `_prepare_naive_mpc_optim`, and the three orchestrators.

Dict `input_data_dict["stage_times"]` is ephemeral (per-run). Nothing persisted — structured/machine-readable export is explicitly out of scope (future `/api/last-run` PR).

## Live-tested in production

Patched files deployed into a running Docker container (0.17.2) and verified with real Node-RED-triggered `dayahead-optim` calls. Output from `action_logs.txt`:

```
INFO  - EMHASS 0.17.2 | Python 3.12.13 | CVXPY 1.7.5 (Highs) | Linux-x86_64
DEBUG - Stage [pv_forecast] completed in 0.010s
DEBUG - Stage [load_forecast] completed in 0.028s
DEBUG - Stage [price_prep] completed in 0.036s
DEBUG - Stage [optim_solve] completed in 4.018s
INFO  - Optimization completed in 4.1s (top: optim_solve=4.0s, 98%)
```

Second NR-triggered run same day:

```
INFO  - EMHASS 0.17.2 | Python 3.12.13 | CVXPY 1.7.5 (Highs) | Linux-x86_64
DEBUG - Stage [pv_forecast] completed in 0.010s
DEBUG - Stage [load_forecast] completed in 0.026s
DEBUG - Stage [price_prep] completed in 0.035s
DEBUG - Stage [optim_solve] completed in 2.061s
INFO  - Optimization completed in 2.1s (top: optim_solve=2.1s, 96%)
```

Default log-level run (banner + summary only, no DEBUG):

```
INFO  - EMHASS 0.17.2 | Python 3.12.13 | CVXPY 1.7.5 (Highs) | Linux-x86_64
INFO  - Optimization completed in 4.1s (top: optim_solve=4.0s, 98%)
```

Confirms the summary line is useful in practice: solver dominated both runs (96–98%), which is exactly the kind of signal the issue asked for.

## Why the diff is ~170 LOC and not the ~25 hinted in the issue

The 25-line sketch assumed banner + outer timer only. Making per-stage timings *actually useful* required:

- One wrap per stage call site across 5 orchestrator paths (dayahead / naive_mpc / perfect × helpers + orchestrator body) — 13 wrap sites total
- `input_data_dict["stage_times"]` plumbed through `_prepare_*` helpers so timings collected during `set_input_data_dict` flow into the orchestrator's summary
- Banner helper + tests + summary tolerant of missing keys (`publish` conditional)

Net: +240/-67. The `stage_timer` contextmanager pass reduced this from +207 to +173 by collapsing 4-line `try/finally` blocks to 1-liners.

## Tests

- `test_log_runtime_banner_logs_info` — asserts banner format via regex
- `test_log_runtime_banner_survives_introspection_failure` — monkeypatches `cvxpy.installed_solvers` to raise, asserts fallback INFO still emitted
- `test_log_runtime_banner_defaults_to_highs_when_key_missing` — locks the solver default in the banner
- `test_perform_perfect_forecast_optim` — extended with `assert "Optimization completed in" in caplog.text`

All existing tests pass.

## Out of scope (for future work)

- Structured JSON / `/api/last-run` endpoint
- Git-SHA / dev-install detection
- Opt-out config flag
- Cross-run aggregation
- Decomposing `optim_solve` into `lp_build` + `solve` (would require refactoring `perform_optimization`)

## Summary by Sourcery

Add runtime diagnostics for optimization runs, including an environment banner and per-stage timing summary.

New Features:
- Log a one-line runtime banner at the start of each optimization setup with EMHASS, Python, CVXPY, solver, and platform information.
- Record per-stage wall-clock timings for optimization pipelines (forecast preparation, price preparation, solve, and publish) and emit an INFO-level summary of total runtime and dominant stage.

Enhancements:
- Thread a per-run stage timing dictionary through optimization setup and orchestrator functions to centralize timing data without affecting business logic.

Tests:
- Add unit tests validating runtime banner formatting, solver selection behavior, and resilience to CVXPY introspection failures, and extend orchestration tests to assert presence of the optimization summary line.