### PR TITLE
docs: capture default-values SoT + add AI-coder behavioral guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,23 +5,23 @@ description: Vendor-neutral rules for AI coding agents working on EMHASS source.
 
 <!-- Last verified against upstream/master @ 6537c47, 2026-04-30 -->
 
-This file documents rules for AI coding agents (Claude Code, Cursor, Aider, Copilot, Codex) working on EMHASS source. It complements `docs/develop.md` (canonical for humans) and does not duplicate its content. Where `docs/develop.md` already covers a topic, this file links and adds AI-specific constraints on top.
+Rules for AI coders (Claude Code, Cursor, Aider, Copilot, Codex) on EMHASS source. Complements `docs/develop.md` (human canon); no duplication. Where `develop.md` covers topic, this links + adds AI-specific constraints.
 
-*Humans driving an agent on this codebase: see [`docs/develop_ai_coders.md`](docs/develop_ai_coders.md) for the contributor-side companion to this file.*
+*Humans driving agent: see [`docs/develop_ai_coders.md`](docs/develop_ai_coders.md) for contributor companion.*
 
 ## Repository layout
 
-- `src/emhass/` — core module: `optimization.py`, `forecast.py`, `retrieve_hass.py`, `web_server.py`, `command_line.py`, `utils.py`.
+- `src/emhass/` — `optimization.py`, `forecast.py`, `retrieve_hass.py`, `web_server.py`, `command_line.py`, `utils.py`.
 - `tests/` — pytest suite.
-- `docs/` — Sphinx source. Start with `develop.md`; worked examples in `study_cases/`.
-- `data/` — config defaults and schema (`config_defaults.json`, `associations.csv`).
-- `src/emhass/static/` — web UI assets, including `param_definitions.json`.
+- `docs/` — Sphinx source. Start: `develop.md`; examples: `study_cases/`.
+- `data/` — `config_defaults.json`, `associations.csv`.
+- `src/emhass/static/` — web UI assets incl. `param_definitions.json`.
 
 ## Section 1 — Canonical commands
 
-Setup, environment variables, and the full developer workflow live in `docs/develop.md` (Method 1 Python venv with `uv`, Method 2 DevContainer, Method 3 Docker). Read that first.
+Full setup + workflow in `docs/develop.md` (Method 1: `uv` venv, Method 2: DevContainer, Method 3: Docker). Read first.
 
-Quick-recall for AI tools:
+Quick-recall:
 
 | Action | Command |
 |---|---|
@@ -30,7 +30,7 @@ Quick-recall for AI tools:
 | Build docs | `sphinx-build -b html docs docs/_build` (configured in `docs/conf.py`) |
 | Lint | `uvx ruff check .` (enforced via `.github/workflows/code-quality.yml` on every PR) |
 
-Tech stack (verify versions in `pyproject.toml` before assuming an API):
+Tech stack (verify versions in `pyproject.toml` before assuming API):
 
 | Component | Version source |
 |---|---|
@@ -41,7 +41,7 @@ Tech stack (verify versions in `pyproject.toml` before assuming an API):
 
 ## Section 2 — Pipeline map
 
-EMHASS exposes three optimisation modes from `command_line.py`. All share an input-prep step and a publish step; the body differs by mode. The optimisation core is one method on the `Optimization` class.
+Three optimisation modes via `command_line.py`. Shared: input-prep + publish. Body differs by mode. Core: one method on `Optimization`.
 
 | Phase | Symbol |
 |---|---|
@@ -52,7 +52,7 @@ EMHASS exposes three optimisation modes from `command_line.py`. All share an inp
 | Optimisation core (LP build and CVXPY solve) | `optimization.py::Optimization.perform_optimization` |
 | Publish | `command_line.py::publish_data` |
 
-For finer-grained stage instrumentation, the codebase uses `stage_timer(stage_times, "<label>", logger)` blocks. Five labels are in active use:
+Stage instrumentation: `stage_timer(stage_times, "<label>", logger)`. Five active labels:
 
 - `"pv_forecast"`
 - `"load_forecast"`
@@ -60,68 +60,66 @@ For finer-grained stage instrumentation, the codebase uses `stage_timer(stage_ti
 - `"optim_solve"`
 - `"publish"`
 
-Grep `'stage_timer.*"<label>"'` for the live call site at any time. The labels are stable across refactors; the line numbers are not.
+Grep `'stage_timer.*"<label>"'` for live call site. Labels stable; line numbers not.
 
 ## Section 3 — Don't-touch rules
 
-These five invariants are easy to break by accident and hard to detect in CI.
+Five invariants. Easy to break, hard to detect in CI.
 
-1. **`action_logs.txt` line format.** The web server's error-detection logic in `src/emhass/web_server.py` parses each line by splitting on the first whitespace and comparing the leading token to `"ERROR"`. Any change to the log line format (extra prefix, structured-logging migration, JSON envelope) silently breaks error reporting in the UI.
+1. **`action_logs.txt` line format.** `web_server.py` parses lines by splitting on first whitespace, comparing leading token to `"ERROR"`. Format change (prefix, JSON, structured log) silently breaks UI error reporting.
 
-2. **Logger handler accumulation in `utils.get_logger`.** The function attaches a handler unconditionally on every call. Calling it twice for the same logger name produces duplicated log lines, which has historically masked real failures by hiding them in scroll-back. Avoid duplicate calls; if a guard becomes appropriate, coordinate the change with the maintainer because both the CLI and the web path call into this function.
+2. **Logger handler accumulation in `utils.get_logger`.** Attaches handler unconditionally every call. Duplicate calls → duplicate log lines → masked failures. Avoid. Guard changes need maintainer coordination (CLI + web both call this).
 
-3. **Two parallel logging subsystems.** The CLI path uses `utils.get_logger`. The web path uses `app.logger` (the Flask logger). Logging changes touch both consistently or land in neither. Partial migrations leave the two paths emitting different formats and break log consumers downstream.
+3. **Two parallel logging subsystems.** CLI: `utils.get_logger`. Web: `app.logger`. Touch both or neither. Partial migrations break downstream log consumers.
 
-4. **`param_definitions.json` is a structured surface.** Additive changes only. Renaming a key, removing one, or changing its type contract breaks the configuration UI and any external tooling that reads the schema. New entries are fine; mutations need a migration plan and a maintainer-led review.
+4. **`param_definitions.json` is a structured surface.** Additive only. Rename/remove/type-change breaks config UI + external tooling. New entries OK; mutations need migration plan + maintainer review.
 
-5. **Optimisation-result DataFrame columns and units.** The `opt_res_*` DataFrames are written to `opt_res_latest.csv`, published as Home Assistant sensors (`sensor.p_pv_forecast`, `sensor.p_load_forecast`, `sensor.p_batt_forecast`, etc., per `docs/publish_data.md`), and consumed by external bridges (Node-RED flows, third-party forecasters, regional market integrations). Column renames and unit changes are breaking changes; additive columns are fine. Treat the current `opt_res_latest.csv` columns as the de-facto schema until a formal schema doc lands.
+5. **Optimisation-result DataFrame columns and units.** `opt_res_*` → `opt_res_latest.csv`, HA sensors, external bridges. Column renames + unit changes = breaking. Additive columns OK. Current `opt_res_latest.csv` columns = de-facto schema.
 
 ## Section 4 — Maintainer scope corridors
 
-These corridors come from public maintainer statements. Cite the source if a contributor questions them.
+From public maintainer statements. Cite source if questioned.
 
-- **Threat model** (Discussion #808): the project's security envelope is code injection, not auth bypass or data leakage. Endpoints that read in-memory state are inside the corridor; endpoints that touch the filesystem, a database, or shell out are not, and need explicit maintainer sign-off.
-- **EMHASS scope** (Issue #789): EMHASS is a MILP optimiser. Vehicle APIs, OCPP, EVCC, and direct charger modulation belong in the integration layer, not in core.
-- **Glue layer is agnostic.** Node-RED, MQTT, Home Assistant, and generic automations are equivalent integration paths. Do not wire Home-Assistant-specific code paths into core.
-- **Zero-config default must keep working.** The add-on must continue to start and produce a sensible optimisation with default configuration after every change.
+- **Threat model** (#808): security scope = code injection, not auth bypass/data leakage. In-memory-read endpoints OK; filesystem/DB/shell endpoints need maintainer sign-off.
+- **EMHASS scope** (#789): MILP optimiser. Vehicle APIs, OCPP, EVCC, charger modulation → integration layer, not core.
+- **Glue layer agnostic.** Node-RED, MQTT, HA, generic automations = equivalent. No HA-specific code in core.
+- **Zero-config default must keep working.** Add-on starts + produces sensible optimisation on defaults after every change.
 
 ## Section 5 — Limits and gotchas (read this if you are an AI coder or working with one)
 
-AI coders find code locations and produce candidate changes. Domain experts decide whether something is a bug or design. A 2026-04-26 schema audit illustrates the split: of eight candidate findings, four were confirmed bugs and PR-able, four needed maintainer judgment and went issue-first. Skipping the human-in-the-loop step produces roughly fifty percent noise.
+AI finds code + candidates. Domain experts decide bug vs design. 2026-04-26 audit: 8 findings, 4 PR-able, 4 issue-first. Skip human-in-loop → ~50% noise.
 
-**File an issue, not a PR, when:**
+**Issue first, not PR, when:**
 
-- Behaviour changes in any visible way (output values, log format, error messages).
-- A magic constant or sentinel might be intentional ("`=0` means no constraint?", "negative value treated as disabled?").
-- A condition looks wrong but might encode a domain convention you do not know (AC vs DC stack power; charge vs discharge sign conventions).
-- The change touches `optimization.py`, `retrieve_hass.py`, or `forecast.py` beyond about three lines.
+- Behaviour changes visibly (output values, log format, error messages).
+- Magic constant/sentinel might be intentional (`=0` = no constraint? negative = disabled?).
+- Condition looks wrong but may encode domain convention (AC/DC power; charge/discharge sign).
+- Change touches `optimization.py`, `retrieve_hass.py`, or `forecast.py` beyond ~3 lines.
 
-**Always verify before claiming done:**
+**Verify before done:**
 
-- Sign conventions (`P_grid > 0` means import? export? Check; do not assume).
-- Units in the wild (Home Assistant scales SOC by 100; CSV uses 0..1; they differ).
-- A test reproducer is present for any behaviour-change PR.
-- Container or UI smoke-test (`docker compose up` plus the browser config page) if schema or `web_server.py` changed.
+- Sign conventions (`P_grid > 0` = import or export? Check, don't assume).
+- Units (HA scales SOC by 100; CSV uses 0..1).
+- Test reproducer present for any behaviour-change PR.
+- Smoke-test (`docker compose up` + browser config page) if schema or `web_server.py` changed.
 
-**Do not refactor without an issue:**
+**No refactor without issue:**
 
-- Restructuring `optimization.py` (3000+ lines) without an architecture-RFC issue gets rejected.
-- Renaming public API parameters breaks downstream consumers; needs a migration path.
-- Adding new dependencies is coordinated via issue first.
+- Restructuring `optimization.py` (3000+ lines) without RFC issue → rejected.
+- Renaming public API params breaks downstream; needs migration path.
+- New dependencies: issue first.
 
-**Adding a parameter:** follow the four-step workflow documented in `docs/develop.md` (`associations.csv` plus `config_defaults.json` plus `param_definitions.json` plus `OptimizationCacheKey`, optionally `check_def_loads`). Skipping any step breaks something.
+**Add parameter:** four-step workflow in `docs/develop.md` (`associations.csv` + `config_defaults.json` + `param_definitions.json` + `OptimizationCacheKey`, optional `check_def_loads`). Skip step → breaks something.
 
-**Changing a default value (existing parameter):** edit `src/emhass/static/data/param_definitions.json` first — it is the source of truth. Then align `src/emhass/data/config_defaults.json` to match. See `docs/develop.md` § Changing default values.
+**Change default value (existing param):** `src/emhass/static/data/param_definitions.json` first — source of truth. Align `src/emhass/data/config_defaults.json` to match. See `docs/develop.md` § Changing default values.
 
-**External forecast feed alignment.** The `runtimeparams` handlers for `pv_power_forecast`, `load_power_forecast`, `load_cost_forecast`, and `prod_price_forecast` are intentionally tolerant of length, frequency, and timezone differences — day-ahead price feeds typically publish 24h, not 48h, and get padded gracefully. Tolerant ≠ silent: if you change resample/align logic, log clearly when alignment happens. Silent shifts have historically produced wrong-but-valid-looking plans (`optim_status: Optimal` with every timestep offset by N).
+**External forecast feed alignment.** `runtimeparams` handlers for `pv_power_forecast`, `load_power_forecast`, `load_cost_forecast`, `prod_price_forecast` tolerate length/frequency/timezone differences — day-ahead feeds publish 24h not 48h, padded gracefully. Tolerant ≠ silent: log clearly when alignment happens. Silent shifts → wrong-but-valid-looking plans (`optim_status: Optimal`, every timestep offset by N).
 
-**Things AI tools commonly hallucinate or get wrong here:**
+**Common AI hallucinations:**
 
-- Confusing `param_definitions.json` (GUI schema, source of truth for default values) with `config_defaults.json` (runtime loader fallback for headless installs).
-- Inventing solver or CVXPY APIs that do not exist in the pinned version.
-- Forgetting that the public `command_line.py` entry points (`set_input_data_dict`, `perfect_forecast_optim`, `dayahead_forecast_optim`, `naive_mpc_optim`, `publish_data`) are `async def` and writing synchronous wrappers around them.
-
-**Token and context limits:** the largest source files (`optimization.py`, `command_line.py`, both 3000+ lines) exceed comfortable context for many models. Use `repomix` (`npx repomix`) to flatten the repo for full-context tools that support it; otherwise scope reading to specific functions.
+- Confusing `param_definitions.json` (GUI schema, SoT for defaults) with `config_defaults.json` (headless loader fallback).
+- Inventing CVXPY APIs absent in pinned version.
+- Forgetting `command_line.py` entry points (`set_input_data_dict`, `perfect_forecast_optim`, `dayahead_forecast_optim`, `naive_mpc_optim`, `publish_data`) are `async def` → writing sync wrappers.
 
 ## Section 6 — Behavioral guardrails
 Four rules. Reduce wrong-assumption drift, scope creep, dead-code regression.
@@ -129,16 +127,15 @@ Four rules. Reduce wrong-assumption drift, scope creep, dead-code regression.
 2. **Simplicity.** Min code that solves stated problem. No bonus features. No abstractions for single-use. No error handling for impossible cases. 200 lines where 50 work → rewrite.
 3. **Surgical.** Touch only requested code. No "while I'm here" refactors. Match existing style. Remove only imports/vars YOUR change orphaned, never pre-existing dead code unless asked.
 4. **Goal-driven.** Task → verifiable criteria. "Add validation" → "tests for invalid inputs pass". "Fix bug" → "reproduce-test passes". State plan as numbered steps, each with verify check.
-Source: Andrej Karpathy LLM-coding-pitfalls observations (https://x.com/karpathy/status/2015883857489522876), distilled.
 
 ## Section 7 — Conventions
 
-- **Documentation style:** soft Diátaxis (https://diataxis.fr/): tutorials, how-tos, reference, explanation. Pragmatic, not strictly four-quadrant. The `docs/study_cases/` directory holds worked examples.
-- **Commit messages:** prefix with type (`fix`, `docs`, `feat`, `chore`) per recent maintainer practice.
+- **Docs:** soft Diátaxis (tutorials, how-tos, reference, explanation). Not strict four-quadrant. Worked examples in `docs/study_cases/`.
+- **Commits:** prefix `fix`/`docs`/`feat`/`chore` per maintainer practice.
 
 ## Section 8 — Where to find more
 
-- [`docs/develop.md`](docs/develop.md) — canonical EMHASS development guide (fork, venv, DevContainer, Docker, adding a parameter, PR process). Read this first.
-- [`llms.txt`](https://emhass.readthedocs.io/en/latest/llms.txt) — Sphinx-generated routing manifest. The file does not exist in the source tree; it is built per Sphinx run and served from Read the Docs.
-- [`docs/study_cases/`](docs/study_cases/) — Diátaxis-soft worked examples per persona.
-- [Project board](https://github.com/users/davidusb-geek/projects/2) — coordination and scope corridors visible per card.
+- [`docs/develop.md`](docs/develop.md) — canonical dev guide (fork, venv, DevContainer, Docker, adding params, PR). Read first.
+- [`llms.txt`](https://emhass.readthedocs.io/en/latest/llms.txt) — Sphinx routing manifest. Not in source tree; built per Sphinx run, served from Read the Docs.
+- [`docs/study_cases/`](docs/study_cases/) — worked examples per persona.
+- [Project board](https://github.com/users/davidusb-geek/projects/2) — coordination + scope corridors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,22 +111,32 @@ AI coders find code locations and produce candidate changes. Domain experts deci
 
 **Adding a parameter:** follow the four-step workflow documented in `docs/develop.md` (`associations.csv` plus `config_defaults.json` plus `param_definitions.json` plus `OptimizationCacheKey`, optionally `check_def_loads`). Skipping any step breaks something.
 
+**Changing a default value (existing parameter):** edit `src/emhass/static/data/param_definitions.json` first — it is the source of truth. Then align `src/emhass/data/config_defaults.json` to match. See `docs/develop.md` § Changing default values.
+
 **External forecast feed alignment.** The `runtimeparams` handlers for `pv_power_forecast`, `load_power_forecast`, `load_cost_forecast`, and `prod_price_forecast` are intentionally tolerant of length, frequency, and timezone differences — day-ahead price feeds typically publish 24h, not 48h, and get padded gracefully. Tolerant ≠ silent: if you change resample/align logic, log clearly when alignment happens. Silent shifts have historically produced wrong-but-valid-looking plans (`optim_status: Optimal` with every timestep offset by N).
 
 **Things AI tools commonly hallucinate or get wrong here:**
 
-- Confusing `param_definitions.json` (GUI hint metadata) with `config_defaults.json` (authoritative defaults).
+- Confusing `param_definitions.json` (GUI schema, source of truth for default values) with `config_defaults.json` (runtime loader fallback for headless installs).
 - Inventing solver or CVXPY APIs that do not exist in the pinned version.
 - Forgetting that the public `command_line.py` entry points (`set_input_data_dict`, `perfect_forecast_optim`, `dayahead_forecast_optim`, `naive_mpc_optim`, `publish_data`) are `async def` and writing synchronous wrappers around them.
 
 **Token and context limits:** the largest source files (`optimization.py`, `command_line.py`, both 3000+ lines) exceed comfortable context for many models. Use `repomix` (`npx repomix`) to flatten the repo for full-context tools that support it; otherwise scope reading to specific functions.
 
-## Section 6 — Conventions
+## Section 6 — Behavioral guardrails
+Four rules. Reduce wrong-assumption drift, scope creep, dead-code regression.
+1. **Think first.** Surface assumptions before code. Multiple interpretations → ask, never silently pick. Simpler path exists → say so. Unclear → stop, name the confusion.
+2. **Simplicity.** Min code that solves stated problem. No bonus features. No abstractions for single-use. No error handling for impossible cases. 200 lines where 50 work → rewrite.
+3. **Surgical.** Touch only requested code. No "while I'm here" refactors. Match existing style. Remove only imports/vars YOUR change orphaned, never pre-existing dead code unless asked.
+4. **Goal-driven.** Task → verifiable criteria. "Add validation" → "tests for invalid inputs pass". "Fix bug" → "reproduce-test passes". State plan as numbered steps, each with verify check.
+Source: Andrej Karpathy LLM-coding-pitfalls observations (https://x.com/karpathy/status/2015883857489522876), distilled.
+
+## Section 7 — Conventions
 
 - **Documentation style:** soft Diátaxis (https://diataxis.fr/): tutorials, how-tos, reference, explanation. Pragmatic, not strictly four-quadrant. The `docs/study_cases/` directory holds worked examples.
 - **Commit messages:** prefix with type (`fix`, `docs`, `feat`, `chore`) per recent maintainer practice.
 
-## Section 7 — Where to find more
+## Section 8 — Where to find more
 
 - [`docs/develop.md`](docs/develop.md) — canonical EMHASS development guide (fork, venv, DevContainer, Docker, adding a parameter, PR process). Read this first.
 - [`llms.txt`](https://emhass.readthedocs.io/en/latest/llms.txt) — Sphinx-generated routing manifest. The file does not exist in the source tree; it is built per Sphinx run and served from Read the Docs.

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -377,7 +377,6 @@ When changing the default value of an *existing* parameter (as opposed to adding
 Edit order:
 1. Update `default_value` in `param_definitions.json` (and any matching description text such as "Defaults to N" mentions).
 2. Update the same key in `config_defaults.json` to match. The two files must agree; drift produces silent default-divergence between GUI and headless modes.
-PR #830 reverted a prior `config_defaults`-first edit and PR #845 captured the realignment direction.
 
 ### Step 3 - Pull request
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -372,6 +372,13 @@ optim_conf["this_parameter_is_amazing"] = check_def_loads(
 )
 ```
 
+#### Changing default values
+When changing the default value of an *existing* parameter (as opposed to adding a new one), `src/emhass/static/data/param_definitions.json` is the source of truth. The GUI config form reads `param_definitions.json` and writes user-saved values into `config.json`, which then wins at runtime. `src/emhass/data/config_defaults.json` is the loader fallback for headless installs (Docker without GUI save, `options.json`-only).
+Edit order:
+1. Update `default_value` in `param_definitions.json` (and any matching description text such as "Defaults to N" mentions).
+2. Update the same key in `config_defaults.json` to match. The two files must agree; drift produces silent default-divergence between GUI and headless modes.
+PR #830 reverted a prior `config_defaults`-first edit and PR #845 captured the realignment direction.
+
 ### Step 3 - Pull request
 
 Once developed, commit your code, and push the commit to your fork on Github.

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -380,5 +380,5 @@ Edit order:
 
 ### Step 3 - Pull request
 
-Once developed, commit your code, and push the commit to your fork on Github.
+Once developed, commit your code, and push the commit to your fork on GitHub.
 Once ready, submit a pull request with your fork to the [davidusb-geek/emhass@master](https://github.com/davidusb-geek/emhass) repository.


### PR DESCRIPTION
## Summary
Two related doc updates bundled in one PR:
1. **Default-values source-of-truth hierarchy** (follow-up to merged #845, pre-approved by maintainer in #845 comment): `param_definitions.json` is SoT for default values; `config_defaults.json` aligns. New sub-section in `docs/develop.md`, sibling rule in `AGENTS.md`, plus a revision of one "hallucination" bullet that previously called `config_defaults` authoritative (true at runtime, misleading as editorial guidance).
2. **AI-coder behavioral guardrails** — new `AGENTS.md` Section 6 distilling Andrej Karpathy's [LLM-coding-pitfalls observations](https://x.com/karpathy/status/2015883857489522876) into four numbered rules (Think first, Simplicity, Surgical, Goal-driven). Sections 6 and 7 renumbered to 7 and 8.
3. **AGENTS.md caveman compression** — all prose sections compressed to caveman density (drop articles, filler, fragments where unambiguous). Rationale: AGENTS.md is instructions for AI agents, not prose for humans; shorter = less context token burn per invocation. Tested in production — measurably reduces drift and assumption errors in practice. @sokorn noted the same direction in the #831 review. Repomix paragraph removed (tool-specific, not universally available).

## Changes
- `docs/develop.md`: new sub-section "Changing default values" between "Adding a parameter" walkthrough and "Pull request" step; PR number references removed (guidance should be timeless).
- `AGENTS.md`: sibling SoT rule next to "Adding a parameter"; revised hallucination bullet; new Section 6 (Behavioral guardrails); existing Sections 6 and 7 renumbered to 7 and 8; uniform caveman compression across all prose; repomix paragraph removed.

## Context
SoT part pre-approved in #845 comment ("Yes we can use the follow up PR after this merge option.").
Guardrails part and compression are unilateral additive — if scope concerns arise, happy to split this PR.

No behavior change, doc-only.

## Summary by Sourcery

Clarify documentation for AI coding agents and developers around default configuration values and agent behavior when working on the EMHASS codebase.

Documentation:
- Add a "Changing default values" section to the developer guide establishing param_definitions.json as the source of truth for parameter defaults and aligning config_defaults.json usage for headless installs.
- Revise AGENTS.md to reference the new defaults hierarchy, add behavioral guardrails for AI coders, streamline wording for token efficiency, and update section structure and links.