### PR TITLE
fix(schema): correct 5 default mismatches in param_definitions.json

### DIFF
--- a/src/emhass/static/data/param_definitions.json
+++ b/src/emhass/static/data/param_definitions.json
@@ -120,9 +120,9 @@
     },
     "historic_days_to_retrieve": {
       "friendly_name": "Historic days to retrieve",
-      "Description": "We will retrieve data from now to days_to_retrieve days. Defaults to 9",
+      "Description": "We will retrieve data from now to days_to_retrieve days. Defaults to 2",
       "input": "int",
-      "default_value": 9
+      "default_value": 2
     },
     "load_negative": {
       "friendly_name": "Load negative values",
@@ -154,7 +154,7 @@
       "Description": "The load forecast method that will be used. The options are ‘csv’ to load a CSV file or ‘naive’ for a simple 1-day persistence model.",
       "input": "select",
       "select_options": ["typical", "naive", "mlforecaster", "csv"],
-      "default_value": "naive"
+      "default_value": "typical"
     },
     "set_total_pv_sell": {
       "friendly_name": "PV straight to grid",
@@ -215,13 +215,13 @@
       "friendly_name": "Max hybrid inverter AC output power",
       "Description": "Maximum hybrid inverter output power from combined PV and battery discharge.",
       "input": "int",
-      "default_value": 5000
+      "default_value": 0
     },
     "inverter_ac_input_max": {
       "friendly_name": "Max hybrid inverter AC input power",
       "Description": "Maximum hybrid inverter input power from grid to charge battery.",
       "input": "int",
-      "default_value": 5000
+      "default_value": 0
     },
     "inverter_efficiency_dc_ac": {
       "friendly_name": "Hybrid inverter efficency DC to AC",

--- a/src/emhass/static/data/param_definitions.json
+++ b/src/emhass/static/data/param_definitions.json
@@ -120,9 +120,9 @@
     },
     "historic_days_to_retrieve": {
       "friendly_name": "Historic days to retrieve",
-      "Description": "We will retrieve data from now to days_to_retrieve days. Defaults to 2",
+      "Description": "We will retrieve data from now to days_to_retrieve days. Defaults to 9",
       "input": "int",
-      "default_value": 2
+      "default_value": 9
     },
     "load_negative": {
       "friendly_name": "Load negative values",
@@ -154,7 +154,7 @@
       "Description": "The load forecast method that will be used. The options are ‘csv’ to load a CSV file or ‘naive’ for a simple 1-day persistence model.",
       "input": "select",
       "select_options": ["typical", "naive", "mlforecaster", "csv"],
-      "default_value": "typical"
+      "default_value": "naive"
     },
     "set_total_pv_sell": {
       "friendly_name": "PV straight to grid",
@@ -215,13 +215,13 @@
       "friendly_name": "Max hybrid inverter AC output power",
       "Description": "Maximum hybrid inverter output power from combined PV and battery discharge.",
       "input": "int",
-      "default_value": 0
+      "default_value": 5000
     },
     "inverter_ac_input_max": {
       "friendly_name": "Max hybrid inverter AC input power",
       "Description": "Maximum hybrid inverter input power from grid to charge battery.",
       "input": "int",
-      "default_value": 0
+      "default_value": 5000
     },
     "inverter_efficiency_dc_ac": {
       "friendly_name": "Hybrid inverter efficency DC to AC",
@@ -572,7 +572,7 @@
     "ignore_pv_feedback_during_curtailment": {
       "friendly_name": "Ignore PV feedback during curtailment",
       "Description": "When set to true, prevents PV forecast from being updated with real PV data, avoiding flip-flop behavior during curtailment operations",
-      "input": "bool",
+      "input": "boolean",
       "default_value": false
     }
   }


### PR DESCRIPTION
## Summary

Per maintainer Option-B decision (2026-05-12 review), this PR now contains a single schema normalization: the `input` field for `ignore_pv_feedback_during_curtailment` changes from `"bool"` to `"boolean"` to match the rest of the file (all other booleans use `"boolean"`).

The 4 default-value mismatches originally proposed here have been reverted. `param_definitions.json` is now treated as source-of-truth; a follow-up PR will update `config_defaults.json` to align with it for these 4 params:

- `historic_days_to_retrieve`: 9 → 2
- `inverter_ac_output_max`: 5000 → 0
- `inverter_ac_input_max`: 5000 → 0
- `load_forecast_method`: `"naive"` → `"typical"`

Behavior change for Headless users on those 4 params — release-notes-heads-up to follow in the `config_defaults` PR.

## Verification

- `git diff` against pre-revert state shows the 4 default-value reverts.
- The boolean-type fix stays (`ignore_pv_feedback_during_curtailment.input = "boolean"`).
- `pytest tests/` passes.
- `uvx ruff check .` clean.

## Sibling PR

Follow-up PR for `config_defaults.json` value changes + release notes will be filed separately. This PR is now minimal: 1 line of schema-normalization.

Closes follow-up dependency direction agreed in this thread.
