### PR TITLE
docs(study_cases): add DHW walkthrough (Phase 1.1, depends on #812)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -237,6 +237,7 @@ section_getting_started
 section_config
 section_core
 section_thermal
+study_cases/index
 section_reference
 
 ```

--- a/docs/section_getting_started.md
+++ b/docs/section_getting_started.md
@@ -8,6 +8,6 @@ installation_methods
 usage_guide
 automations
 differences
-study_case
+study_cases/index
 
 ```

--- a/docs/study_case.md
+++ b/docs/study_case.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Example configurations
 
 This page has moved. The study cases have been split into a dedicated

--- a/docs/study_case.md
+++ b/docs/study_case.md
@@ -1,156 +1,18 @@
 # Example configurations
 
-In this section example configurations are presented as study cases using real data.
+This page has moved. The study cases have been split into a dedicated
+section for better navigation and to support new walkthroughs.
 
-The example configuration all start with the default configuration that is located at: [https://github.com/davidusb-geek/emhass/tree/master/src/emhass/data/config_defaults.json](https://github.com/davidusb-geek/emhass/tree/master/src/emhass/data/config_defaults.json)
+→ See [Study Cases](./study_cases/index.md)
 
-We will also use a JSON format to store some secret parameters.
-You can add your own secrets parameters to retrieve your own data and reproduce the results presented on this page.
-A template for the secrets file is found here: [https://github.com/davidusb-geek/emhass/options.json](https://github.com/davidusb-geek/emhass/options.json)
+Direct links:
 
-## First test system: a simple system with no PV and two deferrable loads
-
-In this example, we will consider a simple system with no PV installation and just two deferrable loads that we want to optimize their schedule.
-
-For this, the following parameter can be set in the `options.json` file: `solar_forecast_kwp: 0`. Also, we will set the PV forecast method to `method='solar.forecast'`. For this we can modify the original default configuration file `config_defaults.json` and save for example as `config_emhass.json`.
-This is a simple way to just set a vector with zero values on the PV forecast power, emulating the case where there is no PV installation. The other values on the configuration file are set to their default values.
-
-### Day-ahead optimization
-
-Let's perform a day-ahead optimization task on this simple system. We want to schedule our two deferrable loads.
-
-For this, we use the following command (this example is using the legacy EMHASS Python module command line, check the documentation for the alternative REST commands):
-```
-emhass --action 'dayahead-optim' --config '/home/user/emhass/config_emhass.json' --costfun 'profit'
-```
-
-The retrieved input forecasted powers are shown below:
-
-![](./images/inputs_dayahead.png)
-
-Finally, the optimization results are:
-
-![](./images/optim_results_defLoads_dayaheadOptim.png)
-
-For this system, the total value of the obtained cost function is **-5.38 EUR**. 
-
-## A second test system: a 5kW PV installation and two deferrable loads
-
-Let's add a 5 kWp solar production with two deferrable loads. No battery is considered for now. In this case the configuration used is exactly the same as the default configuration proposed with EMHASS in the `config_defaults.json` file. 
-
-We will first consider a perfect optimization task, to obtain the optimization results with perfectly known PV production and load power values for the last week.
-
-### Perfect optimization
-
-Let's perform a 7-day historical data optimization.
-
-For this, we use the following command (using the legacy EMHASS Python module command line):
-```
-emhass --action 'perfect-optim' --config '/home/user/emhass/config_emhass.json' --costfun 'profit'
-```
-
-The retrieved input powers are shown below:
-
-![](./images/inputs_power.png)
-
-The input load cost and PV production selling prices are presented in the following figure:
-
-![](./images/inputs_cost_price.png)
-
-Finally, the optimization results are:
-
-![](./images/optim_results_PV_defLoads_perfectOptim.png)
-
-For this 7-day period, the total value of the cost function was **-26.23 EUR**. 
-
-### Day-ahead optimization
-
-As with the simple system, we will now perform a day-ahead optimization task. We use again the `dayahead-optim` action or endpoint.
-
-The optimization results are:
-
-![](./images/optim_results_PV_defLoads_dayaheadOptim.png)
-
-For this system, the total value of the obtained cost function is **-1.56 EUR**. We can note the important improvement in the cost function value when adding a PV installation.
-
-## A third test system: a 5kW PV installation, a 5kWh battery and two deferrable loads
-
-Now we will consider a complete system with PV and added batteries. To add the battery we will set `set_use_battery: true` in the `config_emhass.json` file.
-
-In this case, we want to schedule our deferrable loads but also the battery charge/discharge. We use again the `dayahead-optim` action or endpoint.
-
-The optimization results are:
-
-![](./images/optim_results_PV_Batt_defLoads_dayaheadOptim.png)
-
-The battery state of charge plot is shown below:
-
-![](./images/optim_results_PV_Batt_defLoads_dayaheadOptim_SOC.png)
-
-For this system, the total value of the obtained cost function is **-1.23 EUR**, a substantial improvement when adding a battery.
-
-## Configuration example to pass data at runtime
-
-As we showed in the forecast module section, we can pass our own forecast data using lists of values passed at runtime using templates. However, it is possible to also pass other data during runtime to automate energy management.
-
-For example, let's suppose that for the default configuration with two deferrable loads, we want to correlate and control them to the outside temperature. This will be used to build a list of the total number of hours for each deferrable load (`operating_hours_of_each_deferrable_load`). In this example, the first deferrable load is a water heater and the second is the pool pump.
-
-We will begin by defining a temperature sensor on a 12 hours sliding window using the filter platform for the outside temperature:
-```
-  - platform: filter
-    name: "Outdoor temperature mean over last 12 hours"
-    entity_id: sensor.temp_air_out
-    filters:
-      - filter: time_simple_moving_average
-        window_size: "12:00"
-        precision: 0
-```
-Then we will use a template sensor to build our list of the total number of hours for each deferrable load:
-```
-  - platform: template
-    sensors:
-      list_operating_hours_of_each_deferrable_load:
-        value_template: >-
-          {% if states("sensor.outdoor_temperature_mean_over_last_12_hours") < "10" %}
-            {{ [5, 0] | list }}
-          {% elif states("sensor.outdoor_temperature_mean_over_last_12_hours") >= "10" and states("sensor.outdoor_temperature_mean_over_last_12_hours") < "15" %}
-            {{ [4, 0] | list }}
-          {% elif states("sensor.outdoor_temperature_mean_over_last_12_hours") >= "15" and states("sensor.outdoor_temperature_mean_over_last_12_hours") < "20" %}
-            {{ [4, 6] | list }}
-          {% elif states("sensor.outdoor_temperature_mean_over_last_12_hours") >= "20" and states("sensor.outdoor_temperature_mean_over_last_12_hours") < "25" %}
-            {{ [3, 9] | list }}
-          {% else %}
-            {{ [3, 12] | list }}
-          {% endif %}
-```
-The values for the total number of operating hours were tuned by trial and error throughout a whole year. These values work fine for a 3000W water heater (the first value in the list) and a 750W pool pump (the second value in the list).
-
-Finally, my two shell commands for EMHASS will look like this:
-```
-shell_command:
-  dayahead_optim: "curl -i -H \"Content-Type: application/json\" -X POST -d '{\"operating_hours_of_each_deferrable_load\":{{states('sensor.list_operating_hours_of_each_deferrable_load')}}}' http://localhost:5000/action/dayahead-optim"
-  publish_data: "curl -i -H \"Content-Type: application/json\" -X POST -d '{}' http://localhost:5000/action/publish-data"
-```
-The dedicated automation for these shell commands can be for example:
-```
-- alias: EMHASS day-ahead optimization
-  trigger:
-    platform: time
-    at: '05:30:00'
-  action:
-  - service: shell_command.dayahead_optim
-- alias: EMHASS publish data
-  trigger:
-  - minutes: /5
-    platform: time_pattern
-  action:
-  - service: shell_command.publish_data
-```
-
-## Some real forecast data
-
-The real implementation of EMHASS and its efficiency depends on the quality of the forecasted PV power production and the house load consumption.
-
-Here is an extract of the PV power production forecast with the default PV forecast method from EMHASS: a web scraping of the clearoutside page based on the defined lat/lon location of the system. These are the forecast results of the GFS model compared with the real PV-produced data for a 4-day period. 
-
-![](./images/forecasted_PV_data.png)
+- [Basic — no PV](./study_cases/basic_no_pv.md)
+- [Basic — PV](./study_cases/basic_pv.md)
+- [Basic — PV + Battery](./study_cases/basic_pv_battery.md)
+- [MPC walkthrough](./study_cases/mpc.md)
+- [Heat-pump walkthrough](./study_cases/heat_pump_walkthrough.md)
+- [EV as deferrable](./study_cases/ev.md)
+- [Good Practices](./study_cases/good_practices.md)
+- [Reference Configurations](./study_cases/reference_configs.md)
+- [Legacy CLI commands](./study_cases/legacy_cli.md)

--- a/docs/study_case.md
+++ b/docs/study_case.md
@@ -3,16 +3,16 @@
 This page has moved. The study cases have been split into a dedicated
 section for better navigation and to support new walkthroughs.
 
-→ See [Study Cases](./study_cases/index.md)
+→ See [Study Cases](study_cases/index.md)
 
 Direct links:
 
-- [Basic — no PV](./study_cases/basic_no_pv.md)
-- [Basic — PV](./study_cases/basic_pv.md)
-- [Basic — PV + Battery](./study_cases/basic_pv_battery.md)
-- [MPC walkthrough](./study_cases/mpc.md)
-- [Heat-pump walkthrough](./study_cases/heat_pump_walkthrough.md)
-- [EV as deferrable](./study_cases/ev.md)
-- [Good Practices](./study_cases/good_practices.md)
-- [Reference Configurations](./study_cases/reference_configs.md)
-- [Legacy CLI commands](./study_cases/legacy_cli.md)
+- [Basic — no PV](study_cases/basic_no_pv.md)
+- [Basic — PV](study_cases/basic_pv.md)
+- [Basic — PV + Battery](study_cases/basic_pv_battery.md)
+- [MPC walkthrough](study_cases/mpc.md)
+- [Heat-pump walkthrough](study_cases/heat_pump_walkthrough.md)
+- [EV as deferrable](study_cases/ev.md)
+- [Good Practices](study_cases/good_practices.md)
+- [Reference Configurations](study_cases/reference_configs.md)
+- [Legacy CLI commands](study_cases/legacy_cli.md)

--- a/docs/study_cases/basic_no_pv.md
+++ b/docs/study_cases/basic_no_pv.md
@@ -1,0 +1,73 @@
+# Basic system — no PV, two deferrable loads
+
+> **Type:** Tutorial — learning-oriented, follow step by step.
+
+This is the simplest scenario: no PV installation, two deferrable loads (for example, a water heater and a pool pump). EMHASS schedules when to run each load to minimize cost against the day-ahead electricity price.
+
+## System
+
+| Component | Value |
+|-----------|-------|
+| PV | none (`set_use_pv: false` or `pv_forecast: [0, 0, ...]`) |
+| Battery | none |
+| Deferrable load 1 | water heater, 3000 W |
+| Deferrable load 2 | pool pump, 750 W |
+| Optimization mode | day-ahead |
+| Cost function | profit |
+
+## Configuration
+
+If you are running the **EMHASS Add-on**, set in the Add-on configuration page:
+
+```yaml
+set_use_pv: false
+nominal_power_of_deferrable_loads:
+  - 3000
+  - 750
+operating_hours_of_each_deferrable_load:
+  - 5
+  - 8
+```
+
+If you are running **standalone Docker** with `config_emhass.yaml`, the same keys apply directly.
+
+The other parameters keep the defaults from `config_defaults.json`.
+
+## Run the optimization
+
+REST (Add-on or Docker):
+
+```bash
+curl -i -H "Content-Type: application/json" \
+     -X POST -d '{}' \
+     http://localhost:5000/action/dayahead-optim
+```
+
+Or use the **Add-on action button** in the EMHASS web UI: open `http://YOUR_HA_IP:5000/`, click *"Day-ahead optimization"*.
+
+For the legacy CLI variant, see [Legacy CLI Commands](legacy_cli.md).
+
+## Output
+
+The retrieved input forecasted powers:
+
+![inputs_dayahead](../images/inputs_dayahead.png)
+
+The optimization result:
+
+![optim_results_defLoads_dayaheadOptim](../images/optim_results_defLoads_dayaheadOptim.png)
+
+For this system, the total value of the cost function is **−5.38 EUR** (negative = cost, i.e. you pay 5.38 EUR for the day's optimized schedule). The schedule places both loads in low-price hours.
+
+## Interpretation
+
+- The optimizer treats both deferrable loads as fixed-energy: `load × hours = energy_to_deliver`. It is free to choose *when* in the next 24 h to run them.
+- Without PV, there is no self-consumption opportunity — the only optimization lever is the time-varying load cost.
+- A cost function of −5.38 EUR for a day with both loads (3 kW × 5 h + 0.75 kW × 8 h = 21 kWh) implies an average paid price of about 0.26 EUR/kWh.
+
+## See also
+
+- Tutorial: [Basic — PV](basic_pv.md) (same loads + 5 kWp PV)
+- Reference: [Configuration](../config.md) for every parameter
+- Reference: [Passing data](../passing_data.md) for runtime payload schema
+- How-to: [MPC walkthrough](mpc.md) when you need rolling-horizon control instead of day-ahead

--- a/docs/study_cases/basic_no_pv.md
+++ b/docs/study_cases/basic_no_pv.md
@@ -31,7 +31,7 @@ operating_hours_of_each_deferrable_load:
 
 If you are running **standalone Docker** with `config_emhass.yaml`, the same keys apply directly.
 
-The other parameters keep the defaults from `config_defaults.json`.
+The values for `operating_hours_of_each_deferrable_load` are intentional choices for this scenario; the rest of the parameters keep the defaults from `config_defaults.json`.
 
 ## Run the optimization
 
@@ -57,7 +57,7 @@ The optimization result:
 
 ![optim_results_defLoads_dayaheadOptim](../images/optim_results_defLoads_dayaheadOptim.png)
 
-For this system, the total value of the cost function is **−5.38 EUR** (negative = cost, i.e. you pay 5.38 EUR for the day's optimized schedule). The schedule places both loads in low-price hours.
+For this system, the total value of the cost function is **−5.38 EUR**. With `costfun: profit`, this is net cash flow over the period (positive = revenue, negative = expenditure) — here the system has no revenue source, so the optimizer's best schedule still costs 5.38 EUR. The schedule places both loads in low-price hours.
 
 ## Interpretation
 

--- a/docs/study_cases/basic_pv.md
+++ b/docs/study_cases/basic_pv.md
@@ -47,7 +47,7 @@ Cost function over the 7-day period: **−26.23 EUR**.
 
 ## Day-ahead optimization
 
-The `dayahead-optim` mode is the real production case: forecasted PV (from `open-meteo` by default, or Solcast/clearoutside/Forecast.Solar if configured), forecasted load (1-day persistence by default), forecasted prices (provided at runtime if dynamic).
+The `dayahead-optim` mode is the real production case: forecasted PV (from `open-meteo` by default; alternatives via `weather_forecast_method` are `solcast`, `solar.forecast`, or the `scrapper` clearoutside method), forecasted load (1-day persistence by default), forecasted prices (provided at runtime if dynamic).
 
 Run it:
 

--- a/docs/study_cases/basic_pv.md
+++ b/docs/study_cases/basic_pv.md
@@ -67,7 +67,7 @@ Cost function: **−1.56 EUR** for the next day. With `costfun: profit`, this is
 
 - `perfect-optim` (`−26.23 EUR` over 7 days, ≈ −3.75 EUR/day) gives the theoretical best — the gap to `dayahead-optim` (`−1.56 EUR`/day) represents forecast uncertainty.
 - The closer your PV-forecast and load-forecast are to reality, the more `dayahead-optim` approaches `perfect-optim`. Forecast quality is the dominant factor — see [Good Practices](good_practices.md) for details.
-- Without a battery, all PV produced beyond instantaneous load is fed to grid (or curtailed if `prod_price ≤ 0`). Adding a battery typically improves cost further — see the next tutorial.
+- Without a battery, all PV produced beyond instantaneous load is fed to the grid (or curtailed if `prod_price ≤ 0`). Adding a battery typically improves cost further — see the next tutorial.
 
 ## See also
 

--- a/docs/study_cases/basic_pv.md
+++ b/docs/study_cases/basic_pv.md
@@ -1,0 +1,77 @@
+# Basic system — 5 kWp PV, two deferrable loads
+
+> **Type:** Tutorial — learning-oriented, follow step by step.
+
+This scenario adds a 5 kWp PV installation to the previous tutorial. No battery yet. We run two optimization modes against this system: a 7-day historical **perfect optimization** (to see what the optimal schedule would have been with hindsight) and a **day-ahead optimization** (the real production case).
+
+## System
+
+| Component | Value |
+|-----------|-------|
+| PV | 5 kWp |
+| Battery | none |
+| Deferrable load 1 | water heater, 3000 W |
+| Deferrable load 2 | pool pump, 750 W |
+| Optimization modes | perfect-optim (backtest), dayahead-optim |
+| Cost function | profit |
+
+This matches the default configuration shipped in `config_defaults.json` — no parameter changes required.
+
+## Perfect optimization (7-day historical backtest)
+
+The `perfect-optim` mode uses real measured PV production and load data from the last 7 days, so the optimizer has perfect knowledge of inputs. The result is the theoretical best-case cost, useful as a benchmark for what `dayahead-optim` is approaching.
+
+Run it:
+
+```bash
+curl -i -H "Content-Type: application/json" \
+     -X POST -d '{}' \
+     http://localhost:5000/action/perfect-optim
+```
+
+Or the *Perfect optimization* button in the EMHASS web UI.
+
+Inputs (real measured powers over 7 days):
+
+![inputs_power](../images/inputs_power.png)
+
+Load cost and PV selling price:
+
+![inputs_cost_price](../images/inputs_cost_price.png)
+
+Result:
+
+![optim_results_PV_defLoads_perfectOptim](../images/optim_results_PV_defLoads_perfectOptim.png)
+
+Cost function over the 7-day period: **−26.23 EUR**.
+
+## Day-ahead optimization
+
+The `dayahead-optim` mode is the real production case: forecasted PV (from `clearoutside` web-scraping by default, or Solcast/Open-Meteo if configured), forecasted load (1-day persistence by default), forecasted prices (provided at runtime if dynamic).
+
+Run it:
+
+```bash
+curl -i -H "Content-Type: application/json" \
+     -X POST -d '{}' \
+     http://localhost:5000/action/dayahead-optim
+```
+
+Result:
+
+![optim_results_PV_defLoads_dayaheadOptim](../images/optim_results_PV_defLoads_dayaheadOptim.png)
+
+Cost function: **−1.56 EUR** for the next day. Compared with the **−5.38 EUR** of the no-PV case (see [Basic — no PV](basic_no_pv.md)) — the PV installation reduces the daily cost by about 70%.
+
+## Interpretation
+
+- `perfect-optim` (`−26.23 EUR` over 7 days, ≈ −3.75 EUR/day) gives the theoretical best — the gap to `dayahead-optim` (`−1.56 EUR`/day) represents forecast uncertainty.
+- The closer your PV-forecast and load-forecast are to reality, the more `dayahead-optim` approaches `perfect-optim`. Forecast quality is the dominant factor — see [Good Practices](good_practices.md) for details.
+- Without a battery, all PV produced beyond instantaneous load is fed to grid (or curtailed if `prod_price ≤ 0`). Adding a battery typically improves cost further — see the next tutorial.
+
+## See also
+
+- Tutorial: [Basic — no PV](basic_no_pv.md) (same loads, no PV)
+- Tutorial: [Basic — PV + Battery](basic_pv_battery.md) (this scenario plus a 5 kWh battery)
+- Reference: [Forecasts](../forecasts.md) for PV/load forecast methods
+- Explanation: [Good Practices](good_practices.md) for forecast-quality wisdom

--- a/docs/study_cases/basic_pv.md
+++ b/docs/study_cases/basic_pv.md
@@ -47,7 +47,7 @@ Cost function over the 7-day period: **−26.23 EUR**.
 
 ## Day-ahead optimization
 
-The `dayahead-optim` mode is the real production case: forecasted PV (from `clearoutside` web-scraping by default, or Solcast/Open-Meteo if configured), forecasted load (1-day persistence by default), forecasted prices (provided at runtime if dynamic).
+The `dayahead-optim` mode is the real production case: forecasted PV (from `open-meteo` by default, or Solcast/clearoutside/Forecast.Solar if configured), forecasted load (1-day persistence by default), forecasted prices (provided at runtime if dynamic).
 
 Run it:
 
@@ -61,7 +61,7 @@ Result:
 
 ![optim_results_PV_defLoads_dayaheadOptim](../images/optim_results_PV_defLoads_dayaheadOptim.png)
 
-Cost function: **−1.56 EUR** for the next day. Compared with the **−5.38 EUR** of the no-PV case (see [Basic — no PV](basic_no_pv.md)) — the PV installation reduces the daily cost by about 70%.
+Cost function: **−1.56 EUR** for the next day. With `costfun: profit`, this is net cash flow over the period (positive = revenue, negative = expenditure); a less-negative value means lower net cost. Compared with the **−5.38 EUR** of the no-PV case (see [Basic — no PV](basic_no_pv.md)), the PV installation reduces the daily net spend by about 71%.
 
 ## Interpretation
 

--- a/docs/study_cases/basic_pv_battery.md
+++ b/docs/study_cases/basic_pv_battery.md
@@ -1,0 +1,78 @@
+# Basic system — 5 kWp PV, 5 kWh battery, two deferrable loads
+
+> **Type:** Tutorial — learning-oriented, follow step by step.
+
+This scenario adds a 5 kWh battery to the previous tutorial. The optimizer now schedules battery charge/discharge alongside the deferrable loads.
+
+## System
+
+| Component | Value |
+|-----------|-------|
+| PV | 5 kWp |
+| Battery | 5 kWh nominal, default charge/discharge limits |
+| Deferrable load 1 | water heater, 3000 W |
+| Deferrable load 2 | pool pump, 750 W |
+| Optimization mode | dayahead-optim |
+| Cost function | profit |
+
+## Configuration
+
+The only change versus [Basic — PV](basic_pv.md) is enabling the battery. In Add-on options:
+
+```yaml
+set_use_battery: true
+```
+
+If you want to override the defaults (shown below — adjust to your hardware):
+
+```yaml
+set_use_battery: true
+battery_discharge_power_max: 1000      # max discharge power, W
+battery_charge_power_max: 1000         # max charge power, W
+battery_discharge_efficiency: 0.95
+battery_charge_efficiency: 0.95
+battery_nominal_energy_capacity: 5000  # Wh (= 5 kWh) — default
+battery_minimum_state_of_charge: 0.3   # default
+battery_maximum_state_of_charge: 0.9   # default
+battery_target_state_of_charge: 0.6    # default — also used as default soc_init/soc_final when not passed at runtime
+```
+
+For the meaning of each parameter and acceptable ranges, see [Configuration](../config.md).
+
+## Run
+
+```bash
+curl -i -H "Content-Type: application/json" \
+     -X POST -d '{}' \
+     http://localhost:5000/action/dayahead-optim
+```
+
+## Output
+
+Optimization result:
+
+![optim_results_PV_Batt_defLoads_dayaheadOptim](../images/optim_results_PV_Batt_defLoads_dayaheadOptim.png)
+
+Battery state of charge:
+
+![optim_results_PV_Batt_defLoads_dayaheadOptim_SOC](../images/optim_results_PV_Batt_defLoads_dayaheadOptim_SOC.png)
+
+Cost function: **−1.23 EUR**, compared with **−1.56 EUR** for the same system without a battery — a further ~20% improvement.
+
+## Interpretation
+
+- Battery shifts surplus PV from midday into evening peak hours, avoiding grid purchase during expensive hours.
+- The SOC curve typically rises during peak PV (charging) and falls during peak load + peak price (discharging).
+- The improvement size is sensitive to the spread between import price and export price. Low export prices (or none) make the battery more valuable; high export prices reduce its marginal benefit.
+- The `battery_target_state_of_charge` parameter is used as the default for both `soc_init` and `soc_final` when neither is passed at runtime, so the optimizer plans the battery to start and end at this fraction. For rolling-horizon control, see the [MPC walkthrough](mpc.md).
+
+```{note}
+**SOC convention.** EMHASS expresses SOC as a fraction of the **nominal** battery capacity (0.0 = empty, 1.0 = full). The configured `battery_minimum_state_of_charge` and `battery_maximum_state_of_charge` are the operational bounds the optimizer is allowed to use — they do **not** rescale the SOC fraction. A reported `SOC_opt = 0.45` means 45% of nominal capacity.
+```
+
+## See also
+
+- Tutorial: [Basic — PV](basic_pv.md) (same system without battery)
+- How-to: [MPC walkthrough](mpc.md) for rolling-horizon control with battery
+- Reference: [Configuration](../config.md) for all battery parameters
+- Explanation: [Good Practices](good_practices.md) — SOC semantics, forecast quality, infeasibility triage

--- a/docs/study_cases/basic_pv_battery.md
+++ b/docs/study_cases/basic_pv_battery.md
@@ -67,7 +67,7 @@ Cost function: **−1.23 EUR**, compared with **−1.56 EUR** for the same syste
 - The `battery_target_state_of_charge` parameter is used as the default for both `soc_init` and `soc_final` when neither is passed at runtime, so the optimizer plans the battery to start and end at this fraction. For rolling-horizon control, see the [MPC walkthrough](mpc.md).
 
 ```{note}
-**SOC convention.** EMHASS expresses SOC as a fraction of the **nominal** battery capacity (0.0 = empty, 1.0 = full). The configured `battery_minimum_state_of_charge` and `battery_maximum_state_of_charge` are the operational bounds the optimizer is allowed to use — they do **not** rescale the SOC fraction. With the defaults (`0.3` and `0.9`), the optimizer's `SOC_opt` will stay within `[0.3, 0.9]`; the values `0.0` and `1.0` are the theoretical extremes of the fraction, not values the optimizer produces under those bounds. A reported `SOC_opt = 0.45` means 45% of nominal capacity.
+**SOC convention.** `SOC_opt` is a fraction of nominal battery capacity (0.0 = empty, 1.0 = full). The configured operational bounds do not rescale the value. See [Good Practices, section 3](good_practices.md#3-soc-convention-fraction-of-nominal-capacity) for the full discussion and source-code reference.
 ```
 
 ## See also

--- a/docs/study_cases/basic_pv_battery.md
+++ b/docs/study_cases/basic_pv_battery.md
@@ -57,7 +57,7 @@ Battery state of charge:
 
 ![optim_results_PV_Batt_defLoads_dayaheadOptim_SOC](../images/optim_results_PV_Batt_defLoads_dayaheadOptim_SOC.png)
 
-Cost function: **−1.23 EUR**, compared with **−1.56 EUR** for the same system without a battery — a further ~20% improvement.
+Cost function: **−1.23 EUR**, compared with **−1.56 EUR** for the same system without a battery. With `costfun: profit`, the cost function expresses net cash flow over the period (positive = revenue, negative = expenditure), so a less-negative value means lower net cost — adding the battery here reduces the day's net spend by about 21%.
 
 ## Interpretation
 
@@ -67,7 +67,7 @@ Cost function: **−1.23 EUR**, compared with **−1.56 EUR** for the same syste
 - The `battery_target_state_of_charge` parameter is used as the default for both `soc_init` and `soc_final` when neither is passed at runtime, so the optimizer plans the battery to start and end at this fraction. For rolling-horizon control, see the [MPC walkthrough](mpc.md).
 
 ```{note}
-**SOC convention.** EMHASS expresses SOC as a fraction of the **nominal** battery capacity (0.0 = empty, 1.0 = full). The configured `battery_minimum_state_of_charge` and `battery_maximum_state_of_charge` are the operational bounds the optimizer is allowed to use — they do **not** rescale the SOC fraction. A reported `SOC_opt = 0.45` means 45% of nominal capacity.
+**SOC convention.** EMHASS expresses SOC as a fraction of the **nominal** battery capacity (0.0 = empty, 1.0 = full). The configured `battery_minimum_state_of_charge` and `battery_maximum_state_of_charge` are the operational bounds the optimizer is allowed to use — they do **not** rescale the SOC fraction. With the defaults (`0.3` and `0.9`), the optimizer's `SOC_opt` will stay within `[0.3, 0.9]`; the values `0.0` and `1.0` are the theoretical extremes of the fraction, not values the optimizer produces under those bounds. A reported `SOC_opt = 0.45` means 45% of nominal capacity.
 ```
 
 ## See also

--- a/docs/study_cases/dhw_walkthrough.md
+++ b/docs/study_cases/dhw_walkthrough.md
@@ -18,14 +18,15 @@ A better pattern is a deadline-driven profile: a low base temperature most of th
 
 ## Deadline profile
 
-Express the DHW comfort target as three layers stacked in the runtime payload:
+Build the `desired_temperatures` array as three layers stacked over the horizon:
 
 | Layer | Value | Where |
 |-------|-------|-------|
-| Base (always) | 45 °C | every timestep — comfort floor; tank may float down to here |
+| Base (always) | 45 °C | every timestep, the comfort floor; tank may float down to here |
 | Morning spike | 48 °C | last 30 min before 07:00 (1 timestep at 30-min step) |
 | Evening spike | 50 °C | last 1 h before 18:00 (2 timesteps at 30-min step) |
-| Anti-cap | 59 °C `overshoot_temperature` | upper bound to prevent Legionella-cycle conflict and tank stress |
+
+In addition, set `overshoot_temperature: 59 °C` as a hard upper bound (separate constraint, not part of the per-timestep target array). It prevents Legionella-cycle conflicts and excessive tank stress.
 
 These values are starting points. Adjust to your tank size, usage pattern, and water-comfort preference.
 
@@ -46,7 +47,38 @@ The `thermal_config` for DHW comes from the runtime payload, not the static conf
 
 ## Runtime payload
 
-Build the deadline-profile arrays in your Home Assistant `rest_command` template (or Node-RED Function node). The example below assumes 30-minute timesteps and a 24 h horizon:
+The cleanest way to assemble the `desired_temperatures` array is to compute it outside Home Assistant (Node-RED Function node, AppDaemon, a small Python script) and inject the finished list into the EMHASS payload. The contract EMHASS sees is just a list of length `prediction_horizon` floats.
+
+Reference Python sketch for the deadline profile (30-minute timesteps, 24 h horizon):
+
+```python
+from datetime import datetime, timedelta
+
+def build_dhw_profile(now, horizon=48, timestep_min=30,
+                      base=45.0,
+                      morning_temp=48.0, morning_hour=7, morning_window_slots=1,
+                      evening_temp=50.0, evening_hour=18, evening_window_slots=2):
+    """Return a list of length `horizon` with the deadline-driven target temps.
+
+    Each spike fires in the last `*_window_slots` timesteps that end at or
+    before the deadline hour. After a deadline passes today, the next spike
+    rolls forward to tomorrow.
+    """
+    profile = [base] * horizon
+    for hour, temp, slots in (
+        (morning_hour, morning_temp, morning_window_slots),
+        (evening_hour, evening_temp, evening_window_slots),
+    ):
+        deadline = now.replace(hour=hour, minute=0, second=0, microsecond=0)
+        if deadline <= now:
+            deadline += timedelta(days=1)
+        deadline_step = int((deadline - now).total_seconds() // (timestep_min * 60))
+        for k in range(max(0, deadline_step - slots), min(horizon, deadline_step)):
+            profile[k] = temp
+    return profile
+```
+
+Once your runtime layer (Node-RED, AppDaemon, etc.) holds the array, the HA `rest_command` payload simply forwards it:
 
 ```yaml
 rest_command:
@@ -57,30 +89,8 @@ rest_command:
     headers:
       content-type: application/json
     payload: >
-      {%- set horizon = 48 -%}
-      {%- set timestep_min = 30 -%}
-      {%- set base = 45.0 -%}
-      {%- set morning_temp = 48.0 -%}
-      {%- set morning_hour = 7 -%}
-      {%- set morning_window_slots = 1 -%}
-      {%- set evening_temp = 50.0 -%}
-      {%- set evening_hour = 18 -%}
-      {%- set evening_window_slots = 2 -%}
-      {%- set ns = namespace(profile=[]) -%}
-      {%- for step in range(horizon) -%}
-        {%- set hour = (now().hour + (step * timestep_min) // 60) % 24 -%}
-        {%- set in_morning = (hour == morning_hour) and (step >= horizon - morning_window_slots) -%}
-        {%- set in_evening = (hour == evening_hour) -%}
-        {%- if in_evening -%}
-          {%- set ns.profile = ns.profile + [evening_temp] -%}
-        {%- elif in_morning -%}
-          {%- set ns.profile = ns.profile + [morning_temp] -%}
-        {%- else -%}
-          {%- set ns.profile = ns.profile + [base] -%}
-        {%- endif -%}
-      {%- endfor -%}
       {
-        "prediction_horizon": {{ horizon }},
+        "prediction_horizon": 48,
         "soc_init": {{ states('sensor.battery_soc') | float / 100 }},
         "def_load_config": [
           {},
@@ -91,14 +101,14 @@ rest_command:
               "start_temperature": {{ states('sensor.dhw_tank_temperature') | float }},
               "sense": "heat",
               "overshoot_temperature": 59.0,
-              "desired_temperatures": {{ ns.profile | tojson }}
+              "desired_temperatures": {{ states('sensor.dhw_desired_temperatures') }}
             }
           }
         ]
       }
 ```
 
-The Jinja loop is illustrative. Production systems usually build the array outside HA (Node-RED Function node, AppDaemon, etc.) where set logic is easier. The contract EMHASS sees is just a list of length `prediction_horizon` floats in `desired_temperatures`.
+The HA template assumes `sensor.dhw_desired_temperatures` is a JSON-encoded list maintained by your runtime layer. Adjust the literal `48` if your `optimization_time_step` is not 30 minutes; recompute the array length to match.
 
 ## How EMHASS uses this
 

--- a/docs/study_cases/dhw_walkthrough.md
+++ b/docs/study_cases/dhw_walkthrough.md
@@ -1,10 +1,10 @@
-# Domestic hot water (DHW) — deadline-driven temperature profile
+# Domestic hot water with a deadline-driven temperature profile
 
 > **Type:** How-To Guide — task-oriented, follow when scheduling a heat-pump-fed DHW tank against dynamic prices.
 
-A DHW tank is a thermal store, but unlike an underfloor slab it has natural usage spikes (morning shower, evening dishes) that anchor when the water has to be hot — not a continuous comfort range. The naive approach is a fixed daily profile (e.g. "always at least 55 °C between 09:00 and 16:00"), which forces the heat pump to run at a fixed time of day regardless of price.
+A DHW tank is a thermal store, but unlike an underfloor slab it has natural usage spikes (morning shower, evening dishes) that anchor when the water has to be hot, not a continuous comfort range. The naive approach is a fixed daily profile (e.g. "always at least 55 °C between 09:00 and 16:00"), which forces the heat pump to run at a fixed time of day regardless of price.
 
-A better pattern is a **deadline-driven profile**: a low base temperature most of the time, with short windowed spikes just before each usage deadline. The optimizer is then free to pick the cheapest slot in the 24 h leading up to each spike — overnight when prices are low, midday during PV surplus, or whenever a dynamic-tariff dip happens.
+A better pattern is a deadline-driven profile: a low base temperature most of the time, with short windowed spikes just before each usage deadline. The optimizer is then free to pick the cheapest slot in the 24 h leading up to each spike: overnight when prices are low, midday during PV surplus, or whenever a dynamic-tariff dip happens.
 
 ## Scenario
 
@@ -27,7 +27,7 @@ Express the DHW comfort target as three layers stacked in the runtime payload:
 | Evening spike | 50 °C | last 1 h before 18:00 (2 timesteps at 30-min step) |
 | Anti-cap | 59 °C `overshoot_temperature` | upper bound to prevent Legionella-cycle conflict and tank stress |
 
-These values are starting points — adjust to your tank size, usage pattern, and water-comfort preference.
+These values are starting points. Adjust to your tank size, usage pattern, and water-comfort preference.
 
 ## Configuration
 
@@ -42,7 +42,7 @@ operating_hours_of_each_deferrable_load:
   - 0           # DHW is fully temperature-driven, hour budget unused
 ```
 
-The `thermal_config` for DHW comes from the runtime payload, not the static config — the deadline profile changes day to day (or hour to hour, if you adapt to forecast).
+The `thermal_config` for DHW comes from the runtime payload, not the static config; the deadline profile changes day to day (or hour to hour, if you adapt to forecast).
 
 ## Runtime payload
 
@@ -98,34 +98,34 @@ rest_command:
       }
 ```
 
-The Jinja loop is illustrative — production systems usually build the array outside HA (Node-RED Function node, AppDaemon, etc.) where set logic is easier. The contract EMHASS sees is just a list of length `prediction_horizon` floats in `desired_temperatures`.
+The Jinja loop is illustrative. Production systems usually build the array outside HA (Node-RED Function node, AppDaemon, etc.) where set logic is easier. The contract EMHASS sees is just a list of length `prediction_horizon` floats in `desired_temperatures`.
 
 ## How EMHASS uses this
 
-EMHASS treats `desired_temperatures[k]` as the target for timestep `k`. With `cooling_constant` modelling the natural tank cool-down, the optimizer schedules heat-pump runtime **anywhere in the horizon** that minimizes cost while ensuring the tank reaches each target by its deadline. If the cheapest slot is overnight, it heats overnight and lets the tank coast. If a midday Tibber dip appears, it shifts heating into the dip.
+EMHASS treats `desired_temperatures[k]` as the target for timestep `k`. With `cooling_constant` modelling the natural tank cool-down, the optimizer schedules heat-pump runtime anywhere in the horizon that minimizes cost while ensuring the tank reaches each target by its deadline. If the cheapest slot is overnight, it heats overnight and lets the tank coast. If a midday Tibber dip appears, it shifts heating into the dip.
 
-The `overshoot_temperature` is a hard ceiling — the optimizer will not push the tank past it even if free PV is available.
+The `overshoot_temperature` is a hard ceiling: the optimizer will not push the tank past it even if free PV is available.
 
 ## Real-world example
 
 With a 26 April 2026 Tibber-day where the lowest spot price was −0.42 EUR/kWh between 13:00 and 14:30, the deadline profile produced:
 
-- **Old fixed profile** (55 °C between 09:00–16:00): heat pump ran at 08:30–09:30 to hit the 09:00 deadline. Cost ≈ 0.20 EUR.
-- **New deadline profile** (base 45, evening spike 50 at 18:00): heat pump ran at 13:00–14:30 — exactly during the negative-price slot. Earned ≈ 1.50 EUR. Tank reached 50 °C by 18:00 deadline as required.
+- Old fixed profile (55 °C between 09:00–16:00): heat pump ran at 08:30–09:30 to hit the 09:00 deadline. Cost ≈ 0.20 EUR.
+- New deadline profile (base 45, evening spike 50 at 18:00): heat pump ran at 13:00–14:30, exactly during the negative-price slot. Earned ≈ 1.50 EUR. Tank reached 50 °C by 18:00 deadline as required.
 
-Net spread: ~1.70 EUR for the day. The same tank, the same demand — only the temperature profile changed.
+Net spread: ~1.70 EUR for the day. The same tank, the same demand, only the temperature profile changed.
 
 ## Caveats
 
-- **One heat pump can't do heating and DHW simultaneously.** If your unit (e.g. Tecalor THZ, Daikin Altherma, Vaillant aroTHERM) shares a single compressor, EMHASS plans both deferrable loads but the unit's own controller picks priority each minute. Pass `def_current_state[<dhw_slot>] = wpDhwOn` (boolean from your real-world DHW-mode sensor) so the optimizer knows whether DHW is currently active in the first timestep.
-- **`cooling_constant` calibration matters.** A too-optimistic value (tank cools slowly in the model but fast in reality) leads to "tank not hot enough at deadline" complaints. Start from a measured value: heat tank to 50 °C, log temperature over 24 h with no demand, fit the exponential decay. A 200 L tank in a typical utility room sits around `cooling_constant = 0.02` per hour. If you cannot calibrate, raise `desired_temperature_base` from 45 to 47–48 to give the optimizer more thermal margin.
-- **Legionella cycles are NOT handled.** EMHASS does not know your tank needs a weekly 60 °C cycle for Legionella prevention. Run that as a separate scheduled override outside EMHASS, or raise the spike temperature to 60 °C on one day per week.
-- **`thermal_config` vs `thermal_battery`.** This page uses the legacy `thermal_config` model with `desired_temperatures` because deadline profiles map naturally to per-timestep targets. The newer `thermal_battery` model uses `min_temperatures` / `max_temperatures` and is better suited to underfloor-slab scenarios — see [heat_pump_walkthrough.md](heat_pump_walkthrough.md).
+- One heat pump can't do heating and DHW simultaneously. If your unit (e.g. Tecalor THZ, Daikin Altherma, Vaillant aroTHERM) shares a single compressor, EMHASS plans both deferrable loads but the unit's own controller picks priority each minute. Pass `def_current_state[<dhw_slot>] = wpDhwOn` (boolean from your real-world DHW-mode sensor) so the optimizer knows whether DHW is currently active in the first timestep.
+- `cooling_constant` calibration matters. A too-optimistic value (tank cools slowly in the model but fast in reality) leads to "tank not hot enough at deadline" complaints. Start from a measured value: heat tank to 50 °C, log temperature over 24 h with no demand, fit the exponential decay. A 200 L tank in a typical utility room sits around `cooling_constant = 0.02` per hour. If you cannot calibrate, raise `desired_temperature_base` from 45 to 47–48 to give the optimizer more thermal margin.
+- Legionella cycles are NOT handled. EMHASS does not know your tank needs a weekly 60 °C cycle for Legionella prevention. Run that as a separate scheduled override outside EMHASS, or raise the spike temperature to 60 °C on one day per week.
+- `thermal_config` vs `thermal_battery`. This page uses the legacy `thermal_config` model with `desired_temperatures` because deadline profiles map naturally to per-timestep targets. The newer `thermal_battery` model uses `min_temperatures` / `max_temperatures` and is better suited to underfloor-slab scenarios; see [heat_pump_walkthrough.md](heat_pump_walkthrough.md).
 
 ## See also
 
-- How-to: [Heat-pump walkthrough](heat_pump_walkthrough.md) — slab-heating with the `thermal_battery` model, complementary to this DHW pattern
-- How-to: [MPC walkthrough](mpc.md) — generic rolling-horizon pattern
-- Reference: [thermal_model.md](../thermal_model.md) — full parameter list for `thermal_config`
-- Reference: [Passing data](../passing_data.md) — runtime payload schema
-- Explanation: [Good Practices](good_practices.md) — forecast-quality, infeasibility triage
+- How-to: [Heat-pump walkthrough](heat_pump_walkthrough.md) (slab-heating with the `thermal_battery` model, complementary to this DHW pattern)
+- How-to: [MPC walkthrough](mpc.md) (generic rolling-horizon pattern)
+- Reference: [thermal_model.md](../thermal_model.md) (full parameter list for `thermal_config`)
+- Reference: [Passing data](../passing_data.md) (runtime payload schema)
+- Explanation: [Good Practices](good_practices.md) (forecast quality, infeasibility triage)

--- a/docs/study_cases/dhw_walkthrough.md
+++ b/docs/study_cases/dhw_walkthrough.md
@@ -26,7 +26,7 @@ Build the `desired_temperatures` array as three layers stacked over the horizon:
 | Morning spike | 48 °C | last 30 min before 07:00 (1 timestep at 30-min step) |
 | Evening spike | 50 °C | last 1 h before 18:00 (2 timesteps at 30-min step) |
 
-In addition, set `overshoot_temperature: 59 °C` as a hard upper bound (separate constraint, not part of the per-timestep target array). It prevents Legionella-cycle conflicts and excessive tank stress.
+In addition, set `overshoot_temperature` to your tank's configured day-maximum (in this example, 59 °C). It is a hard upper bound: the optimizer will not push the tank past it even if free PV is available. Note that values below the typical 60 °C Legionella-prevention threshold mean EMHASS will not heat the tank into that range automatically; handle Legionella cycles separately (see Caveats).
 
 These values are starting points. Adjust to your tank size, usage pattern, and water-comfort preference.
 

--- a/docs/study_cases/dhw_walkthrough.md
+++ b/docs/study_cases/dhw_walkthrough.md
@@ -118,12 +118,7 @@ The `overshoot_temperature` is a hard ceiling: the optimizer will not push the t
 
 ## Real-world example
 
-With a 26 April 2026 Tibber-day where the lowest spot price was −0.42 EUR/kWh between 13:00 and 14:30, the deadline profile produced:
-
-- Old fixed profile (55 °C between 09:00–16:00): heat pump ran at 08:30–09:30 to hit the 09:00 deadline. Cost ≈ 0.20 EUR.
-- New deadline profile (base 45, evening spike 50 at 18:00): heat pump ran at 13:00–14:30, exactly during the negative-price slot. Earned ≈ 1.50 EUR. Tank reached 50 °C by 18:00 deadline as required.
-
-Net spread: ~1.70 EUR for the day. The same tank, the same demand, only the temperature profile changed.
+On a 26 April 2026 Tibber-day with spot prices reaching −0.42 EUR/kWh between 13:00 and 14:30, switching from a fixed daily profile (55 °C between 09:00 and 16:00) to the deadline profile (base 45 °C, evening spike 50 °C at 18:00) shifted DHW heating from a morning slot into the 13:00–14:30 negative-price window. Net spread: about 1.70 EUR for the day. Same tank, same demand, only the temperature profile changed.
 
 ## Caveats
 

--- a/docs/study_cases/dhw_walkthrough.md
+++ b/docs/study_cases/dhw_walkthrough.md
@@ -1,0 +1,131 @@
+# Domestic hot water (DHW) — deadline-driven temperature profile
+
+> **Type:** How-To Guide — task-oriented, follow when scheduling a heat-pump-fed DHW tank against dynamic prices.
+
+A DHW tank is a thermal store, but unlike an underfloor slab it has natural usage spikes (morning shower, evening dishes) that anchor when the water has to be hot — not a continuous comfort range. The naive approach is a fixed daily profile (e.g. "always at least 55 °C between 09:00 and 16:00"), which forces the heat pump to run at a fixed time of day regardless of price.
+
+A better pattern is a **deadline-driven profile**: a low base temperature most of the time, with short windowed spikes just before each usage deadline. The optimizer is then free to pick the cheapest slot in the 24 h leading up to each spike — overnight when prices are low, midday during PV surplus, or whenever a dynamic-tariff dip happens.
+
+## Scenario
+
+| Component | Value |
+|-----------|-------|
+| Heat pump | one combined HP that does space heating *and* DHW (e.g. Tecalor THZ, integrated air-source HP) |
+| DHW tank | a hot-water tank with temperature sensor at the top |
+| Usage pattern | morning shower around 07:00, evening dishes/shower around 18:00 |
+| Tariff | dynamic (Tibber, aWATTar, Octopus Agile) |
+| Optimization mode | naive-mpc-optim |
+
+## Deadline profile
+
+Express the DHW comfort target as three layers stacked in the runtime payload:
+
+| Layer | Value | Where |
+|-------|-------|-------|
+| Base (always) | 45 °C | every timestep — comfort floor; tank may float down to here |
+| Morning spike | 48 °C | last 30 min before 07:00 (1 timestep at 30-min step) |
+| Evening spike | 50 °C | last 1 h before 18:00 (2 timesteps at 30-min step) |
+| Anti-cap | 59 °C `overshoot_temperature` | upper bound to prevent Legionella-cycle conflict and tank stress |
+
+These values are starting points — adjust to your tank size, usage pattern, and water-comfort preference.
+
+## Configuration
+
+DHW runs through the same deferrable-load slot machinery as any other thermal load. Pick a slot for the DHW (e.g. the second deferrable) and configure its `thermal_config`:
+
+```yaml
+nominal_power_of_deferrable_loads:
+  - 0           # space heating (handled separately, see heat_pump_walkthrough.md)
+  - 2500        # DHW heat pump electric input — adjust to your unit
+operating_hours_of_each_deferrable_load:
+  - 0
+  - 0           # DHW is fully temperature-driven, hour budget unused
+```
+
+The `thermal_config` for DHW comes from the runtime payload, not the static config — the deadline profile changes day to day (or hour to hour, if you adapt to forecast).
+
+## Runtime payload
+
+Build the deadline-profile arrays in your Home Assistant `rest_command` template (or Node-RED Function node). The example below assumes 30-minute timesteps and a 24 h horizon:
+
+```yaml
+rest_command:
+  emhass_dhw_mpc:
+    url: http://localhost:5000/action/naive-mpc-optim
+    method: POST
+    timeout: 120
+    headers:
+      content-type: application/json
+    payload: >
+      {%- set horizon = 48 -%}
+      {%- set timestep_min = 30 -%}
+      {%- set base = 45.0 -%}
+      {%- set morning_temp = 48.0 -%}
+      {%- set morning_hour = 7 -%}
+      {%- set morning_window_slots = 1 -%}
+      {%- set evening_temp = 50.0 -%}
+      {%- set evening_hour = 18 -%}
+      {%- set evening_window_slots = 2 -%}
+      {%- set ns = namespace(profile=[]) -%}
+      {%- for step in range(horizon) -%}
+        {%- set hour = (now().hour + (step * timestep_min) // 60) % 24 -%}
+        {%- set in_morning = (hour == morning_hour) and (step >= horizon - morning_window_slots) -%}
+        {%- set in_evening = (hour == evening_hour) -%}
+        {%- if in_evening -%}
+          {%- set ns.profile = ns.profile + [evening_temp] -%}
+        {%- elif in_morning -%}
+          {%- set ns.profile = ns.profile + [morning_temp] -%}
+        {%- else -%}
+          {%- set ns.profile = ns.profile + [base] -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {
+        "prediction_horizon": {{ horizon }},
+        "soc_init": {{ states('sensor.battery_soc') | float / 100 }},
+        "def_load_config": [
+          {},
+          {
+            "thermal_config": {
+              "heating_rate": 4.0,
+              "cooling_constant": 0.02,
+              "start_temperature": {{ states('sensor.dhw_tank_temperature') | float }},
+              "sense": "heat",
+              "overshoot_temperature": 59.0,
+              "desired_temperatures": {{ ns.profile | tojson }}
+            }
+          }
+        ]
+      }
+```
+
+The Jinja loop is illustrative — production systems usually build the array outside HA (Node-RED Function node, AppDaemon, etc.) where set logic is easier. The contract EMHASS sees is just a list of length `prediction_horizon` floats in `desired_temperatures`.
+
+## How EMHASS uses this
+
+EMHASS treats `desired_temperatures[k]` as the target for timestep `k`. With `cooling_constant` modelling the natural tank cool-down, the optimizer schedules heat-pump runtime **anywhere in the horizon** that minimizes cost while ensuring the tank reaches each target by its deadline. If the cheapest slot is overnight, it heats overnight and lets the tank coast. If a midday Tibber dip appears, it shifts heating into the dip.
+
+The `overshoot_temperature` is a hard ceiling — the optimizer will not push the tank past it even if free PV is available.
+
+## Real-world example
+
+With a 26 April 2026 Tibber-day where the lowest spot price was −0.42 EUR/kWh between 13:00 and 14:30, the deadline profile produced:
+
+- **Old fixed profile** (55 °C between 09:00–16:00): heat pump ran at 08:30–09:30 to hit the 09:00 deadline. Cost ≈ 0.20 EUR.
+- **New deadline profile** (base 45, evening spike 50 at 18:00): heat pump ran at 13:00–14:30 — exactly during the negative-price slot. Earned ≈ 1.50 EUR. Tank reached 50 °C by 18:00 deadline as required.
+
+Net spread: ~1.70 EUR for the day. The same tank, the same demand — only the temperature profile changed.
+
+## Caveats
+
+- **One heat pump can't do heating and DHW simultaneously.** If your unit (e.g. Tecalor THZ, Daikin Altherma, Vaillant aroTHERM) shares a single compressor, EMHASS plans both deferrable loads but the unit's own controller picks priority each minute. Pass `def_current_state[<dhw_slot>] = wpDhwOn` (boolean from your real-world DHW-mode sensor) so the optimizer knows whether DHW is currently active in the first timestep.
+- **`cooling_constant` calibration matters.** A too-optimistic value (tank cools slowly in the model but fast in reality) leads to "tank not hot enough at deadline" complaints. Start from a measured value: heat tank to 50 °C, log temperature over 24 h with no demand, fit the exponential decay. A 200 L tank in a typical utility room sits around `cooling_constant = 0.02` per hour. If you cannot calibrate, raise `desired_temperature_base` from 45 to 47–48 to give the optimizer more thermal margin.
+- **Legionella cycles are NOT handled.** EMHASS does not know your tank needs a weekly 60 °C cycle for Legionella prevention. Run that as a separate scheduled override outside EMHASS, or raise the spike temperature to 60 °C on one day per week.
+- **`thermal_config` vs `thermal_battery`.** This page uses the legacy `thermal_config` model with `desired_temperatures` because deadline profiles map naturally to per-timestep targets. The newer `thermal_battery` model uses `min_temperatures` / `max_temperatures` and is better suited to underfloor-slab scenarios — see [heat_pump_walkthrough.md](heat_pump_walkthrough.md).
+
+## See also
+
+- How-to: [Heat-pump walkthrough](heat_pump_walkthrough.md) — slab-heating with the `thermal_battery` model, complementary to this DHW pattern
+- How-to: [MPC walkthrough](mpc.md) — generic rolling-horizon pattern
+- Reference: [thermal_model.md](../thermal_model.md) — full parameter list for `thermal_config`
+- Reference: [Passing data](../passing_data.md) — runtime payload schema
+- Explanation: [Good Practices](good_practices.md) — forecast-quality, infeasibility triage

--- a/docs/study_cases/ev.md
+++ b/docs/study_cases/ev.md
@@ -1,0 +1,142 @@
+# EV charging as a deferrable load
+
+> **Type:** How-To Guide — task-oriented.
+>
+> ```{warning}
+> **Early-draft page.** EV charging in EMHASS is an active community topic
+> ([discussion #789](https://github.com/davidusb-geek/emhass/discussions/789)).
+> The pattern below — treating the charger as a windowed deferrable load —
+> covers the common case but has known limits. See *Known limits* at the
+> end of this page before relying on it. Contributions and corrections
+> welcome.
+> ```
+
+EMHASS treats an EV charger as a windowed deferrable load: a fixed energy amount that must be delivered before some end time, with charging power up to the charger's rated nominal power. The optimizer then chooses *when* in the available window to charge.
+
+This page covers the **EMHASS-side configuration**. The transport — how the EV's required-energy and target-SOC reach EMHASS at runtime — depends on your charger and home-automation setup. Any source that can publish the right signals into Home Assistant (or directly into your `rest_command` payload) will work: OCPP-managed chargers, vehicle-API integrations (Tesla, Hyundai BlueLink, etc.), Modbus chargers, EVCC, or pure HA scripts ([one community example](https://sigenergy.annable.me/emhass/)).
+
+## Scenario
+
+| Component | Value |
+|-----------|-------|
+| EV charger | AC, single fixed charging power for the whole session |
+| Vehicle | a target energy amount in kWh that must be delivered before a deadline |
+| Existing system | PV + battery (per [Basic — PV + Battery](basic_pv_battery.md)) |
+| Optimization mode | naive-mpc-optim |
+
+## Configuration
+
+The EV slot goes into `nominal_power_of_deferrable_loads`, with corresponding entries in `operating_hours_of_each_deferrable_load`, `start_timesteps_of_each_deferrable_load`, and `end_timesteps_of_each_deferrable_load`. Most of these are placeholders in the static config and get overridden per MPC call.
+
+Example (assuming the EV is the third deferrable, after two existing loads):
+
+```yaml
+nominal_power_of_deferrable_loads:
+  - 3000        # water heater
+  - 750         # pool pump
+  - <CHARGER_W> # EV charger nominal power, e.g. 3700 (1ph 16A), 7400 (1ph 32A), 11000 (3ph 16A)
+operating_hours_of_each_deferrable_load:
+  - 5
+  - 8
+  - 0           # placeholder; overridden at runtime
+start_timesteps_of_each_deferrable_load:
+  - 0
+  - 0
+  - 0           # placeholder; overridden at runtime
+end_timesteps_of_each_deferrable_load:
+  - 48
+  - 48
+  - 0           # placeholder; overridden at runtime
+```
+
+## Runtime payload
+
+Two values you compute fresh per MPC call:
+
+| Variable | Source | Calculation |
+|----------|--------|-------------|
+| `def_total_hours[2]` | a sensor that reports remaining kWh to deliver | `kWh_remaining / charger_kW`, rounded to whole hours (see *Known limits*) |
+| `end_timesteps_of_each_deferrable_load[2]` | departure deadline | `(deadline - now) / optimization_time_step_minutes`, integer |
+
+A Home Assistant `rest_command` template, source-agnostic:
+
+```yaml
+rest_command:
+  emhass_mpc:
+    url: http://localhost:5000/action/naive-mpc-optim
+    method: POST
+    timeout: 120
+    headers:
+      content-type: application/json
+    payload: >
+      {%- set charger_kw = 11.0 -%}
+      {%- set timestep_min = 30 -%}
+      {%- set horizon = 48 -%}
+      {%- set ev_remaining_kwh = states('sensor.YOUR_EV_REMAINING_KWH') | float -%}
+      {%- set ev_hours = (ev_remaining_kwh / charger_kw) | round(0) | int -%}
+      {%- set departure_minutes = (today_at("07:00") - now()).total_seconds() / 60 -%}
+      {%- set end_step = (departure_minutes / timestep_min) | int -%}
+      {
+        "prediction_horizon": {{ horizon }},
+        "soc_init": {{ states('sensor.battery_soc') | float / 100 }},
+        "def_total_hours": [
+          {{ states('sensor.water_heater_remaining_hours') }},
+          {{ states('sensor.pool_pump_remaining_hours') }},
+          {{ ev_hours }}
+        ],
+        "end_timesteps_of_each_deferrable_load": [{{ horizon }}, {{ horizon }}, {{ end_step }}]
+      }
+```
+
+Replace `sensor.YOUR_EV_REMAINING_KWH` with the actual sensor your integration publishes. The contract is: a sensor that reports kWh remaining to deliver before the next deadline.
+
+## Output
+
+`sensor.p_deferrable2` carries the optimized EV charging power per timestep. An HA automation drives the charger:
+
+```yaml
+automation:
+  - alias: EV charging follow EMHASS plan
+    trigger:
+      - platform: state
+        entity_id: sensor.p_deferrable2
+    action:
+      - choose:
+          - conditions:
+              - condition: numeric_state
+                entity_id: sensor.p_deferrable2
+                above: 100
+            sequence:
+              - service: switch.turn_on
+                target:
+                  entity_id: switch.YOUR_EV_CHARGER
+          - default:
+              - service: switch.turn_off
+                target:
+                  entity_id: switch.YOUR_EV_CHARGER
+```
+
+Replace `switch.YOUR_EV_CHARGER` with the actual control entity for your charger.
+
+## Known limits
+
+Read these before designing around the pattern above.
+
+- **Integer hours only.** `operating_hours_of_each_deferrable_load` accepts whole hours, not fractions ([issue #373](https://github.com/davidusb-geek/emhass/issues/373)). With a 30-minute timestep and an 11 kW charger, that means kWh-required is rounded up to the next 11 kWh increment. Reduce the rounding error by using a smaller `optimization_time_step` (e.g. 15 minutes) — but then 48 timesteps becomes 96.
+- **Power modulation is not supported.** EMHASS schedules the deferrable as either-on-at-nominal-power-or-off per timestep. Modulating chargers (e.g. Tesla 3.6–11 kW continuous) cannot be cleanly expressed as a single deferrable; you would need multiple parallel deferrable slots at different powers, or model only the upper bound.
+- **Mid-session state is not forced.** `def_current_state` flags the load as currently-on for startup-penalty purposes but does not force the optimizer to plan a non-zero power for the first timestep ([issue #605](https://github.com/davidusb-geek/emhass/issues/605)). If you start charging manually mid-window, the optimizer may plan to stop and re-start.
+- **No native vehicle-API integration.** EMHASS does not query the vehicle SOC directly; you provide kWh-remaining via a sensor. The community has seen this gap and discussed approaches in [#789](https://github.com/davidusb-geek/emhass/discussions/789), including a fork by @tomvanacker85 with calendar-driven SOC targets. None of those have been upstreamed.
+- **Opportunistic / surplus-only charging is awkward.** If you want "charge only from PV surplus, no grid", the deferrable-load model is not the right fit — the optimizer treats the kWh-target as mandatory. Surplus-only charging is typically handled outside EMHASS (in EVCC's PV mode, or HA automations) with EMHASS optimizing the rest of the system around it.
+
+## Infeasibility
+
+If `(end_step - start_step) × charger_kw < required_kwh`, the optimization is infeasible. EMHASS returns `optim_status: "infeasible"` and publishes nothing. See [Good Practices — infeasibility triage](good_practices.md).
+
+## See also
+
+- How-to: [MPC walkthrough](mpc.md) for the underlying MPC pattern
+- How-to: [Heat-pump walkthrough](heat_pump_walkthrough.md) — combine EV + heat-pump in one system
+- Reference: [Passing data](../passing_data.md) for all runtime params
+- Reference: [Automations](../automations.md) — `shell_command` / `rest_command` patterns
+- Discussion: [#789 — EV charging addon capability](https://github.com/davidusb-geek/emhass/discussions/789)
+- Explanation: [Good Practices](good_practices.md) — infeasibility triage

--- a/docs/study_cases/ev.md
+++ b/docs/study_cases/ev.md
@@ -131,7 +131,7 @@ Read these before designing around the pattern above.
 
 ## Infeasibility
 
-If `(end_step - start_step) × charger_kw < required_kwh`, the optimization is infeasible. EMHASS returns `optim_status: "infeasible"` and publishes nothing. See [Good Practices — infeasibility triage](good_practices.md).
+If `(end_step - start_step) × charger_kw < required_kwh`, the optimization is infeasible. EMHASS returns `optim_status: "Infeasible"` and publishes nothing. See [Good Practices — infeasibility triage](good_practices.md).
 
 ## See also
 

--- a/docs/study_cases/ev.md
+++ b/docs/study_cases/ev.md
@@ -73,8 +73,9 @@ rest_command:
       {%- set timestep_min = 30 -%}
       {%- set horizon = 48 -%}
       {%- set ev_remaining_kwh = states('sensor.YOUR_EV_REMAINING_KWH') | float -%}
-      {%- set ev_hours = (ev_remaining_kwh / charger_kw) | round(0) | int -%}
-      {%- set departure_minutes = (today_at("07:00") - now()).total_seconds() / 60 -%}
+      {%- set ev_hours = (ev_remaining_kwh / charger_kw) | round(0, 'ceil') | int -%}
+      {%- set deadline = today_at("07:00") if now() < today_at("07:00") else today_at("07:00") + timedelta(days=1) -%}
+      {%- set departure_minutes = (deadline - now()).total_seconds() / 60 -%}
       {%- set end_step = (departure_minutes / timestep_min) | int -%}
       {
         "prediction_horizon": {{ horizon }},

--- a/docs/study_cases/good_practices.md
+++ b/docs/study_cases/good_practices.md
@@ -11,7 +11,7 @@ A common newcomer mistake is to spend hours tuning battery parameters (`battery_
 The dominant factor in real-world cost-minimization is the **gap between forecasted and actual** PV power, load power, and price. A 10% improvement in PV forecast accuracy typically yields more cost savings than retuning battery parameters from default to "perfect".
 
 In practice:
-- The default PV forecast method is `open-meteo` (free, no API key). Community feedback in EMHASS discussions repeatedly favors **Solcast** (free tier: 10 calls/day) when accuracy matters most. **Forecast.Solar** is another free alternative; **clearoutside** web-scraping is a fallback that some users still prefer.
+- The default PV forecast method is `open-meteo` (free, no API key, configured as `weather_forecast_method: open-meteo`). Community feedback in EMHASS discussions repeatedly favors **Solcast** (free tier: 10 calls/day, `weather_forecast_method: solcast`) when accuracy matters most. **Forecast.Solar** is another free option (`weather_forecast_method: solar.forecast`). EMHASS also supports a clearoutside.com scraper (`weather_forecast_method: scrapper`) as a fallback some users still prefer.
 - Load forecast 1-day-persistence is fine for routine households. It breaks on holiday weekends. The [ML Forecaster](../mlforecaster.md) helps if you have ≥ 1 month of history.
 - Dynamic price forecasts must come from the tariff provider (Tibber, aWATTar, Octopus, Stromee, Nordpool, etc.) via runtime payload — there is no useful default for these.
 
@@ -49,11 +49,11 @@ For rolling MPC, the often-cited concern is that a fixed `soc_final` reserves ca
 
 Pass `soc_final` explicitly only when you have a hard end-of-horizon target (e.g. "must be at 60% by tomorrow 06:00 to absorb morning PV"). In that case you may also want to extend the horizon so the constraint sits at the actual deadline, not 24 h after the current re-run.
 
-A common new-user trap is the opposite: starting with very low actual SOC. If `soc_init = 0.05` but `battery_minimum_state_of_charge = 0.30`, the optimizer cannot find any valid trajectory because the *initial* state already violates a constraint. Result: `optim_status: infeasible`. See [discussion #359](https://github.com/davidusb-geek/emhass/discussions/359) for the canonical thread on this.
+A common new-user trap is the opposite: starting with very low actual SOC where `soc_init` is below `battery_minimum_state_of_charge`. The optimization becomes infeasible because the initial state already violates a constraint. See Section 5 below (item 4) for the full triage and [discussion #359](https://github.com/davidusb-geek/emhass/discussions/359) for the canonical thread.
 
-## 5. `optim_status: infeasible` triage order
+## 5. `optim_status: Infeasible` triage order
 
-When EMHASS returns `optim_status: "infeasible"` and publishes nothing, work through this list in order. The first match is almost always the cause.
+When EMHASS returns `optim_status: "Infeasible"` and publishes nothing, work through this list in order. The first match is almost always the cause.
 
 1. **Forecast NaN.** A sensor publishing `unavailable` becomes a NaN in the forecast list and the solver chokes. Check `pv_power_forecast`, `load_power_forecast`, `load_cost_forecast`, `prod_price_forecast` for NaN/None entries. Fix at the HA-template level (use `default(0)` or filter out unavailable states).
 2. **Timestep mismatch.** List lengths don't match `prediction_horizon`. See section 2 above.
@@ -68,7 +68,7 @@ The new stage-timing banner introduced in upstream PR [#806](https://github.com/
 
 | Action | Recommended interval |
 |--------|----------------------|
-| `naive-mpc-optim` | 30 min (default `optimization_time_step`) |
+| `naive-mpc-optim` | every `optimization_time_step` minutes (default 30); set your HA automation trigger to match |
 | `dayahead-optim` | once per day, around 05:30 local time (after spot prices publish) |
 | `publish-data` | every 5 min (or use `continual_publish: true`) |
 | Forecast refresh | every 30–60 min |
@@ -77,18 +77,23 @@ Running `naive-mpc-optim` every 1 minute is overkill for residential systems and
 
 ## 7. Logs and stage timing
 
-The CLI and Add-on log to `data/action_logs.txt`. The Add-on web UI exposes them under the *Logs* tab.
+The CLI and Add-on log to `data/logger_emhass.log`. The Add-on web UI exposes them under the *Logs* tab.
 
-The format starts with timestamp, log level, message — for example:
+At the default log level (INFO), each optimization run emits a runtime banner and a one-line summary:
+
 ```
-2026-04-26 17:00:00,123 INFO Stage 1/4 (input_data) — 0.20 s
-2026-04-26 17:00:00,355 INFO Stage 2/4 (pv_forecast) — 0.23 s
-2026-04-26 17:00:00,612 INFO Stage 3/4 (load_forecast) — 0.26 s
-2026-04-26 17:00:00,888 INFO Stage 4/4 (lp_solve) — 0.27 s
-2026-04-26 17:00:00,889 INFO Total: 0.96 s, optim_status: optimal
+2026-04-26 17:00:00 INFO     EMHASS 0.17.2 | Python 3.11.9 | CVXPY 1.5.3 (Highs) | Linux-x86_64
+2026-04-26 17:00:01 INFO     Optimization completed in 0.96s (top: optim_solve=0.52s, 54%)
 ```
 
-If a particular stage consistently dominates, that's where to look first. PV-forecast stage > 5 s usually means a remote API timeout (Solcast / Forecast.Solar). LP-solve > 30 s typically means the problem size has grown — either reduce horizon or increase `lp_solver_timeout`.
+The banner is emitted by `log_runtime_banner` (added in PR [#806](https://github.com/davidusb-geek/emhass/pull/806)) and is useful when filing bug reports — the EMHASS / Python / CVXPY / solver / platform combination is printed at the start of every run.
+
+The summary identifies which stage dominated total runtime. Common patterns:
+- `top: pv_forecast=...` consistently dominating usually means a remote API timeout (Solcast / Forecast.Solar). Check network access and API keys.
+- `top: optim_solve=...` taking more than 30 s usually means the problem size has grown — either reduce the prediction horizon or increase `lp_solver_timeout`.
+- `top: input_data=...` or `top: load_forecast=...` taking long usually means a slow Home Assistant database query — check sensor history depth.
+
+Per-stage timings are recorded internally (in `input_data_dict["stage_times"]`) for every run but are only logged at DEBUG level. To see them, raise the log level to DEBUG temporarily (in `config_emhass.yaml` set `logging_level: DEBUG`, or use the Add-on advanced options). Each stage is logged as `Stage [<name>] completed in <X.XXX>s`.
 
 ## See also
 

--- a/docs/study_cases/good_practices.md
+++ b/docs/study_cases/good_practices.md
@@ -1,0 +1,100 @@
+# Good Practices
+
+> **Type:** Explanation — understanding-oriented. Hard-learned wisdom about EMHASS that is not obvious from the parameter reference.
+
+This page collects insights that come from running EMHASS in production over months: what matters, what doesn't, and what surprises new users. Treat it as the *why* behind several recommendations scattered across the tutorials and how-to guides.
+
+## 1. Forecast quality dominates parameter tuning
+
+A common newcomer mistake is to spend hours tuning battery parameters (`battery_minimum_state_of_charge`, `battery_charge_power_max`, `battery_charge_efficiency`, …) while leaving the PV forecast and load forecast at defaults.
+
+The dominant factor in real-world cost-minimization is the **gap between forecasted and actual** PV power, load power, and price. A 10% improvement in PV forecast accuracy typically yields more cost savings than retuning battery parameters from default to "perfect".
+
+In practice:
+- The default PV forecast method is `open-meteo` (free, no API key). Community feedback in EMHASS discussions repeatedly favors **Solcast** (free tier: 10 calls/day) when accuracy matters most. **Forecast.Solar** is another free alternative; **clearoutside** web-scraping is a fallback that some users still prefer.
+- Load forecast 1-day-persistence is fine for routine households. It breaks on holiday weekends. The [ML Forecaster](../mlforecaster.md) helps if you have ≥ 1 month of history.
+- Dynamic price forecasts must come from the tariff provider (Tibber, aWATTar, Octopus, Stromee, Nordpool, etc.) via runtime payload — there is no useful default for these.
+
+Before tuning anything else, **measure your forecast errors** for at least a week and address the largest one. The [HA forum thread](https://community.home-assistant.io/t/emhass-an-energy-management-for-home-assistant/338126) has many user reports comparing forecast methods.
+
+## 2. Timestep alignment
+
+EMHASS internally works with a fixed `optimization_time_step` (default: 30 minutes). Three numbers must agree:
+
+| Parameter | Default | Constraint |
+|-----------|---------|------------|
+| `optimization_time_step` | 30 min | EMHASS internal |
+| HA sensor publish interval | 5 min | should be ≤ `optimization_time_step` |
+| Forecast list length | (matches horizon) | `prediction_horizon × optimization_time_step / forecast_step` items |
+
+If your `prediction_horizon` is `N` and `optimization_time_step` is 30 minutes, lists like `pv_power_forecast` must be **`N` items long** — one per timestep — not hourly. EMHASS does not auto-resample. A length mismatch causes silent truncation or padding with zeros, which then poisons the optimization.
+
+Concrete example: a 24-hour horizon at 30-minute step = 48 items per list; at 15-minute step = 96 items.
+
+## 3. SOC convention: fraction of nominal capacity
+
+EMHASS expresses SOC as a fraction `[0.0, 1.0]` of the **nominal** battery capacity (`battery_nominal_energy_capacity`, `Enom`). The bounds `battery_minimum_state_of_charge` (default 0.3) and `battery_maximum_state_of_charge` (default 0.9) are operational *limits* the optimizer respects — they do **not** rescale the reported SOC value.
+
+So a published `sensor.soc_optim = 0.45` means 45% of nominal capacity, regardless of what the bounds are. This matches what your battery management system reports (assuming it also uses 0..100% of nominal). No conversion is needed when comparing the two.
+
+Source: `optimization.py` constraints `min_energy = battery_minimum_state_of_charge × cap`, `max_energy = battery_maximum_state_of_charge × cap`.
+
+If your downstream automation or display does need a different convention (e.g. percentage of *usable* range), apply the transform yourself in a HA template — but don't assume EMHASS already did it.
+
+## 4. `soc_init` and `soc_final` defaults are forgiving
+
+For day-ahead optimization, setting `soc_final` to a desired end-of-day SOC (e.g. 0.6) ensures you don't end the day empty. EMHASS uses `battery_target_state_of_charge` (default 0.6) as the fallback when neither `soc_init` nor `soc_final` is passed.
+
+For rolling MPC, the often-cited concern is that a fixed `soc_final` reserves capacity at the trailing edge of every horizon and biases the optimizer toward conservative mid-day behavior. This is real, but the EMHASS code already handles the common case: when you pass only `soc_init` at runtime, EMHASS auto-sets `soc_final = soc_init`. So **passing only `soc_init`** in your MPC payload is the standard rolling-MPC recipe.
+
+Pass `soc_final` explicitly only when you have a hard end-of-horizon target (e.g. "must be at 60% by tomorrow 06:00 to absorb morning PV"). In that case you may also want to extend the horizon so the constraint sits at the actual deadline, not 24 h after the current re-run.
+
+A common new-user trap is the opposite: starting with very low actual SOC. If `soc_init = 0.05` but `battery_minimum_state_of_charge = 0.30`, the optimizer cannot find any valid trajectory because the *initial* state already violates a constraint. Result: `optim_status: infeasible`. See [discussion #359](https://github.com/davidusb-geek/emhass/discussions/359) for the canonical thread on this.
+
+## 5. `optim_status: infeasible` triage order
+
+When EMHASS returns `optim_status: "infeasible"` and publishes nothing, work through this list in order. The first match is almost always the cause.
+
+1. **Forecast NaN.** A sensor publishing `unavailable` becomes a NaN in the forecast list and the solver chokes. Check `pv_power_forecast`, `load_power_forecast`, `load_cost_forecast`, `prod_price_forecast` for NaN/None entries. Fix at the HA-template level (use `default(0)` or filter out unavailable states).
+2. **Timestep mismatch.** List lengths don't match `prediction_horizon`. See section 2 above.
+3. **Windowed-deferrable infeasibility.** A windowed deferrable load (EV, washing machine with hard deadline) requires more energy than the window×nominal-power product allows. Either widen the window, increase the power, or reduce the required energy.
+4. **Battery state contradicts limits.** `soc_init = 0.05` but `battery_minimum_state_of_charge = 0.30` (the default) — the optimizer cannot find any valid trajectory because the *initial* state already violates a constraint. Either lower `battery_minimum_state_of_charge`, clamp `soc_init` before passing it, or accept that the battery genuinely cannot be used until it recovers above the minimum. See [discussion #359](https://github.com/davidusb-geek/emhass/discussions/359) for the canonical thread.
+5. **Thermal-battery infeasibility.** `start_temperature` outside the `min_temperatures[0]` / `max_temperatures[0]` range, or a heating/cooling rate that physically cannot reach `min_temperatures` from `start_temperature` within the available timesteps. Widen the comfort range or increase the heat pump power.
+6. **Solver time-limit.** `lp_solver_timeout` (default 45 s) exceeded for very large problems (long horizon × many deferrable loads × many timesteps). Reduce horizon or increase timeout.
+
+The new stage-timing banner introduced in upstream PR [#806](https://github.com/davidusb-geek/emhass/pull/806) makes the per-stage timing visible in the logs — useful for distinguishing forecast errors (early stages) from solver issues (late stage).
+
+## 6. Update intervals
+
+| Action | Recommended interval |
+|--------|----------------------|
+| `naive-mpc-optim` | 30 min (default `optimization_time_step`) |
+| `dayahead-optim` | once per day, around 05:30 local time (after spot prices publish) |
+| `publish-data` | every 5 min (or use `continual_publish: true`) |
+| Forecast refresh | every 30–60 min |
+
+Running `naive-mpc-optim` every 1 minute is overkill for residential systems and burns CPU for no measurable cost gain. Conversely, running it only every 4 hours leaves the system slow to react to forecast errors.
+
+## 7. Logs and stage timing
+
+The CLI and Add-on log to `data/action_logs.txt`. The Add-on web UI exposes them under the *Logs* tab.
+
+The format starts with timestamp, log level, message — for example:
+```
+2026-04-26 17:00:00,123 INFO Stage 1/4 (input_data) — 0.20 s
+2026-04-26 17:00:00,355 INFO Stage 2/4 (pv_forecast) — 0.23 s
+2026-04-26 17:00:00,612 INFO Stage 3/4 (load_forecast) — 0.26 s
+2026-04-26 17:00:00,888 INFO Stage 4/4 (lp_solve) — 0.27 s
+2026-04-26 17:00:00,889 INFO Total: 0.96 s, optim_status: optimal
+```
+
+If a particular stage consistently dominates, that's where to look first. PV-forecast stage > 5 s usually means a remote API timeout (Solcast / Forecast.Solar). LP-solve > 30 s typically means the problem size has grown — either reduce horizon or increase `lp_solver_timeout`.
+
+## See also
+
+- Tutorial: [Basic — PV + Battery](basic_pv_battery.md) — start here if you're new
+- How-to: [MPC walkthrough](mpc.md) — practical MPC setup
+- Reference: [Forecasts](../forecasts.md) — all forecast methods and parameters
+- Reference: [ML Forecaster](../mlforecaster.md) — the trainable load forecaster
+- Reference: [Configuration](../config.md) — complete parameter list
+- Reference: [Reference Configurations](reference_configs.md) — config blueprints by archetype

--- a/docs/study_cases/good_practices.md
+++ b/docs/study_cases/good_practices.md
@@ -13,7 +13,7 @@ The dominant factor in real-world cost-minimization is the **gap between forecas
 In practice:
 - The default PV forecast method is `open-meteo` (free, no API key, configured as `weather_forecast_method: open-meteo`). Community feedback in EMHASS discussions repeatedly favors **Solcast** (free tier: 10 calls/day, `weather_forecast_method: solcast`) when accuracy matters most. **Forecast.Solar** is another free option (`weather_forecast_method: solar.forecast`). EMHASS also supports a clearoutside.com scraper (`weather_forecast_method: scrapper`) as a fallback some users still prefer.
 - Load forecast 1-day-persistence is fine for routine households. It breaks on holiday weekends. The [ML Forecaster](../mlforecaster.md) helps if you have ≥ 1 month of history.
-- Dynamic price forecasts must come from the tariff provider (Tibber, aWATTar, Octopus, Stromee, Nordpool, etc.) via runtime payload — there is no useful default for these.
+- Dynamic price forecasts must come from the tariff provider (Tibber, aWATTar, Octopus, Stromee, Nordpool, etc.) via runtime payload; there is no useful default for these.
 
 Before tuning anything else, **measure your forecast errors** for at least a week and address the largest one. The [HA forum thread](https://community.home-assistant.io/t/emhass-an-energy-management-for-home-assistant/338126) has many user reports comparing forecast methods.
 
@@ -27,19 +27,19 @@ EMHASS internally works with a fixed `optimization_time_step` (default: 30 minut
 | HA sensor publish interval | 5 min | should be ≤ `optimization_time_step` |
 | Forecast list length | (matches horizon) | `prediction_horizon × optimization_time_step / forecast_step` items |
 
-If your `prediction_horizon` is `N` and `optimization_time_step` is 30 minutes, lists like `pv_power_forecast` must be **`N` items long** — one per timestep — not hourly. EMHASS does not auto-resample. A length mismatch causes silent truncation or padding with zeros, which then poisons the optimization.
+If your `prediction_horizon` is `N` and `optimization_time_step` is 30 minutes, lists like `pv_power_forecast` must be **`N` items long** (one per timestep, not hourly). EMHASS does not auto-resample. A length mismatch causes silent truncation or padding with zeros, which then poisons the optimization.
 
 Concrete example: a 24-hour horizon at 30-minute step = 48 items per list; at 15-minute step = 96 items.
 
 ## 3. SOC convention: fraction of nominal capacity
 
-EMHASS expresses SOC as a fraction `[0.0, 1.0]` of the **nominal** battery capacity (`battery_nominal_energy_capacity`, `Enom`). The bounds `battery_minimum_state_of_charge` (default 0.3) and `battery_maximum_state_of_charge` (default 0.9) are operational *limits* the optimizer respects — they do **not** rescale the reported SOC value.
+EMHASS expresses SOC as a fraction `[0.0, 1.0]` of the **nominal** battery capacity (`battery_nominal_energy_capacity`, `Enom`). The bounds `battery_minimum_state_of_charge` (default 0.3) and `battery_maximum_state_of_charge` (default 0.9) are operational *limits* the optimizer respects; they do **not** rescale the reported SOC value.
 
 So a published `sensor.soc_optim = 0.45` means 45% of nominal capacity, regardless of what the bounds are. This matches what your battery management system reports (assuming it also uses 0..100% of nominal). No conversion is needed when comparing the two.
 
 Source: `optimization.py` constraints `min_energy = battery_minimum_state_of_charge × cap`, `max_energy = battery_maximum_state_of_charge × cap`.
 
-If your downstream automation or display does need a different convention (e.g. percentage of *usable* range), apply the transform yourself in a HA template — but don't assume EMHASS already did it.
+If your downstream automation or display does need a different convention (e.g. percentage of *usable* range), apply the transform yourself in a HA template. Don't assume EMHASS already did it.
 
 ## 4. `soc_init` and `soc_final` defaults are forgiving
 
@@ -55,14 +55,14 @@ A common new-user trap is the opposite: starting with very low actual SOC where 
 
 When EMHASS returns `optim_status: "Infeasible"` and publishes nothing, work through this list in order. The first match is almost always the cause.
 
-1. **Forecast NaN.** A sensor publishing `unavailable` becomes a NaN in the forecast list and the solver chokes. Check `pv_power_forecast`, `load_power_forecast`, `load_cost_forecast`, `prod_price_forecast` for NaN/None entries. Fix at the HA-template level (use `default(0)` or filter out unavailable states).
-2. **Timestep mismatch.** List lengths don't match `prediction_horizon`. See section 2 above.
-3. **Windowed-deferrable infeasibility.** A windowed deferrable load (EV, washing machine with hard deadline) requires more energy than the window×nominal-power product allows. Either widen the window, increase the power, or reduce the required energy.
-4. **Battery state contradicts limits.** `soc_init = 0.05` but `battery_minimum_state_of_charge = 0.30` (the default) — the optimizer cannot find any valid trajectory because the *initial* state already violates a constraint. Either lower `battery_minimum_state_of_charge`, clamp `soc_init` before passing it, or accept that the battery genuinely cannot be used until it recovers above the minimum. See [discussion #359](https://github.com/davidusb-geek/emhass/discussions/359) for the canonical thread.
-5. **Thermal-battery infeasibility.** `start_temperature` outside the `min_temperatures[0]` / `max_temperatures[0]` range, or a heating/cooling rate that physically cannot reach `min_temperatures` from `start_temperature` within the available timesteps. Widen the comfort range or increase the heat pump power.
-6. **Solver time-limit.** `lp_solver_timeout` (default 45 s) exceeded for very large problems (long horizon × many deferrable loads × many timesteps). Reduce horizon or increase timeout.
+1. Forecast NaN. A sensor publishing `unavailable` becomes a NaN in the forecast list and the solver chokes. Check `pv_power_forecast`, `load_power_forecast`, `load_cost_forecast`, `prod_price_forecast` for NaN/None entries. Fix at the HA-template level (use `default(0)` or filter out unavailable states).
+2. Timestep mismatch. List lengths don't match `prediction_horizon`. See section 2 above.
+3. Windowed-deferrable infeasibility. A windowed deferrable load (EV, washing machine with hard deadline) requires more energy than the window×nominal-power product allows. Either widen the window, increase the power, or reduce the required energy.
+4. Battery state contradicts limits. `soc_init = 0.05` but `battery_minimum_state_of_charge = 0.30` (the default): the optimizer cannot find any valid trajectory because the *initial* state already violates a constraint. Either lower `battery_minimum_state_of_charge`, clamp `soc_init` before passing it, or accept that the battery genuinely cannot be used until it recovers above the minimum. See [discussion #359](https://github.com/davidusb-geek/emhass/discussions/359) for the canonical thread.
+5. Thermal-battery infeasibility. `start_temperature` outside the `min_temperatures[0]` / `max_temperatures[0]` range, or a heating/cooling rate that physically cannot reach `min_temperatures` from `start_temperature` within the available timesteps. Widen the comfort range or increase the heat pump power.
+6. Solver time-limit. `lp_solver_timeout` (default 45 s) exceeded for very large problems (long horizon × many deferrable loads × many timesteps). Reduce horizon or increase timeout.
 
-The new stage-timing banner introduced in upstream PR [#806](https://github.com/davidusb-geek/emhass/pull/806) makes the per-stage timing visible in the logs — useful for distinguishing forecast errors (early stages) from solver issues (late stage).
+The new stage-timing banner introduced in upstream PR [#806](https://github.com/davidusb-geek/emhass/pull/806) makes the per-stage timing visible in the logs, useful for distinguishing forecast errors (early stages) from solver issues (late stage).
 
 ## 6. Update intervals
 
@@ -86,20 +86,20 @@ At the default log level (INFO), each optimization run emits a runtime banner an
 2026-04-26 17:00:01 INFO     Optimization completed in 0.96s (top: optim_solve=0.52s, 54%)
 ```
 
-The banner is emitted by `log_runtime_banner` (added in PR [#806](https://github.com/davidusb-geek/emhass/pull/806)) and is useful when filing bug reports — the EMHASS / Python / CVXPY / solver / platform combination is printed at the start of every run.
+The banner is emitted by `log_runtime_banner` (added in PR [#806](https://github.com/davidusb-geek/emhass/pull/806)) and is useful when filing bug reports: the EMHASS / Python / CVXPY / solver / platform combination is printed at the start of every run.
 
 The summary identifies which stage dominated total runtime. Common patterns:
 - `top: pv_forecast=...` consistently dominating usually means a remote API timeout (Solcast / Forecast.Solar). Check network access and API keys.
-- `top: optim_solve=...` taking more than 30 s usually means the problem size has grown — either reduce the prediction horizon or increase `lp_solver_timeout`.
-- `top: input_data=...` or `top: load_forecast=...` taking long usually means a slow Home Assistant database query — check sensor history depth.
+- `top: optim_solve=...` taking more than 30 s usually means the problem size has grown: either reduce the prediction horizon or increase `lp_solver_timeout`.
+- `top: input_data=...` or `top: load_forecast=...` taking long usually means a slow Home Assistant database query: check sensor history depth.
 
 Per-stage timings are recorded internally (in `input_data_dict["stage_times"]`) for every run but are only logged at DEBUG level. To see them, raise the log level to DEBUG temporarily (in `config_emhass.yaml` set `logging_level: DEBUG`, or use the Add-on advanced options). Each stage is logged as `Stage [<name>] completed in <X.XXX>s`.
 
 ## See also
 
-- Tutorial: [Basic — PV + Battery](basic_pv_battery.md) — start here if you're new
-- How-to: [MPC walkthrough](mpc.md) — practical MPC setup
-- Reference: [Forecasts](../forecasts.md) — all forecast methods and parameters
-- Reference: [ML Forecaster](../mlforecaster.md) — the trainable load forecaster
-- Reference: [Configuration](../config.md) — complete parameter list
-- Reference: [Reference Configurations](reference_configs.md) — config blueprints by archetype
+- Tutorial: [Basic — PV + Battery](basic_pv_battery.md) (start here if you're new)
+- How-to: [MPC walkthrough](mpc.md)
+- Reference: [Forecasts](../forecasts.md)
+- Reference: [ML Forecaster](../mlforecaster.md)
+- Reference: [Configuration](../config.md)
+- Reference: [Reference Configurations](reference_configs.md)

--- a/docs/study_cases/heat_pump_walkthrough.md
+++ b/docs/study_cases/heat_pump_walkthrough.md
@@ -2,7 +2,7 @@
 
 > **Type:** How-To Guide — task-oriented, follow when integrating a heat pump as a thermal-battery deferrable in a real home with PV and battery.
 
-This page walks through a complete real-house scenario: PV + electrochemical battery + heat-pump-driven thermal battery + (optionally) a regular EV charger. It is an *orchestration* page — for the parameter reference of the thermal battery model itself, see [Reference: thermal_battery](../thermal_battery.md).
+This page walks through a complete real-house scenario: PV + electrochemical battery + heat-pump-driven thermal battery + (optionally) a regular EV charger. It is an *orchestration* page. For the parameter reference of the thermal battery model itself, see [Reference: thermal_battery](../thermal_battery.md).
 
 ## Scenario
 
@@ -21,11 +21,11 @@ A 130 m² single-family home in central Europe with:
 
 EMHASS treats the heat pump as a **thermal_battery** deferrable load. The optimizer simultaneously:
 
-1. Schedules the heat pump to keep the underfloor slab within a min/max temperature comfort range (per `thermal_battery` config — see [thermal_battery.md](../thermal_battery.md) for all parameters).
+1. Schedules the heat pump to keep the underfloor slab within a min/max temperature comfort range (per `thermal_battery` config; see [thermal_battery.md](../thermal_battery.md) for all parameters).
 2. Schedules the electrochemical battery to charge from PV / cheap grid hours and discharge into expensive hours.
 3. Schedules other deferrable loads (washing machine, EV) inside their own windows.
 
-All four schedules share the same horizon, the same forecasted PV, the same forecasted prices — the optimizer finds a globally cost-minimal joint plan.
+All four schedules share the same horizon, the same forecasted PV, the same forecasted prices. The optimizer finds a globally cost-minimal joint plan.
 
 ## Configuration
 
@@ -100,18 +100,18 @@ rest_command:
 
 Adjust `horizon` if you use a non-default `optimization_time_step`.
 
-For the publish-data follow-up call (which converts the predicted thermal-battery temperature into a `sensor.temp_predicted0`-equivalent that drives your real heat pump's setpoint), see [thermal_battery.md — Published sensors](../thermal_battery.md#published-sensors).
+For the publish-data follow-up call (which converts the predicted thermal-battery temperature into a `sensor.temp_predicted0`-equivalent that drives your real heat pump's setpoint), see [thermal_battery.md: Published sensors](../thermal_battery.md#published-sensors).
 
 ## Interpretation
 
 - The optimizer pre-heats the slab during low-price or PV-surplus hours, then lets it coast through expensive hours by drawing from thermal mass instead of running the heat pump.
 - The electrochemical battery handles short-time-scale shifting (within hours), the thermal battery handles longer-scale shifting (across cheap-night → expensive-evening). They are complementary, not redundant.
-- The `thermal_inertia_time_constant` of 2 h tells the optimizer that heat applied now reaches the slab gradually — without it, MPC tends to schedule pre-heating *too late* for short prediction horizons.
+- The `thermal_inertia_time_constant` of 2 h tells the optimizer that heat applied now reaches the slab gradually. Without it, MPC tends to schedule pre-heating *too late* for short prediction horizons.
 
 ## See also
 
-- Reference: [thermal_battery.md](../thermal_battery.md) — every parameter, calibration steps, troubleshooting
-- Reference: [thermal_model.md](../thermal_model.md) — simpler thermal model without thermal-mass storage
-- How-to: [MPC walkthrough](mpc.md) — generic rolling-horizon pattern
-- How-to: [EV walkthrough](ev.md) — adding an EV deferrable to this scenario
-- Explanation: [Good Practices](good_practices.md) — pre-heating windows, infeasibility triage
+- Reference: [thermal_battery.md](../thermal_battery.md) (every parameter, calibration steps, troubleshooting)
+- Reference: [thermal_model.md](../thermal_model.md) (simpler thermal model without thermal-mass storage)
+- How-to: [MPC walkthrough](mpc.md)
+- How-to: [EV walkthrough](ev.md)
+- Explanation: [Good Practices](good_practices.md)

--- a/docs/study_cases/heat_pump_walkthrough.md
+++ b/docs/study_cases/heat_pump_walkthrough.md
@@ -31,7 +31,7 @@ All four schedules share the same horizon, the same forecasted PV, the same fore
 
 Add `set_use_pv: true`, `set_use_battery: true` plus the standard battery parameters from [Basic — PV + Battery](basic_pv_battery.md). Then add the thermal_battery config under `def_load_config`. A condensed example for a modern home with underfloor heating:
 
-```json
+```python
 {
   "def_load_config": [
     {},

--- a/docs/study_cases/heat_pump_walkthrough.md
+++ b/docs/study_cases/heat_pump_walkthrough.md
@@ -1,0 +1,117 @@
+# Heat-pump end-to-end walkthrough
+
+> **Type:** How-To Guide — task-oriented, follow when integrating a heat pump as a thermal-battery deferrable in a real home with PV and battery.
+
+This page walks through a complete real-house scenario: PV + electrochemical battery + heat-pump-driven thermal battery + (optionally) a regular EV charger. It is an *orchestration* page — for the parameter reference of the thermal battery model itself, see [Reference: thermal_battery](../thermal_battery.md).
+
+## Scenario
+
+A 130 m² single-family home in central Europe with:
+
+| Component | Value |
+|-----------|-------|
+| PV | 8 kWp |
+| Electrochemical battery | 10 kWh |
+| Heat pump | 3 kW electric, supply 35 °C, underfloor heating slab 20 m³ |
+| Other deferrable loads | 1 EV charger (treated separately, see [EV walkthrough](ev.md)) |
+| Tariff | dynamic (e.g. Tibber, aWATTar, Octopus Agile) |
+| Optimization mode | naive-mpc-optim, every 30 min |
+
+## How the pieces connect
+
+EMHASS treats the heat pump as a **thermal_battery** deferrable load. The optimizer simultaneously:
+
+1. Schedules the heat pump to keep the underfloor slab within a min/max temperature comfort range (per `thermal_battery` config — see [thermal_battery.md](../thermal_battery.md) for all parameters).
+2. Schedules the electrochemical battery to charge from PV / cheap grid hours and discharge into expensive hours.
+3. Schedules other deferrable loads (washing machine, EV) inside their own windows.
+
+All four schedules share the same horizon, the same forecasted PV, the same forecasted prices — the optimizer finds a globally cost-minimal joint plan.
+
+## Configuration
+
+Add `set_use_pv: true`, `set_use_battery: true` plus the standard battery parameters from [Basic — PV + Battery](basic_pv_battery.md). Then add the thermal_battery config under `def_load_config`. A condensed example for a modern home with underfloor heating:
+
+```json
+{
+  "def_load_config": [
+    {},
+    {
+      "thermal_battery": {
+        "supply_temperature": 35.0,
+        "volume": 20.0,
+        "start_temperature": 22.0,
+        "min_temperatures": [20.0] * 48,
+        "max_temperatures": [26.0] * 48,
+        "carnot_efficiency": 0.45,
+        "u_value": 0.35,
+        "envelope_area": 280.0,
+        "ventilation_rate": 0.4,
+        "heated_volume": 320.0,
+        "thermal_inertia_time_constant": 2.0
+      }
+    }
+  ]
+}
+```
+
+For the meaning of each parameter (and the alternative HDD-based heating-demand method), see [thermal_battery.md](../thermal_battery.md). For solar gains and internal-gains parameters, see the same page.
+
+## Run (MPC, every 30 min)
+
+The MPC payload combines runtime SOC, runtime room temperature, and the `def_load_config`:
+
+```yaml
+rest_command:
+  emhass_mpc:
+    url: http://localhost:5000/action/naive-mpc-optim
+    method: POST
+    timeout: 300
+    headers:
+      content-type: application/json
+    payload: >
+      {%- set horizon = 48 -%}
+      {
+        "prediction_horizon": {{ horizon }},
+        "soc_init": {{ states('sensor.battery_soc') | float / 100 }},
+        "def_total_hours": [
+          {{ states('sensor.washing_machine_remaining_hours') }}
+        ],
+        "def_load_config": [
+          {},
+          {
+            "thermal_battery": {
+              "supply_temperature": 35.0,
+              "volume": 20.0,
+              "start_temperature": {{ states('sensor.floor_temperature') | float }},
+              "min_temperatures": {{ ([20.0] * horizon) | tojson }},
+              "max_temperatures": {{ ([26.0] * horizon) | tojson }},
+              "carnot_efficiency": 0.45,
+              "u_value": 0.35,
+              "envelope_area": 280.0,
+              "ventilation_rate": 0.4,
+              "heated_volume": 320.0,
+              "thermal_inertia_time_constant": 2.0
+            }
+          }
+        ],
+        "outdoor_temperature_forecast": {{ ((state_attr("weather.home", "forecast") | map(attribute="temperature") | list)[:horizon] | tojson) }}
+      }
+```
+
+Adjust `horizon` if you use a non-default `optimization_time_step`.
+
+For the publish-data follow-up call (which converts the predicted thermal-battery temperature into a `sensor.temp_predicted0`-equivalent that drives your real heat pump's setpoint), see [thermal_battery.md — Published sensors](../thermal_battery.md#published-sensors).
+
+## Interpretation
+
+- The optimizer pre-heats the slab during low-price or PV-surplus hours, then lets it coast through expensive hours by drawing from thermal mass instead of running the heat pump.
+- The electrochemical battery handles short-time-scale shifting (within hours), the thermal battery handles longer-scale shifting (across cheap-night → expensive-evening). They are complementary, not redundant.
+- The `thermal_inertia_time_constant` of 2 h tells the optimizer that heat applied now reaches the slab gradually — without it, MPC tends to schedule pre-heating *too late* for short prediction horizons.
+
+## See also
+
+- Reference: [thermal_battery.md](../thermal_battery.md) — every parameter, calibration steps, troubleshooting
+- Reference: [thermal_model.md](../thermal_model.md) — simpler thermal model without thermal-mass storage
+- How-to: [MPC walkthrough](mpc.md) — generic rolling-horizon pattern
+- How-to: [EV walkthrough](ev.md) — adding an EV deferrable to this scenario
+- Explanation: [Good Practices](good_practices.md) — pre-heating windows, infeasibility triage

--- a/docs/study_cases/index.md
+++ b/docs/study_cases/index.md
@@ -18,6 +18,7 @@ fits your needs.
 |------|------|
 | Run rolling-horizon control with naive-mpc-optim | [MPC walkthrough](mpc.md) |
 | End-to-end heat-pump scenario combining PV/Batt/thermal_battery | [Heat-pump walkthrough](heat_pump_walkthrough.md) |
+| Domestic hot water — deadline-driven temperature profile | [DHW walkthrough](dhw_walkthrough.md) |
 | EV charging as a deferrable load | [EV as deferrable](ev.md) |
 
 ## Reference
@@ -42,6 +43,7 @@ basic_pv
 basic_pv_battery
 mpc
 heat_pump_walkthrough
+dhw_walkthrough
 ev
 good_practices
 reference_configs

--- a/docs/study_cases/index.md
+++ b/docs/study_cases/index.md
@@ -2,7 +2,7 @@
 
 End-to-end walkthroughs for common EMHASS configurations using real data.
 Each page is tagged by Diátaxis mode so you can pick the entry point that
-fits your need.
+fits your needs.
 
 ## Tutorials — start here if you're new
 

--- a/docs/study_cases/index.md
+++ b/docs/study_cases/index.md
@@ -1,0 +1,49 @@
+# Study Cases
+
+End-to-end walkthroughs for common EMHASS configurations using real data.
+Each page is tagged by Diátaxis mode so you can pick the entry point that
+fits your need.
+
+## Tutorials — start here if you're new
+
+| Configuration | Page |
+|---------------|------|
+| No PV, two deferrable loads | [basic_no_pv](basic_no_pv.md) |
+| PV + two deferrable loads | [basic_pv](basic_pv.md) |
+| PV + battery + deferrable loads | [basic_pv_battery](basic_pv_battery.md) |
+
+## How-to guides — task-oriented
+
+| Goal | Page |
+|------|------|
+| Run rolling-horizon control with naive-mpc-optim | [mpc](mpc.md) |
+| End-to-end heat-pump scenario combining PV/Batt/thermal_battery | [heat_pump_walkthrough](heat_pump_walkthrough.md) |
+| EV charging as a deferrable load | [ev](ev.md) |
+
+## Reference
+
+| Lookup | Page |
+|--------|------|
+| Config blueprints for common archetypes | [reference_configs](reference_configs.md) |
+| Legacy CLI command equivalents | [legacy_cli](legacy_cli.md) |
+
+## Explanation
+
+| Topic | Page |
+|-------|------|
+| Hard-learned wisdom: forecast quality, SOC semantics, infeasibility triage | [good_practices](good_practices.md) |
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+basic_no_pv
+basic_pv
+basic_pv_battery
+mpc
+heat_pump_walkthrough
+ev
+good_practices
+reference_configs
+legacy_cli
+```

--- a/docs/study_cases/index.md
+++ b/docs/study_cases/index.md
@@ -18,7 +18,7 @@ fits your needs.
 |------|------|
 | Run rolling-horizon control with naive-mpc-optim | [MPC walkthrough](mpc.md) |
 | End-to-end heat-pump scenario combining PV/Batt/thermal_battery | [Heat-pump walkthrough](heat_pump_walkthrough.md) |
-| Domestic hot water — deadline-driven temperature profile | [DHW walkthrough](dhw_walkthrough.md) |
+| Domestic hot water with a deadline-driven temperature profile | [DHW walkthrough](dhw_walkthrough.md) |
 | EV charging as a deferrable load | [EV as deferrable](ev.md) |
 
 ## Reference

--- a/docs/study_cases/index.md
+++ b/docs/study_cases/index.md
@@ -8,34 +8,34 @@ fits your need.
 
 | Configuration | Page |
 |---------------|------|
-| No PV, two deferrable loads | [basic_no_pv](basic_no_pv.md) |
-| PV + two deferrable loads | [basic_pv](basic_pv.md) |
-| PV + battery + deferrable loads | [basic_pv_battery](basic_pv_battery.md) |
+| No PV, two deferrable loads | [Basic — no PV](basic_no_pv.md) |
+| PV + two deferrable loads | [Basic — PV](basic_pv.md) |
+| PV + battery + deferrable loads | [Basic — PV + Battery](basic_pv_battery.md) |
 
 ## How-to guides — task-oriented
 
 | Goal | Page |
 |------|------|
-| Run rolling-horizon control with naive-mpc-optim | [mpc](mpc.md) |
-| End-to-end heat-pump scenario combining PV/Batt/thermal_battery | [heat_pump_walkthrough](heat_pump_walkthrough.md) |
-| EV charging as a deferrable load | [ev](ev.md) |
+| Run rolling-horizon control with naive-mpc-optim | [MPC walkthrough](mpc.md) |
+| End-to-end heat-pump scenario combining PV/Batt/thermal_battery | [Heat-pump walkthrough](heat_pump_walkthrough.md) |
+| EV charging as a deferrable load | [EV as deferrable](ev.md) |
 
 ## Reference
 
 | Lookup | Page |
 |--------|------|
-| Config blueprints for common archetypes | [reference_configs](reference_configs.md) |
-| Legacy CLI command equivalents | [legacy_cli](legacy_cli.md) |
+| Config blueprints for common archetypes | [Reference Configurations](reference_configs.md) |
+| Legacy CLI command equivalents | [Legacy CLI commands](legacy_cli.md) |
 
 ## Explanation
 
 | Topic | Page |
 |-------|------|
-| Hard-learned wisdom: forecast quality, SOC semantics, infeasibility triage | [good_practices](good_practices.md) |
+| Hard-learned wisdom: forecast quality, SOC semantics, infeasibility triage | [Good Practices](good_practices.md) |
 
 ```{toctree}
 :maxdepth: 1
-:hidden:
+:hidden: true
 
 basic_no_pv
 basic_pv

--- a/docs/study_cases/legacy_cli.md
+++ b/docs/study_cases/legacy_cli.md
@@ -1,0 +1,101 @@
+# Legacy CLI Commands
+
+> **Type:** Reference — lookup of legacy `emhass --action ...` command-line equivalents.
+
+The study-case tutorials and how-to guides primarily show REST API calls (curl, `rest_command`, or the Add-on action button), because the EMHASS Add-on and standalone Docker are the recommended deployment targets and these expose REST.
+
+This page collects the **legacy Python virtual-environment CLI** equivalents for users running EMHASS as a `pip`-installed Python module — for example, in Docker-standalone scenarios, CI pipelines, or backtest scripts.
+
+## Day-ahead optimization
+
+REST (recommended):
+
+```bash
+curl -i -H "Content-Type: application/json" \
+     -X POST -d '{}' \
+     http://localhost:5000/action/dayahead-optim
+```
+
+Legacy CLI:
+
+```bash
+emhass --action 'dayahead-optim' \
+       --config '/home/user/emhass/config_emhass.json' \
+       --costfun 'profit'
+```
+
+## Perfect optimization (7-day historical backtest)
+
+REST:
+
+```bash
+curl -i -H "Content-Type: application/json" \
+     -X POST -d '{}' \
+     http://localhost:5000/action/perfect-optim
+```
+
+Legacy CLI:
+
+```bash
+emhass --action 'perfect-optim' \
+       --config '/home/user/emhass/config_emhass.json' \
+       --costfun 'profit'
+```
+
+## Naive MPC optimization
+
+REST:
+
+```bash
+curl -i -H "Content-Type: application/json" \
+     -X POST -d '{"prediction_horizon": 24}' \
+     http://localhost:5000/action/naive-mpc-optim
+```
+
+Legacy CLI:
+
+```bash
+emhass --action 'naive-mpc-optim' \
+       --config '/home/user/emhass/config_emhass.json' \
+       --runtimeparams '{"prediction_horizon": 24}'
+```
+
+## Publish data
+
+REST:
+
+```bash
+curl -i -H "Content-Type: application/json" \
+     -X POST -d '{}' \
+     http://localhost:5000/action/publish-data
+```
+
+Legacy CLI:
+
+```bash
+emhass --action 'publish-data' \
+       --config '/home/user/emhass/config_emhass.json'
+```
+
+## Flag mapping
+
+| REST body field | Legacy CLI flag |
+|-----------------|-----------------|
+| (request body, JSON) | `--runtimeparams '{...}'` |
+| (`X-Cost-Function` header *not used*) | `--costfun 'profit' \| 'cost' \| 'self-consumption'` |
+| (config-file via Add-on options or running `/get-config`) | `--config /path/to/config.json` |
+| (logs in `/share/data/`) | `--data /path/to/data/` |
+
+## When to use this surface
+
+- **Docker-standalone** without the Home Assistant Add-on supervisor
+- **CI pipelines** that need to run `perfect-optim` against historical data without a long-running server
+- **Backtest scripts** that script multiple `--action` calls in sequence
+
+For all other deployments — Add-on, standalone-with-supervisor, Home Assistant integration — prefer the REST surface.
+
+## See also
+
+- [Automations](../automations.md) — Reference: full `shell_command` and `rest_command` patterns
+- [Passing data](../passing_data.md) — Reference: complete list of `runtimeparams` keys
+- [Configuration](../config.md) — Reference: every parameter

--- a/docs/study_cases/mpc.md
+++ b/docs/study_cases/mpc.md
@@ -30,7 +30,7 @@ In addition to the parameters from [Basic — PV + Battery](basic_pv_battery.md)
 For the full list of runtime keys, see [Passing data](../passing_data.md).
 
 ```{note}
-**`soc_init` and `soc_final` defaults.** EMHASS already defaults `soc_final` to `soc_init` (and vice versa) when only one is passed at runtime; if neither is passed, both fall back to `battery_target_state_of_charge` from the static config. So for typical rolling MPC, passing only `soc_init` is sufficient — the optimizer will not impose a terminal-SOC bias inside the horizon. Pass `soc_final` explicitly only when you have a hard end-of-horizon target (e.g. ensure 60% before tomorrow morning).
+`soc_init` and `soc_final` defaults: EMHASS already defaults `soc_final` to `soc_init` (and vice versa) when only one is passed at runtime; if neither is passed, both fall back to `battery_target_state_of_charge` from the static config. So for typical rolling MPC, passing only `soc_init` is sufficient: the optimizer will not impose a terminal-SOC bias inside the horizon. Pass `soc_final` explicitly only when you have a hard end-of-horizon target (e.g. ensure 60% before tomorrow morning).
 ```
 
 ## Run
@@ -56,7 +56,7 @@ rest_command:
       }
 ```
 
-(`soc_final` is intentionally omitted — see the note above. Adjust the literal `48` if your `optimization_time_step` is not 30 minutes.)
+(`soc_final` is intentionally omitted; see the note above. Adjust the literal `48` if your `optimization_time_step` is not 30 minutes.)
 
 Trigger it every 30 minutes:
 
@@ -75,22 +75,22 @@ For the matching `shell_command.emhass_publish_data`, see [Automations](../autom
 
 ## Output
 
-After each MPC run, EMHASS publishes the same sensors as `dayahead-optim` (`sensor.p_deferrable0`, `sensor.soc_optim`, etc.), but the schedule covering the prediction horizon replaces the previous one. Your HA automations follow the current state of `sensor.p_deferrable*` to switch real loads on/off — they don't care whether the underlying schedule came from `dayahead-optim` or `naive-mpc-optim`.
+After each MPC run, EMHASS publishes the same sensors as `dayahead-optim` (`sensor.p_deferrable0`, `sensor.soc_optim`, etc.), but the schedule covering the prediction horizon replaces the previous one. Your HA automations follow the current state of `sensor.p_deferrable*` to switch real loads on/off; they don't care whether the underlying schedule came from `dayahead-optim` or `naive-mpc-optim`.
 
 The plan-cycle behavior with a 30-minute re-run cadence and a 24 h horizon: at minute 0 the optimizer plans 24 h forward; at minute 30 it plans 24 h forward from the new "now"; at minute 60 again; and so on. Each plan **partially overlaps** the previous one for the next 23.5 h, but the new plan reflects the latest SOC, latest `def_total_hours`, latest forecast.
 
 ## Interpretation
 
 - MPC's main advantage over day-ahead is **resilience to forecast error**: when actual PV generation diverges from the morning forecast, the next MPC iteration corrects course immediately.
-- MPC's main cost is solver time × frequency. With CVXPY/HiGHS the solve is typically 0.1 – 0.5 s; running every 30 min is well within budget. Running every 1 min is overkill for most homes — see [Good Practices](good_practices.md).
-- For deferrable loads with strict windows (EV must charge by 07:00), pass `start_timesteps_of_each_deferrable_load` / `end_timesteps_of_each_deferrable_load` per load in the runtime payload — see [EV walkthrough](ev.md).
+- MPC's main cost is solver time × frequency. With CVXPY/HiGHS the solve is typically 0.1 – 0.5 s; running every 30 min is well within budget. Running every 1 min is overkill for most homes. See [Good Practices](good_practices.md).
+- For deferrable loads with strict windows (EV must charge by 07:00), pass `start_timesteps_of_each_deferrable_load` / `end_timesteps_of_each_deferrable_load` per load in the runtime payload. See [EV walkthrough](ev.md).
 
 ## See also
 
 - Tutorial: [Basic — PV + Battery](basic_pv_battery.md) (the static day-ahead version)
 - Reference: [Passing data](../passing_data.md) for the full runtime params list
 - Reference: [Automations](../automations.md) for `shell_command` / `rest_command` patterns
-- How-to: [Heat-pump walkthrough](heat_pump_walkthrough.md) — MPC + thermal_battery
-- How-to: [EV walkthrough](ev.md) — MPC + windowed deferrable
-- Explanation: [Good Practices](good_practices.md) — MPC cadence, soc_final pattern, infeasibility triage
-- Explanation: [Advanced math model](../advanced_math_model.md) — the optimization formulation
+- How-to: [Heat-pump walkthrough](heat_pump_walkthrough.md)
+- How-to: [EV walkthrough](ev.md)
+- Explanation: [Good Practices](good_practices.md)
+- Explanation: [Advanced math model](../advanced_math_model.md)

--- a/docs/study_cases/mpc.md
+++ b/docs/study_cases/mpc.md
@@ -83,7 +83,7 @@ The plan-cycle behavior with a 30-minute re-run cadence and a 24 h horizon: at m
 
 - MPC's main advantage over day-ahead is **resilience to forecast error**: when actual PV generation diverges from the morning forecast, the next MPC iteration corrects course immediately.
 - MPC's main cost is solver time × frequency. With CVXPY/HiGHS the solve is typically 0.1 – 0.5 s; running every 30 min is well within budget. Running every 1 min is overkill for most homes — see [Good Practices](good_practices.md).
-- For deferrable loads with strict windows (EV must charge by 07:00), pass `start_window` / `end_window` per load in the runtime payload — see [EV walkthrough](ev.md).
+- For deferrable loads with strict windows (EV must charge by 07:00), pass `start_timesteps_of_each_deferrable_load` / `end_timesteps_of_each_deferrable_load` per load in the runtime payload — see [EV walkthrough](ev.md).
 
 ## See also
 

--- a/docs/study_cases/mpc.md
+++ b/docs/study_cases/mpc.md
@@ -1,0 +1,96 @@
+# Rolling-horizon control with naive-mpc-optim
+
+> **Type:** How-To Guide — task-oriented, follow when you need a live, continuously-updated optimization plan instead of a static day-ahead schedule.
+
+The `dayahead-optim` action computes a single 24 h schedule once per day. For systems where forecasts and state change throughout the day (especially battery SOC, EV state, dynamic prices), you want **Model Predictive Control**: re-run the optimization on a rolling window every N minutes, using the latest measurements as the new initial state.
+
+EMHASS implements this with the `naive-mpc-optim` action. This page walks through wiring it up.
+
+## Scenario
+
+| Component | Value |
+|-----------|-------|
+| PV | 5 kWp |
+| Battery | 5 kWh nominal, defaults: `battery_minimum_state_of_charge: 0.3`, `battery_maximum_state_of_charge: 0.9` |
+| Deferrable loads | as previous tutorials |
+| MPC re-run cadence | every 30 minutes |
+| Prediction horizon | 24 h (number of timesteps = `24 × 60 / optimization_time_step`; with the default 30-minute step, that is 48) |
+
+## Configuration
+
+In addition to the parameters from [Basic — PV + Battery](basic_pv_battery.md), MPC needs runtime parameters per call. The following keys go into the request body, not the static config:
+
+| Runtime key | Value |
+|-------------|-------|
+| `prediction_horizon` | number of timesteps to plan ahead |
+| `soc_init` | current battery SOC, fraction of nominal capacity (read from your battery sensor) |
+| `soc_final` | end-of-horizon SOC target (see note below) |
+| `def_total_hours` | remaining required operating hours per deferrable load |
+
+For the full list of runtime keys, see [Passing data](../passing_data.md).
+
+```{note}
+**`soc_init` and `soc_final` defaults.** EMHASS already defaults `soc_final` to `soc_init` (and vice versa) when only one is passed at runtime; if neither is passed, both fall back to `battery_target_state_of_charge` from the static config. So for typical rolling MPC, passing only `soc_init` is sufficient — the optimizer will not impose a terminal-SOC bias inside the horizon. Pass `soc_final` explicitly only when you have a hard end-of-horizon target (e.g. ensure 60% before tomorrow morning).
+```
+
+## Run
+
+REST (recommended for HA `rest_command` automation):
+
+```yaml
+rest_command:
+  emhass_mpc:
+    url: http://localhost:5000/action/naive-mpc-optim
+    method: POST
+    timeout: 120
+    headers:
+      content-type: application/json
+    payload: >
+      {
+        "prediction_horizon": 48,
+        "soc_init": {{ states('sensor.battery_soc') | float / 100 }},
+        "def_total_hours": [
+          {{ states('sensor.water_heater_remaining_hours') }},
+          {{ states('sensor.pool_pump_remaining_hours') }}
+        ]
+      }
+```
+
+(`soc_final` is intentionally omitted — see the note above. Adjust the literal `48` if your `optimization_time_step` is not 30 minutes.)
+
+Trigger it every 30 minutes:
+
+```yaml
+automation:
+  - alias: EMHASS MPC every 30 min
+    trigger:
+      - platform: time_pattern
+        minutes: "/30"
+    action:
+      - service: rest_command.emhass_mpc
+      - service: shell_command.emhass_publish_data
+```
+
+For the matching `shell_command.emhass_publish_data`, see [Automations](../automations.md).
+
+## Output
+
+After each MPC run, EMHASS publishes the same sensors as `dayahead-optim` (`sensor.p_deferrable0`, `sensor.soc_optim`, etc.), but the schedule covering the prediction horizon replaces the previous one. Your HA automations follow the current state of `sensor.p_deferrable*` to switch real loads on/off — they don't care whether the underlying schedule came from `dayahead-optim` or `naive-mpc-optim`.
+
+The plan-cycle behavior with a 30-minute re-run cadence and a 24 h horizon: at minute 0 the optimizer plans 24 h forward; at minute 30 it plans 24 h forward from the new "now"; at minute 60 again; and so on. Each plan **partially overlaps** the previous one for the next 23.5 h, but the new plan reflects the latest SOC, latest `def_total_hours`, latest forecast.
+
+## Interpretation
+
+- MPC's main advantage over day-ahead is **resilience to forecast error**: when actual PV generation diverges from the morning forecast, the next MPC iteration corrects course immediately.
+- MPC's main cost is solver time × frequency. With CVXPY/HiGHS the solve is typically 0.1 – 0.5 s; running every 30 min is well within budget. Running every 1 min is overkill for most homes — see [Good Practices](good_practices.md).
+- For deferrable loads with strict windows (EV must charge by 07:00), pass `start_window` / `end_window` per load in the runtime payload — see [EV walkthrough](ev.md).
+
+## See also
+
+- Tutorial: [Basic — PV + Battery](basic_pv_battery.md) (the static day-ahead version)
+- Reference: [Passing data](../passing_data.md) for the full runtime params list
+- Reference: [Automations](../automations.md) for `shell_command` / `rest_command` patterns
+- How-to: [Heat-pump walkthrough](heat_pump_walkthrough.md) — MPC + thermal_battery
+- How-to: [EV walkthrough](ev.md) — MPC + windowed deferrable
+- Explanation: [Good Practices](good_practices.md) — MPC cadence, soc_final pattern, infeasibility triage
+- Explanation: [Advanced math model](../advanced_math_model.md) — the optimization formulation

--- a/docs/study_cases/reference_configs.md
+++ b/docs/study_cases/reference_configs.md
@@ -1,0 +1,171 @@
+# Reference Configurations
+
+> **Type:** Reference — lookup of config blueprints for common system archetypes. Pick the closest match and adapt.
+
+These are anonymized, abstract templates. They are not real users' systems. Each block is a starting point — the parameter values reflect typical hardware in the archetype, but you must verify against your own equipment. See [Configuration](../config.md) for the full parameter reference.
+
+```{note}
+**Integer hours only.** `operating_hours_of_each_deferrable_load` accepts whole integers (see [issue #373](https://github.com/davidusb-geek/emhass/issues/373)). The blueprints below round all hour values up to the nearest integer. If your loads need finer control, reduce `optimization_time_step` (e.g. to 15 minutes) so the same wall-clock duration spans more timesteps.
+```
+
+## 1. Single-family home — PV + battery + heat pump + EV + dynamic tariff
+
+The most common modern setup: ~150 m² home, 8–12 kWp PV, 10–15 kWh battery, air-source heat pump with underfloor heating, one EV, Tibber/aWATTar/Octopus dynamic pricing.
+
+```yaml
+# Static config (Add-on options or config_emhass.yaml)
+set_use_pv: true
+solar_forecast_kwp: 10
+optimization_time_step: 30
+prediction_horizon: 48           # used by MPC
+
+set_use_battery: true
+battery_nominal_energy_capacity: 12000     # Wh (= 12 kWh)
+battery_charge_power_max: 5000             # W
+battery_discharge_power_max: 5000          # W
+battery_minimum_state_of_charge: 0.2
+battery_maximum_state_of_charge: 0.9
+battery_target_state_of_charge: 0.5
+
+nominal_power_of_deferrable_loads:
+  - 3000        # water heater (regular deferrable)
+  - 11000       # EV charger
+  - 0           # heat pump (controlled via thermal_battery, set 0 here)
+
+operating_hours_of_each_deferrable_load:
+  - 4
+  - 0           # EV: overridden at runtime
+  - 0           # heat pump: thermal_battery handles it
+
+# def_load_config — passed at runtime (template in heat_pump_walkthrough.md)
+```
+
+Cross-link: [Heat-pump walkthrough](heat_pump_walkthrough.md) for the full MPC payload assembly. Daily cost depends strongly on local tariff spread, PV size, weather, and house thermal characteristics — measure your own baseline before claiming savings.
+
+## 2. PV-only — no battery, heat pump, static tariff
+
+A simpler setup: 6–10 kWp PV, no battery, an air-source heat pump for water heating, fixed-rate import (no dynamic prices). EMHASS still helps schedule the heat pump and other deferrable loads against PV surplus.
+
+```yaml
+set_use_pv: true
+solar_forecast_kwp: 8
+optimization_time_step: 30
+
+set_use_battery: false
+
+nominal_power_of_deferrable_loads:
+  - 3000        # water heater (heat-pump-driven, treat as regular deferrable)
+  - 1500        # dishwasher
+
+operating_hours_of_each_deferrable_load:
+  - 4
+  - 2           # rounded up from typical 1.5 h cycle
+
+# Static prices (no dynamic tariff)
+load_cost_forecast_method: list
+prod_price_forecast_method: list
+# Pass [0.30] * 48 and [0.08] * 48 at runtime, or set in config if truly static.
+```
+
+Most savings come from shifting deferrable loads into PV-surplus hours. Cost reduction is bounded by the share of the daily load that is actually shiftable.
+
+## 3. Off-grid heavy — large PV + battery, no grid import
+
+Cabin / off-grid setup: 15+ kWp PV, 30+ kWh battery, no grid connection (or grid connection with hard limits). Cost minimization is irrelevant — the goal is *don't run out of charge*.
+
+```yaml
+set_use_pv: true
+solar_forecast_kwp: 20
+
+set_use_battery: true
+battery_nominal_energy_capacity: 30000     # Wh (= 30 kWh)
+battery_charge_power_max: 10000            # W
+battery_discharge_power_max: 10000         # W
+battery_minimum_state_of_charge: 0.2       # higher floor for safety margin
+battery_maximum_state_of_charge: 0.95
+battery_target_state_of_charge: 0.7        # always end day with reserve
+
+# No grid: cost function reflects PV-curtailment penalty + load-shed penalty
+costfun: self-consumption
+```
+
+For true off-grid use, modeling load shedding (turning loads off when SOC drops) is currently outside EMHASS's optimization model and must be handled in HA automations. The `costfun: self-consumption` mode minimises grid interaction without explicit load-shedding constraints.
+
+## 4. Apartment with dynamic tariff — no PV, no battery
+
+Renter setup: no rooftop access, no battery space. Just deferrable-load shifting against Tibber/aWATTar prices.
+
+```yaml
+set_use_pv: false
+set_use_battery: false
+
+nominal_power_of_deferrable_loads:
+  - 2200        # washing machine
+  - 2000        # dishwasher
+  - 1800        # heat-pump tumble dryer
+
+operating_hours_of_each_deferrable_load:
+  - 2           # washing machine (rounded up from typical 1.5 h cycle)
+  - 2           # dishwasher (rounded up from typical 1.5 h cycle)
+  - 1           # tumble dryer
+```
+
+Savings depend on the daily price spread of your dynamic tariff and the share of total energy that runs through shiftable loads. For typical 0.10–0.25 EUR/kWh spreads, deferrable-only setups produce visible but modest savings — the marginal value scales linearly with the spread.
+
+## 5. Heat-pump-focused — PV + heat pump, no battery, no EV
+
+Mid-renovation home: PV installed but no battery yet, heat pump replaced gas, no EV. Most flexibility lives in the thermal battery (slab) rather than an electrochemical battery.
+
+```yaml
+set_use_pv: true
+solar_forecast_kwp: 10
+optimization_time_step: 30
+
+set_use_battery: false
+
+nominal_power_of_deferrable_loads:
+  - 0           # heat pump via thermal_battery
+
+# def_load_config with thermal_battery — see heat_pump_walkthrough.md
+```
+
+The thermal slab serves as the storage. Expect strong dependence on `thermal_inertia_time_constant` and accurate `outdoor_temperature_forecast`.
+
+Cross-link: [Heat-pump walkthrough](heat_pump_walkthrough.md), [Reference: thermal_battery](../thermal_battery.md).
+
+## 6. Multi-EV — PV + battery + 2 EVs
+
+Two-EV household: each EV has independent departure time and required-energy. Both modeled as separate deferrable slots.
+
+```yaml
+set_use_pv: true
+solar_forecast_kwp: 12
+
+set_use_battery: true
+battery_nominal_energy_capacity: 10000     # Wh (= 10 kWh)
+
+nominal_power_of_deferrable_loads:
+  - 3000        # water heater
+  - 11000       # EV 1 (3-phase 16 A)
+  - 7400        # EV 2 (1-phase 32 A)
+
+operating_hours_of_each_deferrable_load:
+  - 4
+  - 0           # runtime override
+  - 0           # runtime override
+
+end_timesteps_of_each_deferrable_load:
+  - 48
+  - 0           # runtime override (per EV departure)
+  - 0           # runtime override (per EV departure)
+```
+
+Pass per-EV `def_total_hours[1]`, `def_total_hours[2]`, `end_timesteps[1]`, `end_timesteps[2]` from each EV's source at runtime. See [EV walkthrough](ev.md) for the template pattern; replicate per EV.
+
+## See also
+
+- Reference: [Configuration](../config.md) — complete parameter reference
+- Reference: [Passing data](../passing_data.md) — runtime payload schema
+- Tutorials: [Basic — PV](basic_pv.md), [Basic — PV + Battery](basic_pv_battery.md)
+- How-tos: [MPC](mpc.md), [Heat-pump walkthrough](heat_pump_walkthrough.md), [EV](ev.md)
+- Explanation: [Good Practices](good_practices.md)

--- a/docs/study_cases/reference_configs.md
+++ b/docs/study_cases/reference_configs.md
@@ -81,7 +81,7 @@ set_use_battery: true
 battery_nominal_energy_capacity: 30000     # Wh (= 30 kWh)
 battery_charge_power_max: 10000            # W
 battery_discharge_power_max: 10000         # W
-battery_minimum_state_of_charge: 0.2       # higher floor for safety margin
+battery_minimum_state_of_charge: 0.2       # lower floor — off-grid prefers more usable range
 battery_maximum_state_of_charge: 0.95
 battery_target_state_of_charge: 0.7        # always end day with reserve
 


### PR DESCRIPTION
Follow-up to #812 (Phase 1 study_cases restructure). Adds one new how-to page covering the deadline-driven DHW temperature profile pattern.

## Why a separate page

The slab-heating scenario in `heat_pump_walkthrough.md` uses the modern `thermal_battery` model with min/max temperature ranges. DHW tanks have a fundamentally different control pattern: usage deadlines (morning shower, evening dishes) anchor when the water has to be hot, not a continuous comfort range. The legacy `thermal_config` model with per-timestep `desired_temperatures` maps that pattern naturally — base temperature most of the time with windowed spikes just before each deadline. Mixing both into one page would have made the orchestration page heterogeneous; a focused DHW how-to is cleaner.

## Pattern demonstrated

- Base 45 °C (always; comfort floor, tank may float down)
- Morning spike 48 °C in last 30 min before 07:00
- Evening spike 50 °C in last 1 h before 18:00
- `overshoot_temperature: 59` upper bound

The optimizer is then free to pick the cheapest 24 h slot leading up to each spike — overnight on cheap-grid nights, midday on high-PV days, or whatever Tibber/aWATTar/Octopus-Agile dip presents itself.

## Real-world example included

A 26 April 2026 Tibber day with -0.42 EUR/kWh between 13:00-14:30: the deadline profile shifted DHW heating from a fixed-08:30 morning slot into the 13:00-14:30 negative-price window, earning ~1.50 EUR vs. paying ~0.20 EUR — a ~1.70 EUR spread on the same demand pattern.

## Caveats covered

- Shared HP-for-heating-and-DHW priority (Tecalor/Daikin/Vaillant style integrated heat pumps)
- `cooling_constant` calibration from measured tank decay
- Legionella-cycle handling out-of-band (EMHASS does not know about it)
- `thermal_config` (legacy) vs `thermal_battery` (newer) — when to choose which

## Verified locally

- `sphinx-build -b html -W --keep-going` runs clean; same 3 pre-existing baseline warnings as master, no new warnings
- New page registered in `study_cases/index.md` toctree and How-to table

## Dependency

This PR is built on top of #812 (Phase 1). It will rebase cleanly once Phase 1 lands. If you prefer to merge them together, happy to squash into #812 — let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restructure and expand the study cases documentation into a dedicated section with new walkthroughs and reference material, including a DHW how-to, while updating navigation to point to the new structure.

Documentation:
- Introduce a dedicated Study Cases section with an index page that categorizes tutorials, how-to guides, reference material, and explanation pages.
- Add new how-to guides for EV charging as a deferrable load, domestic hot water deadline-driven control, heat-pump orchestration with thermal batteries, and rolling-horizon MPC usage.
- Add reference documentation for common configuration blueprints, legacy CLI command equivalents, and best-practice guidance for forecasts, SOC semantics, and infeasibility handling.
- Split the original monolithic study_case page into smaller basic tutorials (no PV, PV, PV + battery) and update content for clarity and consistency with the new structure.