### PR TITLE
chore: add prek pre-commit hooks mirroring CI ruff checks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,6 +57,6 @@
 
 	"postStartCommand": ["apt-get", "install", "nodejs", "-y"],
 	"updateContentCommand": ["apt-get", "update" ],
-	"postCreateCommand": [ "uv", "pip", "install", ".[test]" ]
+	"postCreateCommand": "uv pip install .[test] && uv tool install prek && prek install"
 	  
 }

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ secrets_emhass.yaml
 .vscode/launch.json
 .vscode/settings.json
 .vscode/tasks.json
-.devcontainer/devcontainer.json
 *.pkl
 **/app
 .cache.sqlite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Pull requests are very much accepted on this project. For development, you can find some instructions here [Development](https://emhass.readthedocs.io/en/latest/develop.html).
 
+To wire up local pre-commit hooks that mirror CI linting (ruff check + ruff format), install [prek](https://prek.j178.dev/) and run `prek install` once in the repository root.
+
 For AI coding agents working on EMHASS source, see [`AGENTS.md`](AGENTS.md).
 
 Driving an AI coding agent on this codebase? See [`docs/develop_ai_coders.md`](docs/develop_ai_coders.md) for human-side guidance.

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,16 @@
+# prek.toml — local pre-commit hooks mirroring CI (code-quality.yml)
+# https://prek.j178.dev/
+#
+# Install once:  prek install
+# Run manually:  prek run --all-files
+
+[[repos]]
+repo = "https://github.com/astral-sh/ruff-pre-commit"
+rev = "v0.15.12"
+
+[[repos.hooks]]
+id = "ruff"
+args = ["--fix"]
+
+[[repos.hooks]]
+id = "ruff-format"


### PR DESCRIPTION
## Summary

Adds local pre-commit hooks via [prek](https://prek.j178.dev/) that mirror the ruff lint and format checks already enforced in CI (`.github/workflows/code-quality.yml`).

## Changes

- **`prek.toml`** — new config with two hooks from `astral-sh/ruff-pre-commit@v0.15.12`:
  - `ruff --fix` (mirrors `uvx ruff check` in CI, auto-fixes on commit)
  - `ruff-format` (mirrors `uvx ruff format` in CI, auto-formats on commit)
- **`.devcontainer/devcontainer.json`** — `postCreateCommand` extended to install prek via `uv tool install prek` and run `prek install` automatically when the devcontainer is built
- **`.gitignore`** — removed `.devcontainer/devcontainer.json` exclusion so the file is tracked
- **`CONTRIBUTING.md`** — one-line note pointing contributors to `prek install`

## Notes

- prek is a drop-in replacement for pre-commit, written in Rust, with no Python runtime dependency. It reads standard `.pre-commit-config.yaml` too, but `prek.toml` is the recommended native format.
- Hooks auto-fix and auto-format on commit; CI still enforces check-only — no CI changes needed.
- If upstream `pre-commit` compatibility is preferred over `prek.toml`, this can be converted to `.pre-commit-config.yaml` with `prek util yaml-to-toml` in reverse (the config content is identical).

## Summary by Sourcery

Add local prek-based pre-commit-style hooks to mirror existing CI ruff checks and integrate them into the development environment.

Enhancements:
- Introduce a prek configuration with ruff lint and format hooks aligned with CI checks.
- Ensure the devcontainer automatically installs prek and sets up hooks on creation.
- Start tracking the devcontainer configuration file in version control.

Documentation:
- Document how contributors can install and enable local prek hooks that mirror CI linting.

Chores:
- Adjust gitignore entries so that the devcontainer configuration is no longer excluded.