### PR TITLE
fix: normalize None timesteps and use .get() for safe optim_conf reads

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -1557,12 +1557,12 @@ async def naive_mpc_optim(
     def_total_timestep = input_data_dict["params"]["optim_conf"].get(
         "operating_timesteps_of_each_deferrable_load", None
     )
-    def_start_timestep = input_data_dict["params"]["optim_conf"][
+    def_start_timestep = input_data_dict["params"]["optim_conf"].get(
         "start_timesteps_of_each_deferrable_load"
-    ]
-    def_end_timestep = input_data_dict["params"]["optim_conf"][
+    )
+    def_end_timestep = input_data_dict["params"]["optim_conf"].get(
         "end_timesteps_of_each_deferrable_load"
-    ]
+    )
     with stage_timer(input_data_dict["stage_times"], "optim_solve", logger):
         opt_res_naive_mpc = input_data_dict["opt"].perform_naive_mpc_optim(
             df_input_data_dayahead,

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -2524,6 +2524,11 @@ class Optimization:
         def_total_hours = pad_list(def_total_hours, num_deferrable_loads)
         def_start_timestep = pad_list(def_start_timestep, num_deferrable_loads)
         def_end_timestep = pad_list(def_end_timestep, num_deferrable_loads)
+        # Normalize any None elements to 0 (treat as "no time restriction").
+        # params.pkl can be corrupted by partial set-config calls that produce
+        # [None, 0] instead of [0, 0], causing TypeError in validate_def_timewindow.
+        def_start_timestep = [s if s is not None else 0 for s in def_start_timestep]
+        def_end_timestep = [e if e is not None else 0 for e in def_end_timestep]
 
         # Parameter Updates
         self.param_pv_forecast.value = p_pv

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -2365,7 +2365,13 @@ def check_def_loads(
         )
         for _x in range(len(parameter[parameter_name]), num_def_loads):
             parameter[parameter_name].append(default)
-    return parameter[parameter_name]
+    result = parameter[parameter_name]
+    # Replace any None elements with the default (can occur when set-config
+    # receives a partial config, e.g. [null, 0] instead of [0, 0]).
+    if isinstance(result, list):
+        result = [v if v is not None else default for v in result]
+        parameter[parameter_name] = result
+    return result
 
 
 def get_days_list(days_to_retrieve: int) -> pd.DatetimeIndex:


### PR DESCRIPTION
## Summary

Three targeted fixes for a `TypeError` crash in `naive_mpc_optim`, verified live on EMHASS 0.17.2 running as a standalone Docker container against Home Assistant.

---

### 1. `utils.py` — normalize `None` elements in `check_def_loads` (root cause fix)

When `/set-config` receives a partial config payload it can persist a list like `[null, 0]` for `start_timesteps_of_each_deferrable_load`. `check_def_loads` only pads a *short* list — it never replaces `None` values that are already inside the list. After this fix, any `None` element is replaced with the supplied `default` before the value is returned and re-saved.

### 2. `optimization.py` — defensive `None→0` after `pad_list` (second layer)

Adds a guard immediately after the `pad_list()` calls in `perform_optimization()` that replaces any residual `None` with `0` (= "no time restriction"). Protects installations whose `params.pkl` was already corrupted before fix 1 was applied.

Without fixes 1 & 2 the crash is:
```
TypeError: '<=' not supported between instances of 'NoneType' and 'int'
  File "emhass/optimization.py", in validate_def_timewindow
    if start <= end or start <= 0 or end <= 0:
```
Reproduces when `operating_hours_of_each_deferrable_load = [0, 0]` (both loads disabled) and `start_timesteps` contains a `None` element.

### 3. `command_line.py` — use `.get()` for timestep reads (KeyError prevention)

`def_start_timestep` and `def_end_timestep` were read from `optim_conf` using bare `[]` which raises `KeyError` if the key is absent. Changed to `.get()` — consistent with how `operating_hours_of_each_deferrable_load` and `operating_timesteps_of_each_deferrable_load` are already read in the same block.

---

## Reproduction (fixes 1–3)

1. Two deferrable loads (`num_def_loads = 2`).
2. POST to `/set-config` with `start_timesteps_of_each_deferrable_load: [null, 0]`.
3. `check_def_loads` sees `len == num_def_loads`, skips padding, returns `[None, 0]` unchanged.
4. `pad_list` in `perform_optimization` also skips (length already correct).
5. POST to `/action/naive-mpc-optim` with `operating_hours_of_each_deferrable_load: [0, 0]` → `validate_def_timewindow(None, 0, 0, n)` → **crash**.

## Testing

Verified on a live Home Assistant installation (EMHASS 0.17.2, Docker, InfluxDB retrieval):
- Reproduced the crash; confirmed `params.pkl` contained `[None, 0]` for `start_timesteps_of_each_deferrable_load`.
- Applied all three patches; subsequent MPC cycles with `operating_hours = [0, 0]` complete with `Status: Optimal`.
- No regression observed on cycles where `operating_hours > 0`.