### PR TITLE
docs: fix influxdb_measurement example value in passing_data.md (#809)

### DIFF
--- a/docs/passing_data.md
+++ b/docs/passing_data.md
@@ -155,7 +155,7 @@ Then on the EMHASS configuration you need to set:
   "influxdb_database": "homeassistant",
   "influxdb_host": "xxxxxxxx-influxdb",
   "influxdb_port": 8086,
-  "influxdb_measurement": "state",
+  "influxdb_measurement": "W",
   "influxdb_retention_policy": "autogen",
   "influxdb_use_ssl": false,
   "influxdb_verify_ssl": false,


### PR DESCRIPTION
## Summary

Fixes the incorrect example value for `influxdb_measurement` in `passing_data.md`.

**The problem:** The example showed `"influxdb_measurement": "state"`, but the Home Assistant InfluxDB integration stores sensor data using the entity's `unit_of_measurement` as the measurement name — not `state`. Power sensors land in `W`, temperature sensors in `°C`, etc.

**Evidence:** Querying `SHOW MEASUREMENTS` on an InfluxDB instance previously populated by the HA InfluxDB v2 integration returns `W`, `°C`, `%`, `€/kWh` — no `state` measurement.

**The fix:** Update the example to `"W"`, which is consistent with the documented default in `config.md` and `param_definitions.json`, and with the primary EMHASS use case (power sensor data).

Fixes #809

## Summary by Sourcery

Documentation:
- Correct the documented example value for `influxdb_measurement` in `passing_data.md` from `state` to `W` to match the real InfluxDB integration behavior and existing config docs.