### PR TITLE
docs: fix broken link to config_defaults.json (#810)

### DIFF
--- a/docs/installation_methods.md
+++ b/docs/installation_methods.md
@@ -60,7 +60,7 @@ docker run --rm -it --restart always  -p 5000:5000 --name emhass-container -v /e
 
 ### Docker, things to note 
 
-- You can create a `config.json` file prior to running emhass. *(obtain a example from: [config_defaults.json](https://github.com/davidusb-geek/emhass/blob/enhass-standalone-addon-merge/src/emhass/data/config_defaults.json)* Alteratively, you can insert your parameters into the configuration page on the EMHASS web server. (for EMHASS to auto create a config.json) With either option, the volume mount `-v /emhass/share:/share` should be applied to make sure your config is stored on the host device. (to be not deleted when the EMHASS container gets removed/image updated)*
+- You can create a `config.json` file prior to running emhass. *(obtain an example from: [config_defaults.json](https://github.com/davidusb-geek/emhass/blob/master/src/emhass/data/config_defaults.json)* Alternatively, you can insert your parameters into the configuration page on the EMHASS web server. (for EMHASS to auto create a config.json) With either option, the volume mount `-v /emhass/share:/share` should be applied to make sure your config is stored on the host device. (to be not deleted when the EMHASS container gets removed/image updated)*
 
 - If you wish to keep a local, semi-persistent copy of the EMHASS-generated data, create a local folder on your device, then mount said folder inside the container.  
   ```bash


### PR DESCRIPTION
## Summary

- Fixes broken link in the Docker installation guide pointing to a deleted branch (`enhass-standalone-addon-merge`)
- Updates URL to point to `master` branch where `config_defaults.json` currently lives
- Also fixes two nearby typos: `a example` → `an example`, `Alteratively` → `Alternatively`

Fixes #810

## Summary by Sourcery

Fix broken documentation link to the Docker config defaults file and correct nearby typos in the installation guide.

Documentation:
- Update Docker installation guide to point the config_defaults.json link to the master branch instead of a deleted branch.
- Correct grammatical typos in the Docker installation guidance text.