### PR TITLE
docs: add AGENTS.md (vendor-neutral rules for AI coding agents)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,9 +82,40 @@ These corridors come from public maintainer statements. Cite the source if a con
 - **Glue layer is agnostic.** Node-RED, MQTT, Home Assistant, and generic automations are equivalent integration paths. Do not wire Home-Assistant-specific code paths into core.
 - **Zero-config default must keep working.** The add-on must continue to start and produce a sensible optimisation with default configuration after every change.
 
-## Section 5 — Limits and gotchas
+## Section 5 — Limits and gotchas (read this if you are an AI coder or working with one)
 
-(filled in Task 7)
+AI coders find code locations and produce candidate changes. Domain experts decide whether something is a bug or design. A 2026-04-26 schema audit illustrates the split: of eight candidate findings, four were confirmed bugs and PR-able, four needed maintainer judgment and went issue-first. Skipping the human-in-the-loop step produces roughly fifty percent noise.
+
+**File an issue, not a PR, when:**
+
+- Behaviour changes in any visible way (output values, log format, error messages).
+- A magic constant or sentinel might be intentional ("`=0` means no constraint?", "negative value treated as disabled?").
+- A condition looks wrong but might encode a domain convention you do not know (AC vs DC stack power; charge vs discharge sign conventions).
+- The change touches `optimization.py`, `retrieve_hass.py`, or `forecast.py` beyond about three lines.
+
+**Always verify before claiming done:**
+
+- Sign conventions (`P_grid > 0` means import? export? Check; do not assume).
+- Units in the wild (Home Assistant scales SOC by 100; CSV uses 0..1; they differ).
+- A test reproducer is present for any behaviour-change PR.
+- Container or UI smoke-test (`docker compose up` plus the browser config page) if schema or `web_server.py` changed.
+
+**Do not refactor without an issue:**
+
+- Restructuring `optimization.py` (3000+ lines) without an architecture-RFC issue gets rejected.
+- Renaming public API parameters breaks downstream consumers; needs a migration path.
+- Adding new dependencies is coordinated via issue first.
+
+**Adding a parameter:** follow the four-step workflow documented in `docs/develop.md` (`associations.csv` plus `config_defaults.json` plus `param_definitions.json` plus `OptimizationCacheKey`, optionally `check_def_loads`). Skipping any step breaks something.
+
+**Things AI tools commonly hallucinate or get wrong here:**
+
+- Confusing `param_definitions.json` (GUI hint metadata) with `config_defaults.json` (authoritative defaults).
+- Inventing solver or CVXPY APIs that do not exist in the pinned version.
+- Suggesting Pydantic v2 patterns when the codebase is still on v1 (or vice versa — verify in `pyproject.toml`).
+- Flagging the `if not handlers` guard in `get_logger` as missing without checking whether the module is already imported elsewhere.
+
+**Token and context limits:** the largest source files (`optimization.py`, `command_line.py`, both 3000+ lines) exceed comfortable context for many models. Use `repomix` (`npx repomix`) to flatten the repo for full-context tools that support it; otherwise scope reading to specific functions.
 
 ## Section 6 — Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ These four invariants are easy to break by accident and hard to detect in CI.
 
 1. **`action_logs.txt` line format.** The web server's error-detection logic in `src/emhass/web_server.py` parses each line by splitting on the first whitespace and comparing the leading token to `"ERROR"`. Any change to the log line format (extra prefix, structured-logging migration, JSON envelope) silently breaks error reporting in the UI.
 
-2. **`utils.get_logger` handler-proliferation guard.** The function checks whether a logger already has handlers before attaching new ones. Removing or bypassing that guard causes duplicated log lines under repeated module imports, which has historically masked real failures by hiding them in scroll-back.
+2. **Logger handler accumulation in `utils.get_logger`.** The function attaches a handler unconditionally on every call. Calling it twice for the same logger name produces duplicated log lines, which has historically masked real failures by hiding them in scroll-back. Avoid duplicate calls; if a guard becomes appropriate, coordinate the change with the maintainer because both the CLI and the web path call into this function.
 
 3. **Two parallel logging subsystems.** The CLI path uses `utils.get_logger`. The web path uses `app.logger` (the Flask logger). Logging changes touch both consistently or land in neither — partial migrations leave the two paths emitting different formats and break log consumers downstream.
 
@@ -113,7 +113,7 @@ AI coders find code locations and produce candidate changes. Domain experts deci
 - Confusing `param_definitions.json` (GUI hint metadata) with `config_defaults.json` (authoritative defaults).
 - Inventing solver or CVXPY APIs that do not exist in the pinned version.
 - Suggesting Pydantic v2 patterns when the codebase is still on v1 (or vice versa — verify in `pyproject.toml`).
-- Flagging the `if not handlers` guard in `get_logger` as missing without checking whether the module is already imported elsewhere.
+- Forgetting that the public `command_line.py` entry points (`set_input_data_dict`, `perfect_forecast_optim`, `dayahead_forecast_optim`, `naive_mpc_optim`, `publish_data`) are `async def` and writing synchronous wrappers around them.
 
 **Token and context limits:** the largest source files (`optimization.py`, `command_line.py`, both 3000+ lines) exceed comfortable context for many models. Use `repomix` (`npx repomix`) to flatten the repo for full-context tools that support it; otherwise scope reading to specific functions.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,12 @@ These four invariants are easy to break by accident and hard to detect in CI.
 
 ## Section 4 — Maintainer scope corridors
 
-(filled in Task 6)
+These corridors come from public maintainer statements. Cite the source if a contributor questions them.
+
+- **Threat model** (Discussion #808): the project's security envelope is code injection, not auth bypass or data leakage. Endpoints that read in-memory state are inside the corridor; endpoints that touch the filesystem, a database, or shell out are not, and need explicit maintainer sign-off.
+- **EMHASS scope** (Issue #789): EMHASS is a MILP optimiser. Vehicle APIs, OCPP, EVCC, and direct charger modulation belong in the integration layer, not in core.
+- **Glue layer is agnostic.** Node-RED, MQTT, Home Assistant, and generic automations are equivalent integration paths. Do not wire Home-Assistant-specific code paths into core.
+- **Zero-config default must keep working.** The add-on must continue to start and produce a sensible optimisation with default configuration after every change.
 
 ## Section 5 — Limits and gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,26 @@ Tech stack (verify versions in `pyproject.toml` before assuming an API):
 
 ## Section 2 — Pipeline map
 
-(filled in Task 4)
+EMHASS exposes three optimisation modes from `command_line.py`. All share an input-prep step and a publish step; the body differs by mode. The optimisation core is one method on the `Optimization` class.
+
+| Phase | Symbol |
+|---|---|
+| Input preparation | `command_line.py::set_input_data_dict` |
+| Mode entry, perfect forecast | `command_line.py::perfect_forecast_optim` |
+| Mode entry, day-ahead | `command_line.py::dayahead_forecast_optim` |
+| Mode entry, rolling MPC | `command_line.py::naive_mpc_optim` |
+| Optimisation core (LP build and CVXPY solve) | `optimization.py::Optimization.perform_optimization` |
+| Publish | `command_line.py::publish_data` |
+
+For finer-grained stage instrumentation, the codebase uses `stage_timer(stage_times, "<label>", logger)` blocks. Five labels are in active use:
+
+- `"pv_forecast"`
+- `"load_forecast"`
+- `"price_prep"`
+- `"optim_solve"`
+- `"publish"`
+
+Grep `'stage_timer.*"<label>"'` for the live call site at any time. The labels are stable across refactors; the line numbers are not.
 
 ## Section 3 — Don't-touch rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+---
+name: emhass-agents
+description: Vendor-neutral rules for AI coding agents working on EMHASS source.
+---
+
+<!-- Last verified against upstream/master @ 6537c47, 2026-04-30 -->
+
+This file documents rules for AI coding agents (Claude Code, Cursor, Aider, Copilot, Codex) working on EMHASS source. It complements `docs/develop.md` (canonical for humans) and does not duplicate its content. Where `docs/develop.md` already covers a topic, this file links and adds AI-specific constraints on top.
+
+## Repository layout
+
+- `src/emhass/` — core module: `optimization.py`, `forecast.py`, `retrieve_hass.py`, `web_server.py`, `command_line.py`, `utils.py`.
+- `tests/` — pytest suite.
+- `docs/` — Sphinx source. Start with `develop.md`; worked examples in `study_cases/`.
+- `data/` — config defaults and schema (`config_defaults.json`, `associations.csv`).
+- `src/emhass/static/` — web UI assets, including `param_definitions.json`.
+
+## Section 1 — Canonical commands
+
+(filled in Task 3)
+
+## Section 2 — Pipeline map
+
+(filled in Task 4)
+
+## Section 3 — Don't-touch rules
+
+(filled in Task 5)
+
+## Section 4 — Maintainer scope corridors
+
+(filled in Task 6)
+
+## Section 5 — Limits and gotchas
+
+(filled in Task 7)
+
+## Section 6 — Conventions
+
+(filled in Task 8)
+
+## Section 7 — Where to find more
+
+(filled in Task 9)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,8 @@ AI coders find code locations and produce candidate changes. Domain experts deci
 
 ## Section 6 — Conventions
 
-(filled in Task 8)
+- **Documentation style:** soft Diátaxis (https://diataxis.fr/) — tutorials, how-tos, reference, explanation. Pragmatic, not strictly four-quadrant. The `docs/study_cases/` directory holds the worked example.
+- **Commit messages:** prefix with type (`fix`, `docs`, `feat`, `chore`) per recent maintainer practice.
 
 ## Section 7 — Where to find more
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,4 +124,7 @@ AI coders find code locations and produce candidate changes. Domain experts deci
 
 ## Section 7 — Where to find more
 
-(filled in Task 9)
+- [`docs/develop.md`](docs/develop.md) — canonical EMHASS development guide (fork, venv, DevContainer, Docker, adding a parameter, PR process). Read this first.
+- [`llms.txt`](https://emhass.readthedocs.io/en/latest/llms.txt) — Sphinx-generated routing manifest. The file does not exist in the source tree; it is built per Sphinx run and served from Read the Docs.
+- [`docs/study_cases/`](docs/study_cases/) — Diátaxis-soft worked examples per persona.
+- [Project board](https://github.com/users/davidusb-geek/projects/2) — coordination and scope corridors visible per card.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,15 @@ Grep `'stage_timer.*"<label>"'` for the live call site at any time. The labels a
 
 ## Section 3 — Don't-touch rules
 
-(filled in Task 5)
+These four invariants are easy to break by accident and hard to detect in CI.
+
+1. **`action_logs.txt` line format.** The web server's error-detection logic in `src/emhass/web_server.py` parses each line by splitting on the first whitespace and comparing the leading token to `"ERROR"`. Any change to the log line format (extra prefix, structured-logging migration, JSON envelope) silently breaks error reporting in the UI.
+
+2. **`utils.get_logger` handler-proliferation guard.** The function checks whether a logger already has handlers before attaching new ones. Removing or bypassing that guard causes duplicated log lines under repeated module imports, which has historically masked real failures by hiding them in scroll-back.
+
+3. **Two parallel logging subsystems.** The CLI path uses `utils.get_logger`. The web path uses `app.logger` (the Flask logger). Logging changes touch both consistently or land in neither — partial migrations leave the two paths emitting different formats and break log consumers downstream.
+
+4. **`param_definitions.json` is a structured surface.** Additive changes only. Renaming a key, removing one, or changing its type contract breaks the configuration UI and any external tooling that reads the schema. New entries are fine; mutations need a migration plan and a maintainer-led review.
 
 ## Section 4 — Maintainer scope corridors
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,16 +26,15 @@ Quick-recall for AI tools:
 | Run tests | `pytest tests/` |
 | Sync dev deps | `uv sync --extra test` |
 | Build docs | `sphinx-build -b html docs docs/_build` (configured in `docs/conf.py`) |
-| Lint | No enforced linter. |
+| Lint | `uvx ruff check .` (enforced via `.github/workflows/code-quality.yml` on every PR) |
 
 Tech stack (verify versions in `pyproject.toml` before assuming an API):
 
 | Component | Version source |
 |---|---|
 | Python | `pyproject.toml` `requires-python` |
-| Pydantic | v1 |
 | Optimisation | CVXPY (pin in `pyproject.toml`) |
-| Web | Flask |
+| Web | Quart + Uvicorn |
 | Tests | pytest |
 
 ## Section 2 — Pipeline map
@@ -63,7 +62,7 @@ Grep `'stage_timer.*"<label>"'` for the live call site at any time. The labels a
 
 ## Section 3 — Don't-touch rules
 
-These four invariants are easy to break by accident and hard to detect in CI.
+These five invariants are easy to break by accident and hard to detect in CI.
 
 1. **`action_logs.txt` line format.** The web server's error-detection logic in `src/emhass/web_server.py` parses each line by splitting on the first whitespace and comparing the leading token to `"ERROR"`. Any change to the log line format (extra prefix, structured-logging migration, JSON envelope) silently breaks error reporting in the UI.
 
@@ -72,6 +71,8 @@ These four invariants are easy to break by accident and hard to detect in CI.
 3. **Two parallel logging subsystems.** The CLI path uses `utils.get_logger`. The web path uses `app.logger` (the Flask logger). Logging changes touch both consistently or land in neither. Partial migrations leave the two paths emitting different formats and break log consumers downstream.
 
 4. **`param_definitions.json` is a structured surface.** Additive changes only. Renaming a key, removing one, or changing its type contract breaks the configuration UI and any external tooling that reads the schema. New entries are fine; mutations need a migration plan and a maintainer-led review.
+
+5. **Optimisation-result DataFrame columns and units.** The `opt_res_*` DataFrames are written to `opt_res_latest.csv`, published as Home Assistant sensors (`sensor.p_pv_forecast`, `sensor.p_load_forecast`, `sensor.p_batt_forecast`, etc., per `docs/publish_data.md`), and consumed by external bridges (Node-RED flows, third-party forecasters, regional market integrations). Column renames and unit changes are breaking changes; additive columns are fine. Treat the current `opt_res_latest.csv` columns as the de-facto schema until a formal schema doc lands.
 
 ## Section 4 — Maintainer scope corridors
 
@@ -108,18 +109,19 @@ AI coders find code locations and produce candidate changes. Domain experts deci
 
 **Adding a parameter:** follow the four-step workflow documented in `docs/develop.md` (`associations.csv` plus `config_defaults.json` plus `param_definitions.json` plus `OptimizationCacheKey`, optionally `check_def_loads`). Skipping any step breaks something.
 
+**External forecast feed alignment.** The `runtimeparams` handlers for `pv_power_forecast`, `load_power_forecast`, `load_cost_forecast`, and `prod_price_forecast` are intentionally tolerant of length, frequency, and timezone differences — day-ahead price feeds typically publish 24h, not 48h, and get padded gracefully. Tolerant ≠ silent: if you change resample/align logic, log clearly when alignment happens. Silent shifts have historically produced wrong-but-valid-looking plans (`optim_status: Optimal` with every timestep offset by N).
+
 **Things AI tools commonly hallucinate or get wrong here:**
 
 - Confusing `param_definitions.json` (GUI hint metadata) with `config_defaults.json` (authoritative defaults).
 - Inventing solver or CVXPY APIs that do not exist in the pinned version.
-- Suggesting Pydantic v2 patterns when the codebase is still on v1, or vice versa. Verify in `pyproject.toml`.
 - Forgetting that the public `command_line.py` entry points (`set_input_data_dict`, `perfect_forecast_optim`, `dayahead_forecast_optim`, `naive_mpc_optim`, `publish_data`) are `async def` and writing synchronous wrappers around them.
 
 **Token and context limits:** the largest source files (`optimization.py`, `command_line.py`, both 3000+ lines) exceed comfortable context for many models. Use `repomix` (`npx repomix`) to flatten the repo for full-context tools that support it; otherwise scope reading to specific functions.
 
 ## Section 6 — Conventions
 
-- **Documentation style:** soft Diátaxis (https://diataxis.fr/): tutorials, how-tos, reference, explanation. Pragmatic, not strictly four-quadrant. The `docs/study_cases/` directory holds the worked example.
+- **Documentation style:** soft Diátaxis (https://diataxis.fr/): tutorials, how-tos, reference, explanation. Pragmatic, not strictly four-quadrant. The `docs/study_cases/` directory holds worked examples.
 - **Commit messages:** prefix with type (`fix`, `docs`, `feat`, `chore`) per recent maintainer practice.
 
 ## Section 7 — Where to find more

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,14 +26,14 @@ Quick-recall for AI tools:
 | Run tests | `pytest tests/` |
 | Sync dev deps | `uv sync --extra test` |
 | Build docs | `sphinx-build -b html docs docs/_build` (configured in `docs/conf.py`) |
-| Lint | No enforced linter at the time of writing. |
+| Lint | No enforced linter. |
 
 Tech stack (verify versions in `pyproject.toml` before assuming an API):
 
 | Component | Version source |
 |---|---|
 | Python | `pyproject.toml` `requires-python` |
-| Pydantic | v1 at the time of writing |
+| Pydantic | v1 |
 | Optimisation | CVXPY (pin in `pyproject.toml`) |
 | Web | Flask |
 | Tests | pytest |
@@ -69,7 +69,7 @@ These four invariants are easy to break by accident and hard to detect in CI.
 
 2. **Logger handler accumulation in `utils.get_logger`.** The function attaches a handler unconditionally on every call. Calling it twice for the same logger name produces duplicated log lines, which has historically masked real failures by hiding them in scroll-back. Avoid duplicate calls; if a guard becomes appropriate, coordinate the change with the maintainer because both the CLI and the web path call into this function.
 
-3. **Two parallel logging subsystems.** The CLI path uses `utils.get_logger`. The web path uses `app.logger` (the Flask logger). Logging changes touch both consistently or land in neither — partial migrations leave the two paths emitting different formats and break log consumers downstream.
+3. **Two parallel logging subsystems.** The CLI path uses `utils.get_logger`. The web path uses `app.logger` (the Flask logger). Logging changes touch both consistently or land in neither. Partial migrations leave the two paths emitting different formats and break log consumers downstream.
 
 4. **`param_definitions.json` is a structured surface.** Additive changes only. Renaming a key, removing one, or changing its type contract breaks the configuration UI and any external tooling that reads the schema. New entries are fine; mutations need a migration plan and a maintainer-led review.
 
@@ -112,14 +112,14 @@ AI coders find code locations and produce candidate changes. Domain experts deci
 
 - Confusing `param_definitions.json` (GUI hint metadata) with `config_defaults.json` (authoritative defaults).
 - Inventing solver or CVXPY APIs that do not exist in the pinned version.
-- Suggesting Pydantic v2 patterns when the codebase is still on v1 (or vice versa — verify in `pyproject.toml`).
+- Suggesting Pydantic v2 patterns when the codebase is still on v1, or vice versa. Verify in `pyproject.toml`.
 - Forgetting that the public `command_line.py` entry points (`set_input_data_dict`, `perfect_forecast_optim`, `dayahead_forecast_optim`, `naive_mpc_optim`, `publish_data`) are `async def` and writing synchronous wrappers around them.
 
 **Token and context limits:** the largest source files (`optimization.py`, `command_line.py`, both 3000+ lines) exceed comfortable context for many models. Use `repomix` (`npx repomix`) to flatten the repo for full-context tools that support it; otherwise scope reading to specific functions.
 
 ## Section 6 — Conventions
 
-- **Documentation style:** soft Diátaxis (https://diataxis.fr/) — tutorials, how-tos, reference, explanation. Pragmatic, not strictly four-quadrant. The `docs/study_cases/` directory holds the worked example.
+- **Documentation style:** soft Diátaxis (https://diataxis.fr/): tutorials, how-tos, reference, explanation. Pragmatic, not strictly four-quadrant. The `docs/study_cases/` directory holds the worked example.
 - **Commit messages:** prefix with type (`fix`, `docs`, `feat`, `chore`) per recent maintainer practice.
 
 ## Section 7 — Where to find more

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,26 @@ This file documents rules for AI coding agents (Claude Code, Cursor, Aider, Copi
 
 ## Section 1 — Canonical commands
 
-(filled in Task 3)
+Setup, environment variables, and the full developer workflow live in `docs/develop.md` (Method 1 Python venv with `uv`, Method 2 DevContainer, Method 3 Docker). Read that first.
+
+Quick-recall for AI tools:
+
+| Action | Command |
+|---|---|
+| Run tests | `pytest tests/` |
+| Sync dev deps | `uv sync --extra test` |
+| Build docs | `sphinx-build -b html docs docs/_build` (configured in `docs/conf.py`) |
+| Lint | No enforced linter at the time of writing. |
+
+Tech stack (verify versions in `pyproject.toml` before assuming an API):
+
+| Component | Version source |
+|---|---|
+| Python | `pyproject.toml` `requires-python` |
+| Pydantic | v1 at the time of writing |
+| Optimisation | CVXPY (pin in `pyproject.toml`) |
+| Web | Flask |
+| Tests | pytest |
 
 ## Section 2 — Pipeline map
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
 # Contributing
 
 Pull requests are very much accepted on this project. For development, you can find some instructions here [Development](https://emhass.readthedocs.io/en/latest/develop.html).
+
+For AI coding agents working on EMHASS source, see [`AGENTS.md`](AGENTS.md).


### PR DESCRIPTION
## Rationale

Upstream EMHASS has no vendor-neutral rules file for AI coding agents (Claude Code, Cursor, Aider, Copilot, Codex). Without one, AI tools default to inferred conventions; a 2026-04-26 schema audit illustrates the cost — eight candidate findings → four PR-able, four needed maintainer judgment and went issue-first. `docs/develop.md` is canonical for humans. `AGENTS.md` fills the orthogonal AI-rules gap and routes back to `develop.md` instead of restating it.

This PR adds:

- `AGENTS.md` at the repo root — YAML frontmatter, a freshness marker, a repository-layout preamble, and seven sections (canonical commands, pipeline map, don't-touch rules, scope corridors, limits and gotchas, conventions, where to find more).
- `CONTRIBUTING.md` — one-line addition pointing AI coding agents at `AGENTS.md`.

## Maintainer ack

Per Discussion #808 reply (2026-04-27): *"rich in concrete examples, that was what was needed"* — the workflow-demo gate cleared this deliverable.

## Doc complementarity

`AGENTS.md` does not duplicate `docs/develop.md`. Where `develop.md` already covers a topic (setup, fork workflow, the four-step "Adding a parameter" workflow), `AGENTS.md` links and adds AI-specific rules on top. Section 1 is a quick-recall command table, not setup steps. Section 5 points at `develop.md` for the parameter workflow rather than restating it.

## Best-practice sources consulted

- [GitHub Blog — *How to write a great AGENTS.md*](https://github.blog/ai-and-ml/github-copilot/how-to-write-a-great-agents-md-lessons-from-over-2500-repositories/) (2500-repo Copilot analysis)
- [OpenAI Codex — *Best practices*](https://developers.openai.com/codex/learn/best-practices)

Adopted from those sources: minimal YAML frontmatter, freshness marker, repository-layout preamble, tech-stack with versions, length cap of 350 source lines.

## Pre-push verification

- [x] Section 2 symbols verified against \`upstream/master\` HEAD: \`set_input_data_dict\`, \`perfect_forecast_optim\`, \`dayahead_forecast_optim\`, \`naive_mpc_optim\`, \`perform_optimization\`, \`publish_data\` — all present.
- [x] Section 2 \`stage_timer\` labels verified: \`pv_forecast\`, \`load_forecast\`, \`price_prep\`, \`optim_solve\`, \`publish\` — all present in \`command_line.py\`.
- [x] Section 3 invariants verified in current source: action-log ERROR parser at \`web_server.py:135\`; \`get_logger\` handler accumulation behaviour; both CLI and web logging paths; \`param_definitions.json\` schema file.
- [x] All HTTP links return 200; in-repo paths (\`docs/develop.md\`, \`docs/study_cases/\`, schema files) exist.
- [x] No content duplication between \`AGENTS.md\` and \`docs/develop.md\`.
- [x] British spelling consistent throughout prose; only Python identifiers retain \`optimization\` (filename).
- [x] YAML frontmatter parses; freshness marker carries the actual SHA \`6537c47\` and date \`2026-04-30\`.
- [x] Diff contains exactly two file changes: \`AGENTS.md\` (new, 130 lines), \`CONTRIBUTING.md\` (+2 lines).
- [ ] GitHub render preview to be verified once this PR is open.

## Summary by Sourcery

Add a vendor-neutral guidance document for AI coding agents and link it from contributing guidelines.

Documentation:
- Introduce an AGENTS.md document at the repository root describing rules, constraints, and workflows for AI coding agents working on EMHASS.
- Update CONTRIBUTING.md to direct AI coding agents to the new AGENTS.md guidance instead of duplicating development instructions.