### PR TITLE
docs: clarify influxdb_measurement default vs HA recorder value (#809)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -29,7 +29,7 @@ We will need to define these parameters to retrieve data from Home Assistant. Th
 - `influxdb_host`: The IP address or hostname of your InfluxDB instance. Defaults to `localhost`.
 - `influxdb_port`: The port number for your InfluxDB instance. Defaults to 8086.
 - `influxdb_database`: The name of the InfluxDB database containing your Home Assistant data. Defaults to `homeassistant`.
-- `influxdb_measurement`: The measurement name where your sensor data is stored. Defaults to `W` for the Home Assistant integration.
+- `influxdb_measurement`: The measurement name where your sensor data is stored. Defaults to `W`. When using the Home Assistant InfluxDB integration, set this to `state` (the measurement name used by the HA InfluxDB recorder).
 - `influxdb_retention_policy`: The retention policy to use for InfluxDB queries. Defaults to `autogen`.
 
 A second part of this section is given by some privacy-sensitive parameters that should be included as:

--- a/src/emhass/static/data/param_definitions.json
+++ b/src/emhass/static/data/param_definitions.json
@@ -75,7 +75,7 @@
     },
     "influxdb_measurement": {
       "friendly_name": "InfluxDB measurement name",
-      "Description": "The measurement name where your sensor data is stored. Defaults to 'W' for the Home Assistant integration.",
+      "Description": "The measurement name where your sensor data is stored. Defaults to 'W'. When using the Home Assistant InfluxDB integration, set this to 'state'.",
       "input": "string",
       "default_value": "W"
     },


### PR DESCRIPTION
## Summary

- Fixes documentation inconsistency reported in #809
- `config.md` previously stated the default is `W` "for the Home Assistant integration" — misleading, because the HA InfluxDB recorder actually uses `state` as measurement name
- Clarifies that `W` is the EMHASS default, and HA InfluxDB users should set it to `state` (consistent with the example already shown in `passing_data.md`)
- Updates `param_definitions.json` description to match

Fixes #809

## Summary by Sourcery

Clarify configuration documentation for the InfluxDB measurement parameter and align parameter metadata with the updated description.

Enhancements:
- Update parameter definition metadata to match the clarified InfluxDB measurement description.

Documentation:
- Explain that the default InfluxDB measurement is `W` and that Home Assistant InfluxDB users should set it to `state`.