### PR TITLE
fix: deduplicate DataFrame index before asfreq() in _apply_df_freq_horizon

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -736,6 +736,7 @@ def _apply_df_freq_horizon(
         step = retrieve_hass_conf["optimization_time_step"]
         if not isinstance(step, pd._libs.tslibs.timedeltas.Timedelta):
             step = pd.to_timedelta(step, "minute")
+        df = df[~df.index.duplicated(keep="last")]
         df = df.asfreq(step)
     else:
         df = utils.set_df_index_freq(df)


### PR DESCRIPTION
## Problem

`naive-mpc-optim` raises `ValueError: cannot reindex on an axis with duplicate labels` inside `_apply_df_freq_horizon` when `df.asfreq(step)` is called on the concatenated PV + load forecast DataFrame.

**Root cause:** `get_days_list(n)` spans two UTC calendar dates (due to timezone offsets), so InfluxDB returns roughly 2x the expected data points for a nominal "1 day" window. After the PV and load forecast Series are concatenated on `axis=1`, the resulting DatetimeIndex can contain duplicate timestamps, which causes `asfreq()` to fail.

**Traceback:**
```
File "src/emhass/command_line.py", line 737, in _apply_df_freq_horizon
    df = df.asfreq(step)
ValueError: cannot reindex on an axis with duplicate labels
```

## Fix

Deduplicate the index immediately before calling `asfreq`, using the same `~df.index.duplicated()` pattern already present in `set_df_index_freq()` and `prepare_data()` elsewhere in the codebase:

```python
# before
df = df.asfreq(step)

# after
df = df[~df.index.duplicated(keep="last")]
df = df.asfreq(step)
```

## Tested on

EMHASS 0.17.2, InfluxDB backend, 30-min optimization time step, `naive` load forecast method, `Australia/Sydney` timezone (UTC+10, no DST at time of testing).

## Summary by Sourcery

Bug Fixes:
- Prevent ValueError in _apply_df_freq_horizon by removing duplicate index entries before calling asfreq on forecast data.