### PR TITLE
fix: regression_model default typo (AdaBoostRegression -> AdaBoostRegressor)

### DIFF
--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1139,7 +1139,7 @@ async def treat_runtimeparams(
             ("model_type", "long_train_data", None),
             ("var_model", default_var_model, None),
             ("sklearn_model", "KNeighborsRegressor", None),
-            ("regression_model", "AdaBoostRegression", None),
+            ("regression_model", "AdaBoostRegressor", None),
             ("num_lags", 48, None),
             ("split_date_delta", "48h", None),
             ("n_trials", 10, int),


### PR DESCRIPTION
## Problem

`utils.treat_runtimeparams` ml_param_defs sets the runtime default for `regression_model` to `"AdaBoostRegression"`, which is not a valid key in `REGRESSION_METHODS` (machine_learning_regressor.py). The valid key is `"AdaBoostRegressor"` (with trailing `r`).

When a user runs `regressor-model-fit` or `regressor-model-predict` without explicitly passing `regression_model` at runtime, this default propagates into `MLRegressor.fit_model`, where `REGRESSION_METHODS.get(self.regression_model)` returns `None` and the regressor logs `"Invalid regression model: AdaBoostRegression"`.

## Origin (git history)

The default for `regression_model` was set to `"AdaBoostRegression"` in commit `6c21629` (2024-04-18, Giel Janssens, MLRegressor introduction PR #526). At that time the corresponding `REGRESSION_METHODS` key was also `"AdaBoostRegression"`, so the default worked.

In commit `195d33d` (2025-12-09, "Fixed bug on search space name and uniform regressor names in code and documentation"), all `REGRESSION_METHODS` keys were renamed to drop the `Regression` suffix in favour of `Regressor`:

- `AdaBoostRegression` → `AdaBoostRegressor`
- `ElasticNetRegression` → `ElasticNet`
- `KNeighborsRegression` → `KNeighborsRegressor`
- `DecisionTreeRegression` → `DecisionTreeRegressor`
- `RandomForestRegression` → `RandomForestRegressor`
- `ExtraTreesRegression` → `ExtraTreesRegressor`
- `GradientBoostingRegression` → `GradientBoostingRegressor`
- `MLPRegression` → `MLPRegressor`

The default in `utils.treat_runtimeparams` was not updated in that refactor, so it has pointed at a non-existent key ever since.

This PR aligns the default with the renamed key, restoring the original intent (AdaBoost as the default regressor).

## Fix

One-line typo fix.

## Why this slipped through

The existing test `tests/test_machine_learning_regressor.py` passes `regression_model: "LassoRegression"` explicitly in its runtimeparams setup, so the default path is never exercised.

## Verification

`REGRESSION_METHODS` keys (`machine_learning_regressor.py`):
LinearRegression, RidgeRegression, LassoRegression, ElasticNet, KNeighborsRegressor, DecisionTreeRegressor, SVR, RandomForestRegressor, ExtraTreesRegressor, GradientBoostingRegressor, **AdaBoostRegressor**, MLPRegressor.

No `AdaBoostRegression` (without trailing `r`) anywhere else in the codebase.

## Test plan

- [ ] Existing regressor test still passes (uses explicit `LassoRegression`).
- [ ] Manual: run `regressor-model-fit` action without `regression_model` runtimeparam — should now succeed instead of logging "Invalid regression model".