### PR TITLE
docs(schema): publish plan-output column schema + version constant

### DIFF
--- a/docs/plan_output_schema.md
+++ b/docs/plan_output_schema.md
@@ -1,0 +1,123 @@
+# Plan / Optimization Output Schema
+
+This page documents the columns of the optimization-result DataFrame returned by
+`publish_data` (see [API Reference](emhass.html#emhass.command_line.publish_data)).
+Downstream consumers — Home Assistant cards, Node-RED flows, EVCC adapters, third-party
+automations — can rely on this schema as a versioned contract.
+
+## Schema version
+
+Every result DataFrame carries the schema version as a pandas attribute:
+
+```python
+result = await publish_data(...)
+result.attrs["emhass_schema_version"]
+# "1.0"
+```
+
+The version string is also exposed as a module-level constant:
+
+```python
+from emhass.command_line import EMHASS_SCHEMA_VERSION
+```
+
+### Semver rules
+
+| Bump kind | Trigger |
+|-----------|---------|
+| **Patch** (`1.0` → `1.0.1`) | Documentation clarification, sign convention confirmed, description sharpened. No consumer code change required. |
+| **Minor** (`1.0` → `1.1`) | New column added without removing or renaming existing columns. Consumers using `.get(col)` keep working. |
+| **Major** (`1.0` → `2.0`) | Column removed, column renamed, sign convention flipped, unit changed, or HA-scaling factor changed for a column. |
+
+Consumers pin to a major version. Code that requires schema ≥ 1.0 should check:
+
+```python
+major = int(result.attrs.get("emhass_schema_version", "0").split(".")[0])
+if major != 1:
+    raise RuntimeError(f"Unexpected EMHASS schema major {major}")
+```
+
+## Column table
+
+11 fixed columns plus four variable groups: `P_deferrable{k}`,
+`predicted_temp_heater{k}`, `heating_demand_heater{k}` (for each configured
+deferrable / thermal load), and `cost_fun_<name>` (one column per cost-function
+component the chosen `costfun` decomposes into).
+
+| Column | Source helper | Unit | Sign convention | Conditional | HA scaling | `type_var` | Notes |
+|--------|---------------|------|-----------------|-------------|------------|------------|-------|
+| `P_Load` | `_publish_standard_forecasts` | W | positive = consumption | always | 1:1 | `power` | DataFrame column read directly |
+| `P_PV` | `_publish_standard_forecasts` | W | (TBD — see PR comment 1) | when `"P_PV"` is in DataFrame | 1:1 | `power` | `custom_pv_forecast_id` |
+| `P_PV_curtailment` | `_publish_standard_forecasts` | W | (TBD — see PR comment 2) | `plant_conf.compute_curtailment = true` | 1:1 | `power` | `custom_pv_curtailment_id` |
+| `P_hybrid_inverter` | `_publish_standard_forecasts` | W | (TBD — see PR comment 3) | `plant_conf.inverter_is_hybrid = true` | 1:1 | `power` | `custom_hybrid_inverter_id` |
+| `P_deferrable{k}` | `_publish_deferrable_loads` | W | positive = consumption | `k ∈ [0, number_of_deferrable_loads)`; row skipped (error log) if column missing | 1:1 | `deferrable` | `custom_deferrable_forecast_id[k]` |
+| `predicted_temp_heater{k}` | `_publish_thermal_loads` | °C | n/a (state, not flow) — (TBD which temperature: room / supply / tank — see PR comment 7) | per `k` where `def_load_config[k]` has `thermal_config` or `thermal_battery` | 1:1 | `temperature` | `custom_predicted_temperature_id[k]` |
+| `heating_demand_heater{k}` | `_publish_thermal_loads` | **kWh** | (TBD — thermal vs electrical energy, see PR comment 6) | same as `predicted_temp_heater{k}` | 1:1 | `energy` | unit `"kWh"` confirmed at `utils.py` (`heating_demand_friendly_name`). `custom_heating_demand_id[k]` |
+| `P_batt` | `_publish_battery_data` | W | (TBD — charge vs discharge sign, see PR comment 4) | `optim_conf.set_use_battery = true`; row skipped if column missing | 1:1 | `batt` | `custom_batt_forecast_id` |
+| `SOC_opt` | `_publish_battery_data` | **fraction (0..1) in CSV; ×100 in HA** | n/a (state) | `optim_conf.set_use_battery = true` | **×100** | `SOC` | See [SOC_opt scaling callout](#soc_opt-scaling-callout) |
+| `P_grid` | `_publish_grid_and_costs` | W | (TBD — import vs export sign, see PR comment 5) | always | 1:1 | `power` | `custom_grid_forecast_id` |
+| `cost_fun_<name>` | `_publish_grid_and_costs` | € | n/a (cost) | always; multi-column (filter on substring `"cost_fun_"`) | 1:1 | `cost_fun` | Components depend on `costfun` (`profit`, `cost`, `self-consumption`). HA single entity `custom_cost_fun_id` aggregates them. |
+| `optim_status` | `_publish_grid_and_costs` | text | n/a | always (defaulted to `"Optimal"` with WARN log if missing) | n/a | `optim_status` | CVXPY status strings: `Optimal`, `Infeasible`, `Unbounded`, etc. `device_class=""`, `unit_of_measurement=""`. |
+| `unit_load_cost` | `_publish_grid_and_costs` | €/kWh | n/a (price) | always | 1:1 | `unit_load_cost` | per-timestep tariff series for load |
+| `unit_prod_price` | `_publish_grid_and_costs` | €/kWh | n/a (price) | always | 1:1 | `unit_prod_price` | per-timestep sell price series |
+
+### SOC_opt scaling callout
+
+> ⚠️ **`SOC_opt` is the most common consumer bug.**
+>
+> The DataFrame value and the CSV export carry the state-of-charge as a **fraction in
+> [0, 1]**. When the same column is published to Home Assistant it is multiplied by
+> **100** to display as a percentage. Consumers reading the result DataFrame or the
+> exported CSV must therefore multiply by 100 themselves if they expect percent;
+> consumers reading the HA entity get percent already and must not double-scale.
+
+## Sign conventions — open
+
+Five power columns and two thermal columns have ambiguous sign conventions until
+maintainer confirms. The opened PR carries those questions in its description; once
+answered, this doc gets a follow-up patch on the same branch that replaces the `(TBD —
+see PR comment N)` markers with the confirmed convention. Until then, consumers must
+inspect the source or wait for the merged version.
+
+## Consumer recipes
+
+### Python (pandas)
+
+```python
+from emhass.command_line import publish_data, EMHASS_SCHEMA_VERSION
+
+result = await publish_data(input_data_dict, logger)
+assert result.attrs["emhass_schema_version"].startswith("1.")
+
+if "SOC_opt" in result.columns:
+    soc_percent = result["SOC_opt"] * 100  # CSV holds fraction
+```
+
+### Node-RED
+
+The published HA entities carry the result columns by their friendly names (set per
+`custom_*_id` config). A flow that depends on the schema should hard-code the major
+version it was authored against and refuse to run if the EMHASS instance advertises a
+different major (read from the EMHASS log line at startup, or via the `/api/last-run`
+endpoint once that lands — see board item AC-3).
+
+## Source helpers
+
+Per-column source helpers in `src/emhass/command_line.py`:
+
+| Helper | Approximate line range | Columns published |
+|--------|------------------------|-------------------|
+| `_publish_standard_forecasts` | 2152-2214 | `P_Load`, `P_PV`, `P_PV_curtailment`, `P_hybrid_inverter` |
+| `_publish_deferrable_loads` | 2215-2259 | `P_deferrable{k}` for `k ∈ [0, N)` |
+| `_publish_thermal_loads` | 2260-2304 | `predicted_temp_heater{k}`, `heating_demand_heater{k}` |
+| `_publish_battery_data` | 2305-2341 | `P_batt`, `SOC_opt` |
+| `_publish_grid_and_costs` | 2342-2405 | `P_grid`, `cost_fun_<name>`, `optim_status`, `unit_load_cost`, `unit_prod_price` |
+
+The aggregator `publish_data` (~line 2408) calls these in order and subsets the result
+DataFrame to the published columns before returning.
+
+## Version history
+
+| Version | Date | Change |
+|---------|------|--------|
+| 1.0 | 2026-05-10 | Initial published schema. 7 sign conventions still TBD; will be resolved in a follow-up patch on the same PR branch before merge. |

--- a/docs/plan_output_schema.md
+++ b/docs/plan_output_schema.md
@@ -1,7 +1,7 @@
 # Plan / Optimization Output Schema
 
 This page documents the columns of the optimization-result DataFrame returned by
-`publish_data` (see [API Reference](emhass.html#emhass.command_line.publish_data)).
+`publish_data` (see [API Reference](emhass.md)).
 Downstream consumers — Home Assistant cards, Node-RED flows, EVCC adapters, third-party
 automations — can rely on this schema as a versioned contract.
 

--- a/docs/plan_output_schema.md
+++ b/docs/plan_output_schema.md
@@ -47,15 +47,15 @@ component the chosen `costfun` decomposes into).
 | Column | Source helper | Unit | Sign convention | Conditional | HA scaling | `type_var` | Notes |
 |--------|---------------|------|-----------------|-------------|------------|------------|-------|
 | `P_Load` | `_publish_standard_forecasts` | W | positive = consumption | always | 1:1 | `power` | DataFrame column read directly |
-| `P_PV` | `_publish_standard_forecasts` | W | (TBD — see PR comment 1) | when `"P_PV"` is in DataFrame | 1:1 | `power` | `custom_pv_forecast_id` |
-| `P_PV_curtailment` | `_publish_standard_forecasts` | W | (TBD — see PR comment 2) | `plant_conf.compute_curtailment = true` | 1:1 | `power` | `custom_pv_curtailment_id` |
-| `P_hybrid_inverter` | `_publish_standard_forecasts` | W | (TBD — see PR comment 3) | `plant_conf.inverter_is_hybrid = true` | 1:1 | `power` | `custom_hybrid_inverter_id` |
+| `P_PV` | `_publish_standard_forecasts` | W | positive = production (PV → DC bus) | when `"P_PV"` is in DataFrame | 1:1 | `power` | `custom_pv_forecast_id`. Assigned from `p_pv` forecast input at `optimization.py:2291`. |
+| `P_PV_curtailment` | `_publish_standard_forecasts` | W | positive = curtailed delta (subtracts from gross PV in DC balance) | `plant_conf.compute_curtailment = true` | 1:1 | `power` | `custom_pv_curtailment_id`. CVXPY `nonneg=True` at `optimization.py:876`; appears as `(p_pv - p_pv_curtailment)` in DC-balance constraint at line 1131; bounded by `<= param_pv_forecast` at line 2761. |
+| `P_hybrid_inverter` | `_publish_standard_forecasts` | W | AC-side power; positive = DC → AC delivery, negative = AC → DC (charging-from-grid via DC bus) | `plant_conf.inverter_is_hybrid = true` | 1:1 | `power` | `custom_hybrid_inverter_id`. Defined at `optimization.py:1140` as `p_hybrid_inverter == (p_dc_ac * eff_dc_ac) - (p_ac_dc * (1.0 / eff_ac_dc))`. |
 | `P_deferrable{k}` | `_publish_deferrable_loads` | W | positive = consumption | `k ∈ [0, number_of_deferrable_loads)`; row skipped (error log) if column missing | 1:1 | `deferrable` | `custom_deferrable_forecast_id[k]` |
-| `predicted_temp_heater{k}` | `_publish_thermal_loads` | °C | n/a (state, not flow) — (TBD which temperature: room / supply / tank — see PR comment 7) | per `k` where `def_load_config[k]` has `thermal_config` or `thermal_battery` | 1:1 | `temperature` | `custom_predicted_temperature_id[k]` |
-| `heating_demand_heater{k}` | `_publish_thermal_loads` | **kWh** | (TBD — thermal vs electrical energy, see PR comment 6) | same as `predicted_temp_heater{k}` | 1:1 | `energy` | unit `"kWh"` confirmed at `utils.py` (`heating_demand_friendly_name`). `custom_heating_demand_id[k]` |
-| `P_batt` | `_publish_battery_data` | W | (TBD — charge vs discharge sign, see PR comment 4) | `optim_conf.set_use_battery = true`; row skipped if column missing | 1:1 | `batt` | `custom_batt_forecast_id` |
+| `predicted_temp_heater{k}` | `_publish_thermal_loads` | °C | n/a (state) | per `k` where `def_load_config[k]` has `thermal_config` or `thermal_battery` | 1:1 | `temperature` | `custom_predicted_temperature_id[k]`. Semantics depend on heater type: **room (air) temperature** for `thermal_config` loads (kept within `min_temps`/`max_temps` band toward `desired_temps`); **thermal-storage/tank temperature** for `thermal_battery` loads. |
+| `heating_demand_heater{k}` | `_publish_thermal_loads` | **kWh** | **thermal energy** delivered to the storage (heat in), not electrical input | only set for `thermal_battery`-type loads (not bare `thermal_config`) | 1:1 | `energy` | `custom_heating_demand_id[k]`. The thermal-battery model carries a separate `heatpump_cops` parameter (`optimization.py:310`); electrical input = thermal / COP, so the two are decoupled. Unit `"kWh"` confirmed at `utils.py` (`heating_demand_friendly_name`). |
+| `P_batt` | `_publish_battery_data` | W | positive = discharge (battery → house), negative = charge (house/grid → battery) | `optim_conf.set_use_battery = true`; row skipped if column missing | 1:1 | `batt` | `custom_batt_forecast_id`. Sum of `p_sto_pos + p_sto_neg` at `optimization.py:2312`. SOC reconstruction at lines 2319-2322 confirms direction: `power_flow = p_sto_pos / eff_dis + p_sto_neg * eff_chg`, then `SOC_opt = soc_init - cumulative_change / cap` (so positive `P_batt` drives SOC down → discharge). |
 | `SOC_opt` | `_publish_battery_data` | **fraction (0..1) in CSV; ×100 in HA** | n/a (state) | `optim_conf.set_use_battery = true` | **×100** | `SOC` | See [SOC_opt scaling callout](#soc_opt-scaling-callout) |
-| `P_grid` | `_publish_grid_and_costs` | W | (TBD — import vs export sign, see PR comment 5) | always | 1:1 | `power` | `custom_grid_forecast_id` |
+| `P_grid` | `_publish_grid_and_costs` | W | positive = import (grid → house), negative = export (house → grid) | always | 1:1 | `power` | `custom_grid_forecast_id`. `P_grid = P_grid_pos + P_grid_neg` at `optimization.py:2299`. `p_grid_pos` is CVXPY `nonneg=True` bounded by `maximum_power_from_grid` (line 803); `p_grid_neg` is `nonpos=True` bounded by `-maximum_power_to_grid` (line 798). |
 | `cost_fun_<name>` | `_publish_grid_and_costs` | € | n/a (cost) | always; multi-column (filter on substring `"cost_fun_"`) | 1:1 | `cost_fun` | Components depend on `costfun` (`profit`, `cost`, `self-consumption`). HA single entity `custom_cost_fun_id` aggregates them. |
 | `optim_status` | `_publish_grid_and_costs` | text | n/a | always (defaulted to `"Optimal"` with WARN log if missing) | n/a | `optim_status` | CVXPY status strings: `Optimal`, `Infeasible`, `Unbounded`, etc. `device_class=""`, `unit_of_measurement=""`. |
 | `unit_load_cost` | `_publish_grid_and_costs` | €/kWh | n/a (price) | always | 1:1 | `unit_load_cost` | per-timestep tariff series for load |
@@ -71,13 +71,19 @@ component the chosen `costfun` decomposes into).
 > exported CSV must therefore multiply by 100 themselves if they expect percent;
 > consumers reading the HA entity get percent already and must not double-scale.
 
-## Sign conventions — open
+## Sign conventions
 
-Five power columns and two thermal columns have ambiguous sign conventions until
-maintainer confirms. The opened PR carries those questions in its description; once
-answered, this doc gets a follow-up patch on the same branch that replaces the `(TBD —
-see PR comment N)` markers with the confirmed convention. Until then, consumers must
-inspect the source or wait for the merged version.
+All sign conventions are derived from `src/emhass/optimization.py` (the CVXPY model
+definition). Per-column citations are inline in the column table above. Summary:
+
+| Quantity | Positive means | Negative means |
+|----------|----------------|----------------|
+| `P_PV` | PV production (panels → DC bus) | (always ≥ 0; PV does not consume) |
+| `P_PV_curtailment` | curtailed delta (subtracted from gross PV) | (always ≥ 0; CVXPY `nonneg=True`) |
+| `P_hybrid_inverter` | DC → AC flow (delivered to house/grid) | AC → DC flow (charging via DC bus) |
+| `P_deferrable{k}` | load consumption | (always ≥ 0; loads do not export) |
+| `P_batt` | battery discharge (battery → house) | battery charge (house/grid → battery) |
+| `P_grid` | import (grid → house) | export (house → grid) |
 
 ## Consumer recipes
 
@@ -120,4 +126,4 @@ DataFrame to the published columns before returning.
 
 | Version | Date | Change |
 |---------|------|--------|
-| 1.0 | 2026-05-10 | Initial published schema. 7 sign conventions still TBD; will be resolved in a follow-up patch on the same PR branch before merge. |
+| 1.0 | 2026-05-10 | Initial published schema. Sign conventions derived from `src/emhass/optimization.py` with inline citations. |

--- a/docs/section_reference.md
+++ b/docs/section_reference.md
@@ -2,6 +2,7 @@
 
 ```{toctree}
 :maxdepth: 2
+plan_output_schema
 emhass
 develop
 ```

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -29,6 +29,7 @@ default_csv_filename = "opt_res_latest.csv"
 default_pkl_suffix = "_mlf.pkl"
 default_metadata_json = "metadata.json"
 test_df_literal = "test_df_final.pkl"
+EMHASS_SCHEMA_VERSION = "1.0"
 
 
 @dataclass

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -2439,6 +2439,7 @@ async def publish_data(
     if not save_data_to_file and publish_prefix != "" and not dont_post:
         opt_res = await _publish_from_saved_entities(input_data_dict, logger, params)
         if opt_res is not None:
+            opt_res.attrs["emhass_schema_version"] = EMHASS_SCHEMA_VERSION
             return opt_res
     # Load Optimization Results (if not passed)
     if opt_res_latest is None:
@@ -2469,6 +2470,7 @@ async def publish_data(
     cols_published.extend(await _publish_grid_and_costs(ctx, opt_res_latest))
     # Return Summary DataFrame
     opt_res = opt_res_latest[cols_published].loc[[opt_res_latest.index[idx_closest]]]
+    opt_res.attrs["emhass_schema_version"] = EMHASS_SCHEMA_VERSION
     return opt_res
 
 

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -2049,6 +2049,32 @@ class TestCommandLineTimezoneLogic(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class TestSchemaVersion(unittest.IsolatedAsyncioTestCase):
+    """Cover EMHASS_SCHEMA_VERSION constant and the publish_data early-return attach."""
+
+    def test_constant_value(self):
+        from emhass.command_line import EMHASS_SCHEMA_VERSION
+
+        self.assertEqual(EMHASS_SCHEMA_VERSION, "1.0")
+
+    async def test_publish_data_attaches_schema_version_on_saved_entities_path(self):
+        from emhass.command_line import EMHASS_SCHEMA_VERSION
+
+        mock_df = pd.DataFrame({"P_grid": [0.0]})
+        with (
+            patch(
+                "emhass.command_line._get_params",
+                return_value={"passed_data": {"publish_prefix": "test_"}},
+            ),
+            patch(
+                "emhass.command_line._publish_from_saved_entities",
+                new=AsyncMock(return_value=mock_df),
+            ),
+        ):
+            result = await publish_data({}, logger)
+        self.assertEqual(result.attrs["emhass_schema_version"], EMHASS_SCHEMA_VERSION)
+
+
 class TestOptimizationCache(unittest.TestCase):
     """Unit tests for the OptimizationCache warm-starting functionality."""
 


### PR DESCRIPTION
## Summary
Publishes a versioned schema for the optimization output:
- New `docs/plan_output_schema.md` — 11 fixed columns + 4 variable groups (deferrable / thermal / cost_fun), with units, sign conventions, conditionals, HA-scaling notes, and source-helper map.
- New module constant `EMHASS_SCHEMA_VERSION = "1.0"` in `command_line.py`.
- Attached to the result `DataFrame` via `opt_res.attrs["emhass_schema_version"]` at both return paths of `publish_data`.

Closes #828.

## Why
Downstream consumers (Node-RED flows, HA cards, EVCC adapters, future LLM helper skills) today reverse-engineer the schema from `command_line.py`. Sign conventions for `P_grid`, `P_batt`, `P_PV`, etc. are not declared anywhere consumer-visible. The `SOC_opt` HA-scaling trap (fraction in CSV, ×100 in HA) is undocumented. This PR turns the implicit schema into an explicit contract.

## What's included
- `docs/plan_output_schema.md`
- `docs/section_reference.md` — toctree entry
- `src/emhass/command_line.py` — constant + two `attrs` writes inside `publish_data`
- `tests/test_command_line_utils.py` — new `TestSchemaVersion` class covering the constant and the early-return attach path

## Sign conventions

All sign conventions in the doc are derived from `src/emhass/optimization.py` (the CVXPY model definition) with inline line-number citations. Summary:

| Column | Positive means | Source citation |
|--------|----------------|-----------------|
| `P_PV` | PV production (panels → DC bus) | `optimization.py:2291` |
| `P_PV_curtailment` | curtailed delta (subtracted from gross PV) | `optimization.py:876` (`nonneg=True`), `:1131` (DC balance) |
| `P_hybrid_inverter` | DC → AC delivery (negative = AC → DC charge path) | `optimization.py:1140` |
| `P_batt` | battery discharge (battery → house) | `optimization.py:2312, 2319-2322` (SOC reconstruction direction) |
| `P_grid` | import (grid → house); negative = export | `optimization.py:795-803, 2297-2299` |
| `heating_demand_heater{k}` | thermal energy delivered to storage (kWh) | `optimization.py:310` (separate `heatpump_cops` parameter decouples thermal from electrical) |
| `predicted_temp_heater{k}` | room temp for `thermal_config` loads, tank/storage temp for `thermal_battery` loads | `optimization.py:264-287` (thermal_config params), `:298-324` (thermal_battery params) |

Happy to adjust wording or rename columns if any of the above misstates intent — please flag and I will patch on this branch before merge.

## Test plan
- `python -c "from emhass.command_line import EMHASS_SCHEMA_VERSION; print(EMHASS_SCHEMA_VERSION)"` → `1.0`
- `python -m py_compile src/emhass/command_line.py` → no output
- `grep -c emhass_schema_version src/emhass/command_line.py` → 3 (constant + 2 attaches)
- `pytest tests/test_command_line_utils.py::TestSchemaVersion -v` → 2 tests pass
- Sphinx build (`./make.bat html` from `docs/`) — new page renders, no warnings naming it.

## Notes
- Independent of PR #830 (input-side `param_definitions.json` schema fix). Different files, no key overlap.
