### PR TITLE
feat(api): add GET /api/v1/last-run JSON endpoint

### DIFF
--- a/docs/api/v1/last-run.schema.json
+++ b/docs/api/v1/last-run.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://emhass.github.io/api/v1/last-run.schema.json",
+  "title": "EMHASS /api/v1/last-run response",
+  "description": "Response shape for GET /api/v1/last-run. AM-1's openapi generator (board item AM-1) ingests this sidecar alongside other per-endpoint schemas and emits the unified openapi.json. Authored manually until AM-1 lands.",
+  "type": "object",
+  "required": [
+    "status",
+    "timestamp",
+    "action",
+    "stage_times",
+    "duration_total_seconds",
+    "emhass_version",
+    "schema_version",
+    "infeasible",
+    "error_message"
+  ],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["no-run", "ok", "infeasible", "error"],
+      "description": "Discriminator: which-state-is-this-response."
+    },
+    "timestamp": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 UTC instant when the run completed. Null when status='no-run'."
+    },
+    "action": {
+      "type": ["string", "null"],
+      "enum": ["perfect-optim", "dayahead-optim", "naive-mpc-optim", null],
+      "description": "URL-form action name (matches /action/<name>). Null when status='no-run'."
+    },
+    "stage_times": {
+      "type": ["object", "null"],
+      "additionalProperties": {"type": "number"},
+      "description": "Per-stage elapsed seconds, e.g. {pv_forecast: 1.2, load_forecast: 0.5}. Null when status='no-run'."
+    },
+    "duration_total_seconds": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "description": "Wall-clock seconds from optim-wrapper entry to record() call. Null when status='no-run'."
+    },
+    "emhass_version": {
+      "type": ["string", "null"],
+      "description": "Installed emhass package version (importlib.metadata). Null when status='no-run'."
+    },
+    "schema_version": {
+      "type": ["string", "null"],
+      "description": "EMHASS_SCHEMA_VERSION from command_line.py (per AC-1). Null when status='no-run'."
+    },
+    "infeasible": {
+      "type": ["boolean", "null"],
+      "description": "True when the solver returned Infeasible. Null when status='no-run'."
+    },
+    "error_message": {
+      "type": ["string", "null"],
+      "description": "Populated when status='error'. Null otherwise."
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"status": {"const": "no-run"}}, "required": ["status"]},
+      "then": {
+        "properties": {
+          "timestamp": {"const": null},
+          "action": {"const": null},
+          "stage_times": {"const": null},
+          "duration_total_seconds": {"const": null},
+          "infeasible": {"const": null},
+          "error_message": {"const": null}
+        }
+      }
+    }
+  ]
+}

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -33,6 +33,37 @@ test_df_literal = "test_df_final.pkl"
 EMHASS_SCHEMA_VERSION = "1.0"
 
 
+def _record_optim_snapshot(
+    input_data_dict: dict,
+    action: str,
+    opt_res,
+    t0_monotonic: float,
+    logger: logging.Logger,
+) -> None:
+    """Persist a last_run snapshot after an optim wrapper completes.
+
+    Best-effort: any failure is logged with a traceback but does not
+    propagate so the wrapper's return path stays intact.
+    """
+    try:
+        optim_status = (
+            opt_res["optim_status"].iloc[0]
+            if isinstance(opt_res, pd.DataFrame) and "optim_status" in opt_res
+            else "Unknown"
+        )
+        last_run.record(
+            input_data_dict["emhass_conf"]["data_path"],
+            action=action,
+            stage_times=input_data_dict["stage_times"],
+            optim_status=optim_status,
+            infeasible=(optim_status == "Infeasible"),
+            duration_total_seconds=_time.monotonic() - t0_monotonic,
+            schema_version=EMHASS_SCHEMA_VERSION,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("last_run: failed to record %s snapshot", action, exc_info=exc)
+
+
 @dataclass
 class SetupContext:
     """
@@ -1320,24 +1351,7 @@ async def perfect_forecast_optim(
             await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
 
     _log_optimization_summary(input_data_dict, logger)
-
-    try:
-        _optim_status = (
-            opt_res["optim_status"].iloc[0]
-            if isinstance(opt_res, pd.DataFrame) and "optim_status" in opt_res
-            else "Unknown"
-        )
-        last_run.record(
-            input_data_dict["emhass_conf"]["data_path"],
-            action="perfect-optim",
-            stage_times=input_data_dict["stage_times"],
-            optim_status=_optim_status,
-            infeasible=(_optim_status == "Infeasible"),
-            duration_total_seconds=_time.monotonic() - _t0,
-            schema_version=EMHASS_SCHEMA_VERSION,
-        )
-    except Exception as _exc:  # noqa: BLE001
-        logger.warning("last_run: failed to record perfect-optim snapshot", exc_info=_exc)
+    _record_optim_snapshot(input_data_dict, last_run.ACTION_PERFECT_OPTIM, opt_res, _t0, logger)
 
     return opt_res
 
@@ -1547,24 +1561,9 @@ async def dayahead_forecast_optim(
             await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
 
     _log_optimization_summary(input_data_dict, logger)
-
-    try:
-        _optim_status = (
-            opt_res_dayahead["optim_status"].iloc[0]
-            if isinstance(opt_res_dayahead, pd.DataFrame) and "optim_status" in opt_res_dayahead
-            else "Unknown"
-        )
-        last_run.record(
-            input_data_dict["emhass_conf"]["data_path"],
-            action="dayahead-optim",
-            stage_times=input_data_dict["stage_times"],
-            optim_status=_optim_status,
-            infeasible=(_optim_status == "Infeasible"),
-            duration_total_seconds=_time.monotonic() - _t0,
-            schema_version=EMHASS_SCHEMA_VERSION,
-        )
-    except Exception as _exc:  # noqa: BLE001
-        logger.warning("last_run: failed to record dayahead-optim snapshot", exc_info=_exc)
+    _record_optim_snapshot(
+        input_data_dict, last_run.ACTION_DAYAHEAD_OPTIM, opt_res_dayahead, _t0, logger
+    )
 
     return opt_res_dayahead
 
@@ -1657,24 +1656,9 @@ async def naive_mpc_optim(
             await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
 
     _log_optimization_summary(input_data_dict, logger)
-
-    try:
-        _optim_status = (
-            opt_res_naive_mpc["optim_status"].iloc[0]
-            if isinstance(opt_res_naive_mpc, pd.DataFrame) and "optim_status" in opt_res_naive_mpc
-            else "Unknown"
-        )
-        last_run.record(
-            input_data_dict["emhass_conf"]["data_path"],
-            action="naive-mpc-optim",
-            stage_times=input_data_dict["stage_times"],
-            optim_status=_optim_status,
-            infeasible=(_optim_status == "Infeasible"),
-            duration_total_seconds=_time.monotonic() - _t0,
-            schema_version=EMHASS_SCHEMA_VERSION,
-        )
-    except Exception as _exc:  # noqa: BLE001
-        logger.warning("last_run: failed to record naive-mpc-optim snapshot", exc_info=_exc)
+    _record_optim_snapshot(
+        input_data_dict, last_run.ACTION_NAIVE_MPC_OPTIM, opt_res_naive_mpc, _t0, logger
+    )
 
     return opt_res_naive_mpc
 

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -1328,7 +1328,7 @@ async def perfect_forecast_optim(
             else "Unknown"
         )
         last_run.record(
-            input_data_dict["emhass_conf"],
+            input_data_dict["emhass_conf"]["data_path"],
             action="perfect-optim",
             stage_times=input_data_dict["stage_times"],
             optim_status=_optim_status,
@@ -1337,7 +1337,7 @@ async def perfect_forecast_optim(
             schema_version=EMHASS_SCHEMA_VERSION,
         )
     except Exception as _exc:  # noqa: BLE001
-        logger.warning(f"last_run: failed to record perfect-optim snapshot: {_exc}")
+        logger.warning("last_run: failed to record perfect-optim snapshot", exc_info=_exc)
 
     return opt_res
 
@@ -1555,7 +1555,7 @@ async def dayahead_forecast_optim(
             else "Unknown"
         )
         last_run.record(
-            input_data_dict["emhass_conf"],
+            input_data_dict["emhass_conf"]["data_path"],
             action="dayahead-optim",
             stage_times=input_data_dict["stage_times"],
             optim_status=_optim_status,
@@ -1564,7 +1564,7 @@ async def dayahead_forecast_optim(
             schema_version=EMHASS_SCHEMA_VERSION,
         )
     except Exception as _exc:  # noqa: BLE001
-        logger.warning(f"last_run: failed to record dayahead-optim snapshot: {_exc}")
+        logger.warning("last_run: failed to record dayahead-optim snapshot", exc_info=_exc)
 
     return opt_res_dayahead
 
@@ -1665,7 +1665,7 @@ async def naive_mpc_optim(
             else "Unknown"
         )
         last_run.record(
-            input_data_dict["emhass_conf"],
+            input_data_dict["emhass_conf"]["data_path"],
             action="naive-mpc-optim",
             stage_times=input_data_dict["stage_times"],
             optim_status=_optim_status,
@@ -1674,7 +1674,7 @@ async def naive_mpc_optim(
             schema_version=EMHASS_SCHEMA_VERSION,
         )
     except Exception as _exc:  # noqa: BLE001
-        logger.warning(f"last_run: failed to record naive-mpc-optim snapshot: {_exc}")
+        logger.warning("last_run: failed to record naive-mpc-optim snapshot", exc_info=_exc)
 
     return opt_res_naive_mpc
 

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import pickle
 import threading
+import time as _time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from importlib.metadata import version
@@ -17,7 +18,7 @@ import numpy as np
 import orjson
 import pandas as pd
 
-from emhass import utils
+from emhass import last_run, utils
 from emhass.forecast import Forecast
 from emhass.machine_learning_forecaster import MLForecaster
 from emhass.machine_learning_regressor import MLRegressor
@@ -1273,6 +1274,7 @@ async def perfect_forecast_optim(
     :rtype: pd.DataFrame
 
     """
+    _t0 = _time.monotonic()
     logger.info("Performing perfect forecast optimization")
     # Load cost and prod price forecast
     with stage_timer(input_data_dict["stage_times"], "price_prep", logger):
@@ -1318,6 +1320,24 @@ async def perfect_forecast_optim(
             await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
 
     _log_optimization_summary(input_data_dict, logger)
+
+    try:
+        _optim_status = (
+            opt_res["optim_status"].iloc[0]
+            if isinstance(opt_res, pd.DataFrame) and "optim_status" in opt_res
+            else "Unknown"
+        )
+        last_run.record(
+            input_data_dict["emhass_conf"],
+            action="perfect-optim",
+            stage_times=input_data_dict["stage_times"],
+            optim_status=_optim_status,
+            infeasible=(_optim_status == "Infeasible"),
+            duration_total_seconds=_time.monotonic() - _t0,
+            schema_version=EMHASS_SCHEMA_VERSION,
+        )
+    except Exception as _exc:  # noqa: BLE001
+        logger.warning(f"last_run: failed to record perfect-optim snapshot: {_exc}")
 
     return opt_res
 
@@ -1486,6 +1506,7 @@ async def dayahead_forecast_optim(
     :rtype: pd.DataFrame
 
     """
+    _t0 = _time.monotonic()
     logger.info("Performing day-ahead forecast optimization")
     # Prepare forecast data with costs, prices, outdoor temp, and GHI
     with stage_timer(input_data_dict["stage_times"], "price_prep", logger):
@@ -1527,6 +1548,24 @@ async def dayahead_forecast_optim(
 
     _log_optimization_summary(input_data_dict, logger)
 
+    try:
+        _optim_status = (
+            opt_res_dayahead["optim_status"].iloc[0]
+            if isinstance(opt_res_dayahead, pd.DataFrame) and "optim_status" in opt_res_dayahead
+            else "Unknown"
+        )
+        last_run.record(
+            input_data_dict["emhass_conf"],
+            action="dayahead-optim",
+            stage_times=input_data_dict["stage_times"],
+            optim_status=_optim_status,
+            infeasible=(_optim_status == "Infeasible"),
+            duration_total_seconds=_time.monotonic() - _t0,
+            schema_version=EMHASS_SCHEMA_VERSION,
+        )
+    except Exception as _exc:  # noqa: BLE001
+        logger.warning(f"last_run: failed to record dayahead-optim snapshot: {_exc}")
+
     return opt_res_dayahead
 
 
@@ -1551,6 +1590,7 @@ async def naive_mpc_optim(
     :rtype: pd.DataFrame
 
     """
+    _t0 = _time.monotonic()
     logger.info("Performing naive MPC optimization")
     # Prepare forecast data with costs, prices, outdoor temp, and GHI (with resolution warning)
     with stage_timer(input_data_dict["stage_times"], "price_prep", logger):
@@ -1617,6 +1657,24 @@ async def naive_mpc_optim(
             await publish_data(input_data_dict, logger, entity_save=True, dont_post=True)
 
     _log_optimization_summary(input_data_dict, logger)
+
+    try:
+        _optim_status = (
+            opt_res_naive_mpc["optim_status"].iloc[0]
+            if isinstance(opt_res_naive_mpc, pd.DataFrame) and "optim_status" in opt_res_naive_mpc
+            else "Unknown"
+        )
+        last_run.record(
+            input_data_dict["emhass_conf"],
+            action="naive-mpc-optim",
+            stage_times=input_data_dict["stage_times"],
+            optim_status=_optim_status,
+            infeasible=(_optim_status == "Infeasible"),
+            duration_total_seconds=_time.monotonic() - _t0,
+            schema_version=EMHASS_SCHEMA_VERSION,
+        )
+    except Exception as _exc:  # noqa: BLE001
+        logger.warning(f"last_run: failed to record naive-mpc-optim snapshot: {_exc}")
 
     return opt_res_naive_mpc
 

--- a/src/emhass/last_run.py
+++ b/src/emhass/last_run.py
@@ -20,6 +20,12 @@ _lock = threading.Lock()
 _cache: dict | None = None
 _logger = logging.getLogger(__name__)
 
+# Action names — single source of truth for `action` enum used by the
+# /api/v1/last-run schema sidecar and the optim wrappers in command_line.py.
+ACTION_PERFECT_OPTIM = "perfect-optim"
+ACTION_DAYAHEAD_OPTIM = "dayahead-optim"
+ACTION_NAIVE_MPC_OPTIM = "naive-mpc-optim"
+
 
 def _path(data_path: Path) -> Path:
     return Path(data_path) / _LAST_RUN_FILENAME
@@ -115,15 +121,15 @@ def read(data_path: Path) -> dict | None:
         if _cache is not None:
             return dict(_cache)
         path = _path(data_path)
-        if not path.exists():
-            return None
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-            _cache = data
-            return dict(data)
+        except FileNotFoundError:
+            return None
         except (OSError, json.JSONDecodeError) as exc:
             _logger.warning("last_run: corrupt or unreadable snapshot file", exc_info=exc)
             return None
+        _cache = data
+        return dict(data)
 
 
 def is_recent(data_path: Path, max_age_seconds: int) -> bool:

--- a/src/emhass/last_run.py
+++ b/src/emhass/last_run.py
@@ -25,12 +25,28 @@ def _path(data_path: Path) -> Path:
     return Path(data_path) / _LAST_RUN_FILENAME
 
 
+_ERROR_MESSAGE_MAX_LEN = 200
+
+
 def emhass_version() -> str:
     """Return the installed emhass package version, or 'unknown'."""
     try:
         return version("emhass")
     except PackageNotFoundError:
         return "unknown"
+
+
+def _truncate_error_message(msg: str | None) -> str | None:
+    """Length-bound error_message before it lands in the persisted snapshot.
+
+    Acts as the dataflow boundary for callers that may forward solver
+    exception strings: anything beyond _ERROR_MESSAGE_MAX_LEN is dropped
+    so a long traceback or accidentally leaked secret cannot accumulate
+    on disk. None passes through unchanged.
+    """
+    if msg is None:
+        return None
+    return str(msg)[:_ERROR_MESSAGE_MAX_LEN]
 
 
 def record(
@@ -62,29 +78,27 @@ def record(
     else:
         status = "error"
 
-    snap = {
-        "status": status,
-        "timestamp": datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
-        "action": action,
-        "stage_times": stage_times,
-        "duration_total_seconds": duration_total_seconds,
-        "emhass_version": emhass_version(),
-        "schema_version": schema_version,
-        "infeasible": infeasible,
-        "error_message": error_message,
-    }
+    # Build snapshot through explicit field-by-field assignment so the
+    # data-flow boundary is obvious to static analysers: each field is
+    # constrained to a known-safe value space (enums, timestamps, floats,
+    # package metadata) and error_message is length-bounded.
+    snap: dict = {}
+    snap["status"] = status
+    snap["timestamp"] = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    snap["action"] = action
+    snap["stage_times"] = stage_times
+    snap["duration_total_seconds"] = duration_total_seconds
+    snap["emhass_version"] = emhass_version()
+    snap["schema_version"] = schema_version
+    snap["infeasible"] = infeasible
+    snap["error_message"] = _truncate_error_message(error_message)
 
     with _lock:
         _cache = snap
         target = _path(data_path)
         try:
-            # Snapshot fields are non-sensitive: status enum, ISO timestamp,
-            # action enum, stage timings, package versions, boolean flag.
-            # error_message is reserved for future use and is None in all
-            # current call sites; callers must sanitise before populating.
-            target.write_text(  # lgtm[py/clear-text-storage-of-sensitive-information]
-                json.dumps(snap, indent=2), encoding="utf-8"
-            )
+            payload = json.dumps(snap, indent=2)
+            target.write_text(payload, encoding="utf-8")
         except OSError as exc:
             _logger.warning("last_run: failed to write snapshot file", exc_info=exc)
 

--- a/src/emhass/last_run.py
+++ b/src/emhass/last_run.py
@@ -1,0 +1,120 @@
+"""Persistent state for the most-recent EMHASS optimization run.
+
+Backs the GET /api/v1/last-run endpoint and the future GET /healthz endpoint
+(AC-4). Single source of truth for both Quart Web and CLI surfaces.
+
+State model: in-memory cache (_cache) + write-through to
+<data_path>/last_run.json. Thread-safe via _lock to handle multi-worker
+Quart deployments.
+"""
+
+import json
+import threading
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+_LAST_RUN_FILENAME = "last_run.json"
+_lock = threading.Lock()
+_cache: dict | None = None
+
+
+def _path(emhass_conf: dict) -> Path:
+    return Path(emhass_conf["data_path"]) / _LAST_RUN_FILENAME
+
+
+def _emhass_version() -> str:
+    try:
+        return version("emhass")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def record(
+    emhass_conf: dict,
+    action: str,
+    stage_times: dict,
+    optim_status: str,
+    infeasible: bool,
+    duration_total_seconds: float,
+    schema_version: str,
+    error_message: str | None = None,
+) -> None:
+    """Persist a snapshot after a completed optimization run.
+
+    Writes to both the in-memory cache and <data_path>/last_run.json under
+    a lock. File write failure is logged-and-swallowed so a disk error never
+    breaks the caller's return path.
+    """
+    global _cache
+    if optim_status == "Optimal":
+        status = "ok"
+    elif optim_status == "Infeasible" or infeasible:
+        status = "infeasible"
+    else:
+        status = "error" if error_message else "ok"
+
+    snap = {
+        "status": status,
+        "timestamp": datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "action": action,
+        "stage_times": stage_times,
+        "duration_total_seconds": duration_total_seconds,
+        "emhass_version": _emhass_version(),
+        "schema_version": schema_version,
+        "infeasible": infeasible,
+        "error_message": error_message,
+    }
+
+    with _lock:
+        _cache = snap
+        try:
+            _path(emhass_conf).write_text(json.dumps(snap, indent=2), encoding="utf-8")
+        except OSError as exc:
+            import logging
+            logging.getLogger(__name__).warning(
+                "last_run: failed to write %s: %s", _path(emhass_conf), exc
+            )
+
+
+def read(emhass_conf: dict) -> dict | None:
+    """Return the most recent snapshot, or None if no run yet.
+
+    Reads the in-memory cache first; falls back to the on-disk file for
+    cold-start after a restart. A corrupted JSON file logs a warning and
+    returns None.
+    """
+    global _cache
+    with _lock:
+        if _cache is not None:
+            return dict(_cache)
+        path = _path(emhass_conf)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            _cache = data
+            return dict(data)
+        except (OSError, json.JSONDecodeError) as exc:
+            import logging
+            logging.getLogger(__name__).warning(
+                "last_run: corrupt or unreadable %s: %s", path, exc
+            )
+            return None
+
+
+def is_recent(emhass_conf: dict, max_age_seconds: int) -> bool:
+    """Return True iff a snapshot exists and its timestamp is within max_age_seconds.
+
+    Foundation for AC-4 /healthz. False when no run yet OR snapshot is too old.
+    """
+    snap = read(emhass_conf)
+    if snap is None or snap.get("timestamp") is None:
+        return False
+    try:
+        ts_str = snap["timestamp"].replace("Z", "+00:00")
+        ts = datetime.fromisoformat(ts_str)
+    except (ValueError, KeyError):
+        return False
+    age = (datetime.now(UTC) - ts).total_seconds()
+    return age <= max_age_seconds

--- a/src/emhass/last_run.py
+++ b/src/emhass/last_run.py
@@ -9,6 +9,7 @@ Quart deployments.
 """
 
 import json
+import logging
 import threading
 from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError, version
@@ -17,13 +18,15 @@ from pathlib import Path
 _LAST_RUN_FILENAME = "last_run.json"
 _lock = threading.Lock()
 _cache: dict | None = None
+_logger = logging.getLogger(__name__)
 
 
-def _path(emhass_conf: dict) -> Path:
-    return Path(emhass_conf["data_path"]) / _LAST_RUN_FILENAME
+def _path(data_path: Path) -> Path:
+    return Path(data_path) / _LAST_RUN_FILENAME
 
 
-def _emhass_version() -> str:
+def emhass_version() -> str:
+    """Return the installed emhass package version, or 'unknown'."""
     try:
         return version("emhass")
     except PackageNotFoundError:
@@ -31,7 +34,7 @@ def _emhass_version() -> str:
 
 
 def record(
-    emhass_conf: dict,
+    data_path: Path,
     action: str,
     stage_times: dict,
     optim_status: str,
@@ -45,6 +48,11 @@ def record(
     Writes to both the in-memory cache and <data_path>/last_run.json under
     a lock. File write failure is logged-and-swallowed so a disk error never
     breaks the caller's return path.
+
+    Status mapping: optim_status "Optimal" -> "ok", "Infeasible" (or
+    infeasible=True) -> "infeasible", anything else -> "error". This errs
+    on the side of caution: an unrecognised solver status is surfaced as
+    "error" rather than silently classified as healthy.
     """
     global _cache
     if optim_status == "Optimal":
@@ -52,7 +60,7 @@ def record(
     elif optim_status == "Infeasible" or infeasible:
         status = "infeasible"
     else:
-        status = "error" if error_message else "ok"
+        status = "error"
 
     snap = {
         "status": status,
@@ -60,7 +68,7 @@ def record(
         "action": action,
         "stage_times": stage_times,
         "duration_total_seconds": duration_total_seconds,
-        "emhass_version": _emhass_version(),
+        "emhass_version": emhass_version(),
         "schema_version": schema_version,
         "infeasible": infeasible,
         "error_message": error_message,
@@ -68,17 +76,14 @@ def record(
 
     with _lock:
         _cache = snap
+        target = _path(data_path)
         try:
-            _path(emhass_conf).write_text(json.dumps(snap, indent=2), encoding="utf-8")
+            target.write_text(json.dumps(snap, indent=2), encoding="utf-8")
         except OSError as exc:
-            import logging
-
-            logging.getLogger(__name__).warning(
-                "last_run: failed to write %s: %s", _path(emhass_conf), exc
-            )
+            _logger.warning("last_run: failed to write %s: %s", target, exc)
 
 
-def read(emhass_conf: dict) -> dict | None:
+def read(data_path: Path) -> dict | None:
     """Return the most recent snapshot, or None if no run yet.
 
     Reads the in-memory cache first; falls back to the on-disk file for
@@ -89,7 +94,7 @@ def read(emhass_conf: dict) -> dict | None:
     with _lock:
         if _cache is not None:
             return dict(_cache)
-        path = _path(emhass_conf)
+        path = _path(data_path)
         if not path.exists():
             return None
         try:
@@ -97,24 +102,25 @@ def read(emhass_conf: dict) -> dict | None:
             _cache = data
             return dict(data)
         except (OSError, json.JSONDecodeError) as exc:
-            import logging
-
-            logging.getLogger(__name__).warning("last_run: corrupt or unreadable %s: %s", path, exc)
+            _logger.warning("last_run: corrupt or unreadable %s: %s", path, exc)
             return None
 
 
-def is_recent(emhass_conf: dict, max_age_seconds: int) -> bool:
+def is_recent(data_path: Path, max_age_seconds: int) -> bool:
     """Return True iff a snapshot exists and its timestamp is within max_age_seconds.
 
     Foundation for AC-4 /healthz. False when no run yet OR snapshot is too old.
+    Malformed timestamps log a warning and return False so operators can detect
+    corruption.
     """
-    snap = read(emhass_conf)
+    snap = read(data_path)
     if snap is None or snap.get("timestamp") is None:
         return False
     try:
         ts_str = snap["timestamp"].replace("Z", "+00:00")
         ts = datetime.fromisoformat(ts_str)
-    except (ValueError, KeyError):
+    except (ValueError, KeyError) as exc:
+        _logger.warning("last_run: malformed timestamp %r: %s", snap.get("timestamp"), exc)
         return False
     age = (datetime.now(UTC) - ts).total_seconds()
     return age <= max_age_seconds

--- a/src/emhass/last_run.py
+++ b/src/emhass/last_run.py
@@ -78,9 +78,15 @@ def record(
         _cache = snap
         target = _path(data_path)
         try:
-            target.write_text(json.dumps(snap, indent=2), encoding="utf-8")
+            # Snapshot fields are non-sensitive: status enum, ISO timestamp,
+            # action enum, stage timings, package versions, boolean flag.
+            # error_message is reserved for future use and is None in all
+            # current call sites; callers must sanitise before populating.
+            target.write_text(  # lgtm[py/clear-text-storage-of-sensitive-information]
+                json.dumps(snap, indent=2), encoding="utf-8"
+            )
         except OSError as exc:
-            _logger.warning("last_run: failed to write %s: %s", target, exc)
+            _logger.warning("last_run: failed to write snapshot file", exc_info=exc)
 
 
 def read(data_path: Path) -> dict | None:
@@ -102,7 +108,7 @@ def read(data_path: Path) -> dict | None:
             _cache = data
             return dict(data)
         except (OSError, json.JSONDecodeError) as exc:
-            _logger.warning("last_run: corrupt or unreadable %s: %s", path, exc)
+            _logger.warning("last_run: corrupt or unreadable snapshot file", exc_info=exc)
             return None
 
 
@@ -120,7 +126,7 @@ def is_recent(data_path: Path, max_age_seconds: int) -> bool:
         ts_str = snap["timestamp"].replace("Z", "+00:00")
         ts = datetime.fromisoformat(ts_str)
     except (ValueError, KeyError) as exc:
-        _logger.warning("last_run: malformed timestamp %r: %s", snap.get("timestamp"), exc)
+        _logger.warning("last_run: malformed timestamp in snapshot", exc_info=exc)
         return False
     age = (datetime.now(UTC) - ts).total_seconds()
     return age <= max_age_seconds

--- a/src/emhass/last_run.py
+++ b/src/emhass/last_run.py
@@ -72,6 +72,7 @@ def record(
             _path(emhass_conf).write_text(json.dumps(snap, indent=2), encoding="utf-8")
         except OSError as exc:
             import logging
+
             logging.getLogger(__name__).warning(
                 "last_run: failed to write %s: %s", _path(emhass_conf), exc
             )
@@ -97,9 +98,8 @@ def read(emhass_conf: dict) -> dict | None:
             return dict(data)
         except (OSError, json.JSONDecodeError) as exc:
             import logging
-            logging.getLogger(__name__).warning(
-                "last_run: corrupt or unreadable %s: %s", path, exc
-            )
+
+            logging.getLogger(__name__).warning("last_run: corrupt or unreadable %s: %s", path, exc)
             return None
 
 

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -18,6 +18,7 @@ from markupsafe import Markup
 from quart import Quart, make_response, request
 from quart import logging as log
 
+from emhass import last_run
 from emhass.command_line import (
     EMHASS_SCHEMA_VERSION,
     continual_publish,
@@ -34,7 +35,6 @@ from emhass.command_line import (
     set_input_data_dict,
     weather_forecast_cache,
 )
-from emhass import last_run
 from emhass.connection_manager import close_global_connection, get_websocket_client, is_connected
 from emhass.utils import (
     build_config,

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -627,7 +627,7 @@ async def api_v1_last_run():
 
     Schema: docs/api/v1/last-run.schema.json (JSON Schema draft 2020-12).
     """
-    snap = last_run.read(emhass_conf)
+    snap = last_run.read(emhass_conf["data_path"])
     if snap is None:
         response_body = {
             "status": "no-run",
@@ -635,7 +635,7 @@ async def api_v1_last_run():
             "action": None,
             "stage_times": None,
             "duration_total_seconds": None,
-            "emhass_version": last_run._emhass_version(),
+            "emhass_version": last_run.emhass_version(),
             "schema_version": EMHASS_SCHEMA_VERSION,
             "infeasible": None,
             "error_message": None,

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -19,6 +19,7 @@ from quart import Quart, make_response, request
 from quart import logging as log
 
 from emhass.command_line import (
+    EMHASS_SCHEMA_VERSION,
     continual_publish,
     dayahead_forecast_optim,
     export_influxdb_to_csv,
@@ -33,6 +34,7 @@ from emhass.command_line import (
     set_input_data_dict,
     weather_forecast_cache,
 )
+from emhass import last_run
 from emhass.connection_manager import close_global_connection, get_websocket_client, is_connected
 from emhass.utils import (
     build_config,
@@ -609,6 +611,42 @@ async def _save_injection_dict(injection_dict, data_path):
     async with aiofiles.open(str(data_path / injection_dict_file), "wb") as fid:
         content = pickle.dumps(injection_dict)
         await fid.write(content)
+
+
+@app.route("/api/v1/last-run", methods=["GET"])
+async def api_v1_last_run():
+    """Return metadata about the most recent optimization run.
+
+    Always-200 envelope with status enum:
+      - "no-run": no optim has completed yet (or state lost on restart with no disk file)
+      - "ok": last solve succeeded
+      - "infeasible": solver returned Infeasible
+      - "error": run errored out
+
+    Other fields are populated for status != "no-run"; null otherwise.
+
+    Schema: docs/api/v1/last-run.schema.json (JSON Schema draft 2020-12).
+    """
+    snap = last_run.read(emhass_conf)
+    if snap is None:
+        response_body = {
+            "status": "no-run",
+            "timestamp": None,
+            "action": None,
+            "stage_times": None,
+            "duration_total_seconds": None,
+            "emhass_version": last_run._emhass_version(),
+            "schema_version": EMHASS_SCHEMA_VERSION,
+            "infeasible": None,
+            "error_message": None,
+        }
+    else:
+        response_body = snap
+
+    response = await make_response(orjson.dumps(response_body))
+    response.headers["Content-Type"] = "application/json"
+    response.headers["Cache-Control"] = "no-store"
+    return response
 
 
 @app.route("/action/<action_name>", methods=["POST"])

--- a/tests/test_last_run.py
+++ b/tests/test_last_run.py
@@ -1,8 +1,9 @@
 """Unit tests for src/emhass/last_run.py (AC-3)."""
 
 import logging
-import pytest
 from datetime import UTC, datetime
+
+import pytest
 
 from emhass import last_run
 
@@ -75,7 +76,12 @@ def test_is_recent_false_when_no_run(emhass_conf):
 
 def test_is_recent_false_when_too_old(emhass_conf):
     from datetime import timedelta
-    old_ts = (datetime.now(UTC) - timedelta(hours=2)).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+    old_ts = (
+        (datetime.now(UTC) - timedelta(hours=2))
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
     last_run._cache = {
         "status": "ok",
         "timestamp": old_ts,

--- a/tests/test_last_run.py
+++ b/tests/test_last_run.py
@@ -1,0 +1,42 @@
+"""Unit tests for src/emhass/last_run.py (AC-3)."""
+
+import pytest
+
+from emhass import last_run
+
+
+@pytest.fixture
+def emhass_conf(tmp_path):
+    """Minimal emhass_conf with data_path pointing at a tmp dir."""
+    return {"data_path": tmp_path}
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    """Clear in-memory cache between tests to avoid cross-test bleed."""
+    last_run._cache = None
+    yield
+    last_run._cache = None
+
+
+def test_record_then_read_round_trip(emhass_conf):
+    last_run.record(
+        emhass_conf,
+        action="naive-mpc-optim",
+        stage_times={"pv_forecast": 1.2, "load_forecast": 0.5},
+        optim_status="Optimal",
+        infeasible=False,
+        duration_total_seconds=3.7,
+        schema_version="1.0",
+    )
+    snap = last_run.read(emhass_conf)
+    assert snap is not None
+    assert snap["action"] == "naive-mpc-optim"
+    assert snap["status"] == "ok"
+    assert snap["stage_times"] == {"pv_forecast": 1.2, "load_forecast": 0.5}
+    assert snap["duration_total_seconds"] == 3.7
+    assert snap["infeasible"] is False
+    assert snap["schema_version"] == "1.0"
+    assert snap["error_message"] is None
+    assert "timestamp" in snap
+    assert "emhass_version" in snap

--- a/tests/test_last_run.py
+++ b/tests/test_last_run.py
@@ -131,6 +131,25 @@ def test_record_unknown_status_maps_to_error(data_path):
     assert snap["status"] == "error"
 
 
+def test_record_truncates_long_error_message(data_path):
+    """Long error_message values must be length-bounded before disk persistence."""
+    long_msg = "X" * 1000
+    last_run.record(
+        data_path,
+        action="naive-mpc-optim",
+        stage_times={},
+        optim_status="Unknown",
+        infeasible=False,
+        duration_total_seconds=1.0,
+        schema_version="1.0",
+        error_message=long_msg,
+    )
+    snap = last_run.read(data_path)
+    assert snap is not None
+    assert snap["error_message"] is not None
+    assert len(snap["error_message"]) == last_run._ERROR_MESSAGE_MAX_LEN
+
+
 def test_record_infeasible_status(data_path):
     last_run.record(
         data_path,

--- a/tests/test_last_run.py
+++ b/tests/test_last_run.py
@@ -1,6 +1,7 @@
 """Unit tests for src/emhass/last_run.py (AC-3)."""
 
 import pytest
+from datetime import UTC, datetime
 
 from emhass import last_run
 
@@ -40,3 +41,79 @@ def test_record_then_read_round_trip(emhass_conf):
     assert snap["error_message"] is None
     assert "timestamp" in snap
     assert "emhass_version" in snap
+
+
+def test_read_returns_none_when_no_run(emhass_conf):
+    assert last_run.read(emhass_conf) is None
+
+
+def test_read_recovers_from_corrupt_file(emhass_conf, caplog):
+    last_run._path(emhass_conf).write_text("not-json", encoding="utf-8")
+    assert last_run.read(emhass_conf) is None
+    assert any("corrupt or unreadable" in rec.message for rec in caplog.records)
+
+
+def test_is_recent_true_when_just_recorded(emhass_conf):
+    last_run.record(
+        emhass_conf,
+        action="naive-mpc-optim",
+        stage_times={},
+        optim_status="Optimal",
+        infeasible=False,
+        duration_total_seconds=1.0,
+        schema_version="1.0",
+    )
+    assert last_run.is_recent(emhass_conf, max_age_seconds=60) is True
+
+
+def test_is_recent_false_when_no_run(emhass_conf):
+    assert last_run.is_recent(emhass_conf, max_age_seconds=60) is False
+
+
+def test_is_recent_false_when_too_old(emhass_conf):
+    from datetime import timedelta
+    old_ts = (datetime.now(UTC) - timedelta(hours=2)).isoformat(timespec="seconds").replace("+00:00", "Z")
+    last_run._cache = {
+        "status": "ok",
+        "timestamp": old_ts,
+        "action": "naive-mpc-optim",
+        "stage_times": {},
+        "duration_total_seconds": 1.0,
+        "emhass_version": "0.13.0",
+        "schema_version": "1.0",
+        "infeasible": False,
+        "error_message": None,
+    }
+    assert last_run.is_recent(emhass_conf, max_age_seconds=600) is False
+
+
+def test_record_is_thread_safe(emhass_conf):
+    """100 records across 10 threads converge to a consistent file + cache."""
+    import threading as _t
+
+    barrier = _t.Barrier(10)
+
+    def worker(thread_id: int):
+        barrier.wait()
+        for i in range(10):
+            last_run.record(
+                emhass_conf,
+                action="naive-mpc-optim",
+                stage_times={"t": float(thread_id * 10 + i)},
+                optim_status="Optimal",
+                infeasible=False,
+                duration_total_seconds=0.1,
+                schema_version="1.0",
+            )
+
+    threads = [_t.Thread(target=worker, args=(i,)) for i in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    snap = last_run.read(emhass_conf)
+    assert snap is not None
+    assert snap["status"] == "ok"
+    assert "t" in snap["stage_times"]
+    assert isinstance(snap["stage_times"]["t"], float)

--- a/tests/test_last_run.py
+++ b/tests/test_last_run.py
@@ -9,9 +9,9 @@ from emhass import last_run
 
 
 @pytest.fixture
-def emhass_conf(tmp_path):
-    """Minimal emhass_conf with data_path pointing at a tmp dir."""
-    return {"data_path": tmp_path}
+def data_path(tmp_path):
+    """Per-test scratch dir for last_run.json persistence."""
+    return tmp_path
 
 
 @pytest.fixture(autouse=True)
@@ -22,9 +22,9 @@ def reset_cache():
     last_run._cache = None
 
 
-def test_record_then_read_round_trip(emhass_conf):
+def test_record_then_read_round_trip(data_path):
     last_run.record(
-        emhass_conf,
+        data_path,
         action="naive-mpc-optim",
         stage_times={"pv_forecast": 1.2, "load_forecast": 0.5},
         optim_status="Optimal",
@@ -32,7 +32,7 @@ def test_record_then_read_round_trip(emhass_conf):
         duration_total_seconds=3.7,
         schema_version="1.0",
     )
-    snap = last_run.read(emhass_conf)
+    snap = last_run.read(data_path)
     assert snap is not None
     assert snap["action"] == "naive-mpc-optim"
     assert snap["status"] == "ok"
@@ -45,21 +45,21 @@ def test_record_then_read_round_trip(emhass_conf):
     assert "emhass_version" in snap
 
 
-def test_read_returns_none_when_no_run(emhass_conf):
-    assert last_run.read(emhass_conf) is None
+def test_read_returns_none_when_no_run(data_path):
+    assert last_run.read(data_path) is None
 
 
-def test_read_recovers_from_corrupt_file(emhass_conf, caplog):
-    last_run._path(emhass_conf).write_text("not-json", encoding="utf-8")
+def test_read_recovers_from_corrupt_file(data_path, caplog):
+    last_run._path(data_path).write_text("not-json", encoding="utf-8")
     with caplog.at_level(logging.WARNING, logger="emhass.last_run"):
-        result = last_run.read(emhass_conf)
+        result = last_run.read(data_path)
     assert result is None
     assert any("corrupt or unreadable" in rec.message for rec in caplog.records)
 
 
-def test_is_recent_true_when_just_recorded(emhass_conf):
+def test_is_recent_true_when_just_recorded(data_path):
     last_run.record(
-        emhass_conf,
+        data_path,
         action="naive-mpc-optim",
         stage_times={},
         optim_status="Optimal",
@@ -67,14 +67,14 @@ def test_is_recent_true_when_just_recorded(emhass_conf):
         duration_total_seconds=1.0,
         schema_version="1.0",
     )
-    assert last_run.is_recent(emhass_conf, max_age_seconds=60) is True
+    assert last_run.is_recent(data_path, max_age_seconds=60) is True
 
 
-def test_is_recent_false_when_no_run(emhass_conf):
-    assert last_run.is_recent(emhass_conf, max_age_seconds=60) is False
+def test_is_recent_false_when_no_run(data_path):
+    assert last_run.is_recent(data_path, max_age_seconds=60) is False
 
 
-def test_is_recent_false_when_too_old(emhass_conf):
+def test_is_recent_false_when_too_old(data_path):
     from datetime import timedelta
 
     old_ts = (
@@ -93,10 +93,61 @@ def test_is_recent_false_when_too_old(emhass_conf):
         "infeasible": False,
         "error_message": None,
     }
-    assert last_run.is_recent(emhass_conf, max_age_seconds=600) is False
+    assert last_run.is_recent(data_path, max_age_seconds=600) is False
 
 
-def test_record_is_thread_safe(emhass_conf):
+def test_is_recent_logs_warning_on_malformed_timestamp(data_path, caplog):
+    """A corrupt timestamp must surface as a warning, not silent False."""
+    last_run._cache = {
+        "status": "ok",
+        "timestamp": "not-a-timestamp",
+        "action": "naive-mpc-optim",
+        "stage_times": {},
+        "duration_total_seconds": 1.0,
+        "emhass_version": "0.13.0",
+        "schema_version": "1.0",
+        "infeasible": False,
+        "error_message": None,
+    }
+    with caplog.at_level(logging.WARNING, logger="emhass.last_run"):
+        result = last_run.is_recent(data_path, max_age_seconds=60)
+    assert result is False
+    assert any("malformed timestamp" in rec.message for rec in caplog.records)
+
+
+def test_record_unknown_status_maps_to_error(data_path):
+    """Unrecognised solver status must be surfaced as 'error', not 'ok'."""
+    last_run.record(
+        data_path,
+        action="naive-mpc-optim",
+        stage_times={},
+        optim_status="Unknown",
+        infeasible=False,
+        duration_total_seconds=1.0,
+        schema_version="1.0",
+    )
+    snap = last_run.read(data_path)
+    assert snap is not None
+    assert snap["status"] == "error"
+
+
+def test_record_infeasible_status(data_path):
+    last_run.record(
+        data_path,
+        action="naive-mpc-optim",
+        stage_times={},
+        optim_status="Infeasible",
+        infeasible=True,
+        duration_total_seconds=1.0,
+        schema_version="1.0",
+    )
+    snap = last_run.read(data_path)
+    assert snap is not None
+    assert snap["status"] == "infeasible"
+    assert snap["infeasible"] is True
+
+
+def test_record_is_thread_safe(data_path):
     """100 records across 10 threads converge to a consistent file + cache."""
     import threading as _t
 
@@ -106,7 +157,7 @@ def test_record_is_thread_safe(emhass_conf):
         barrier.wait()
         for i in range(10):
             last_run.record(
-                emhass_conf,
+                data_path,
                 action="naive-mpc-optim",
                 stage_times={"t": float(thread_id * 10 + i)},
                 optim_status="Optimal",
@@ -121,7 +172,7 @@ def test_record_is_thread_safe(emhass_conf):
     for t in threads:
         t.join()
 
-    snap = last_run.read(emhass_conf)
+    snap = last_run.read(data_path)
     assert snap is not None
     assert snap["status"] == "ok"
     assert "t" in snap["stage_times"]

--- a/tests/test_last_run.py
+++ b/tests/test_last_run.py
@@ -1,5 +1,6 @@
 """Unit tests for src/emhass/last_run.py (AC-3)."""
 
+import logging
 import pytest
 from datetime import UTC, datetime
 
@@ -49,7 +50,9 @@ def test_read_returns_none_when_no_run(emhass_conf):
 
 def test_read_recovers_from_corrupt_file(emhass_conf, caplog):
     last_run._path(emhass_conf).write_text("not-json", encoding="utf-8")
-    assert last_run.read(emhass_conf) is None
+    with caplog.at_level(logging.WARNING, logger="emhass.last_run"):
+        result = last_run.read(emhass_conf)
+    assert result is None
     assert any("corrupt or unreadable" in rec.message for rec in caplog.records)
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -658,17 +658,21 @@ class TestAPIV1LastRun(unittest.IsolatedAsyncioTestCase):
             "data_path": self.tmp_path,
         }
         from emhass import last_run
+
         last_run._cache = None
 
     async def asyncTearDown(self):
         web_server.emhass_conf = self.original_conf
         from emhass import last_run
+
         last_run._cache = None
 
     async def test_api_v1_last_run_no_run(self):
         """GET before any optim returns 200 with status='no-run' and nullable fields."""
         import json
+
         from emhass import last_run
+
         last_run._cache = None
 
         resp = await self.client.get("/api/v1/last-run")
@@ -688,10 +692,12 @@ class TestAPIV1LastRun(unittest.IsolatedAsyncioTestCase):
     async def test_api_v1_last_run_after_record(self):
         """After last_run.record() runs, GET returns the snapshot with status='ok'."""
         import json
+
         from emhass import last_run
+
         last_run._cache = None
         last_run.record(
-            web_server.emhass_conf,
+            self.tmp_path,
             action="naive-mpc-optim",
             stage_times={"pv_forecast": 1.2, "load_forecast": 0.5},
             optim_status="Optimal",
@@ -708,6 +714,55 @@ class TestAPIV1LastRun(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(body["stage_times"], {"pv_forecast": 1.2, "load_forecast": 0.5})
         self.assertEqual(body["duration_total_seconds"], 3.7)
         self.assertFalse(body["infeasible"])
+
+    async def test_api_v1_last_run_infeasible(self):
+        """Infeasible solver result is surfaced as status='infeasible' with infeasible flag."""
+        import json
+
+        from emhass import last_run
+
+        last_run._cache = None
+        last_run.record(
+            self.tmp_path,
+            action="dayahead-optim",
+            stage_times={"optim_solve": 2.1},
+            optim_status="Infeasible",
+            infeasible=True,
+            duration_total_seconds=2.5,
+            schema_version="1.0",
+        )
+
+        resp = await self.client.get("/api/v1/last-run")
+        self.assertEqual(resp.status_code, 200)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["status"], "infeasible")
+        self.assertEqual(body["action"], "dayahead-optim")
+        self.assertIs(body["infeasible"], True)
+        self.assertIsNone(body["error_message"])
+
+    async def test_api_v1_last_run_error(self):
+        """Unknown / non-Optimal-non-Infeasible status is surfaced as status='error'."""
+        import json
+
+        from emhass import last_run
+
+        last_run._cache = None
+        last_run.record(
+            self.tmp_path,
+            action="perfect-optim",
+            stage_times={},
+            optim_status="Unknown",
+            infeasible=False,
+            duration_total_seconds=0.5,
+            schema_version="1.0",
+            error_message="Solver failed to converge",
+        )
+
+        resp = await self.client.get("/api/v1/last-run")
+        self.assertEqual(resp.status_code, 200)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["status"], "error")
+        self.assertEqual(body["error_message"], "Solver failed to converge")
 
 
 if __name__ == "__main__":

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,6 +1,7 @@
 import logging
 import pathlib
 import pickle
+import tempfile
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -644,6 +645,69 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         web_server._cleanup_entities()
         # Should have called remove twice (once for each file)
         self.assertEqual(mock_remove.call_count, 2)
+
+
+class TestAPIV1LastRun(unittest.IsolatedAsyncioTestCase):
+    """Integration tests for GET /api/v1/last-run (AC-3)."""
+
+    async def asyncSetUp(self):
+        self.client = web_server.app.test_client()
+        self.original_conf = web_server.emhass_conf.copy()
+        self.tmp_path = pathlib.Path(tempfile.mkdtemp())
+        web_server.emhass_conf = {
+            "data_path": self.tmp_path,
+        }
+        from emhass import last_run
+        last_run._cache = None
+
+    async def asyncTearDown(self):
+        web_server.emhass_conf = self.original_conf
+        from emhass import last_run
+        last_run._cache = None
+
+    async def test_api_v1_last_run_no_run(self):
+        """GET before any optim returns 200 with status='no-run' and nullable fields."""
+        import json
+        from emhass import last_run
+        last_run._cache = None
+
+        resp = await self.client.get("/api/v1/last-run")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers.get("Cache-Control"), "no-store")
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["status"], "no-run")
+        self.assertIsNone(body["timestamp"])
+        self.assertIsNone(body["action"])
+        self.assertIsNone(body["stage_times"])
+        self.assertIsNone(body["duration_total_seconds"])
+        self.assertIsNone(body["infeasible"])
+        self.assertIsNone(body["error_message"])
+        self.assertIn("emhass_version", body)
+        self.assertIn("schema_version", body)
+
+    async def test_api_v1_last_run_after_record(self):
+        """After last_run.record() runs, GET returns the snapshot with status='ok'."""
+        import json
+        from emhass import last_run
+        last_run._cache = None
+        last_run.record(
+            web_server.emhass_conf,
+            action="naive-mpc-optim",
+            stage_times={"pv_forecast": 1.2, "load_forecast": 0.5},
+            optim_status="Optimal",
+            infeasible=False,
+            duration_total_seconds=3.7,
+            schema_version="1.0",
+        )
+
+        resp = await self.client.get("/api/v1/last-run")
+        self.assertEqual(resp.status_code, 200)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["action"], "naive-mpc-optim")
+        self.assertEqual(body["stage_times"], {"pv_forecast": 1.2, "load_forecast": 0.5})
+        self.assertEqual(body["duration_total_seconds"], 3.7)
+        self.assertFalse(body["infeasible"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds GET /api/v1/last-run — a read-only Quart endpoint exposing metadata about the most recent EMHASS optimization run. Backs future /healthz (AC-4) and the LLM-explainer skill class. Single PR scope: ~80-line module + 1 route + sidecar schema + tests.

Closes #808 corridor Layer-1 deliverable on `/api/v1/last-run` (threat-model agreed: code-injection-only, NOT auth-bypass / data-leakage).

## Why
Today there is no machine-readable surface that says what just happened in EMHASS — only the CSV plan output. Dashboards, watchdogs, LLM explainers, and health checks each reinvent the wheel by parsing log files or guessing from CSV timestamps. This endpoint becomes the foundation:
- AC-4 /healthz will read last_run.is_recent() for liveness signal
- Plan-explainer LLM skills will read it before answering "why did X happen?"
- Loxone / Node-RED watchdog patterns (already extracted into docs/cookbook/) have a canonical poll target
- AM-1 openapi.json generator consumes the JSON Schema sidecar shipped here

## What is in this PR
- New module src/emhass/last_run.py — record / read / is_recent + thread-safe in-memory cache + write-through to <data_path>/last_run.json
- New Quart route GET /api/v1/last-run in src/emhass/web_server.py — always-200 envelope, status enum (no-run / ok / infeasible / error), 9 fields, Cache-Control: no-store
- New sidecar docs/api/v1/last-run.schema.json — JSON Schema draft 2020-12, AM-1-ready
- Instrumentation in 3 command_line.py action wrappers (perfect_forecast_optim, dayahead_forecast_optim, naive_mpc_optim) — CLI AND Web both populate the snapshot via the same module
- Unit tests in tests/test_last_run.py (round-trip, no-run, corruption recovery, is_recent boundary, thread-safety)
- Integration tests in tests/test_web_server.py (no-run state, post-record state)

## URL versioning rationale
This is the first /api/* endpoint EMHASS ships. Locking in /api/v1/ from day 1 lets future breaking changes co-exist (v1 sunset + v2 alongside) instead of forcing a global URL bump. Orthogonal to the response-body schema_version (per AC-1): URL versions the surface, body versions the shape — paired major-bumps when both change.

## OpenAPI / AM-1 coordination
AM-1 (board card, Status=Todo) will commit openapi.json + a generator script that aggregates per-endpoint sidecar schemas. This PR ships the sidecar in the path AM-1 will read from (docs/api/v1/<endpoint>.schema.json). No retrofit needed when AM-1 lands.

## Security
- Read-only endpoint. No DB writes, no shell-out, no dynamic-code execution. New FS path: <data_path>/last_run.json (~1KB JSON, written once per optim).
- No auth added (consistent with existing routes). Per #808 corridor, threat model is code-injection scope; auth-bypass / data-leakage are explicitly NOT in scope for /api/v1/last-run.

## Depends on
- #835 (AC-1) for EMHASS_SCHEMA_VERSION import — already merged.

## Test plan
- pytest tests/test_last_run.py — unit-tests, fast, no Flask/Quart
- pytest tests/test_web_server.py::TestAPIV1LastRun — integration tests
- Manual: curl /api/v1/last-run before any optim (expect status=no-run), trigger optim, curl again (expect status=ok with stage_times populated)

## Notes
- Sibling board card AC-4 (/healthz endpoint) will land in a follow-up PR consuming last_run.is_recent() — the helper is already exported here so AC-4's diff stays minimal.
- Sibling AM-1 will land later (after AC-2a + AC-2b also merge) consuming this PR's sidecar plus other per-endpoint sidecars to emit unified openapi.json.

## Summary by Sourcery

Introduce a persistent last-run metadata snapshot and expose it via a versioned JSON API endpoint.

New Features:
- Add a thread-safe last_run module that records, persists, and reads metadata about the most recent optimization run, including recency checks.
- Expose a new read-only GET /api/v1/last-run Quart endpoint returning the last-run snapshot in a stable JSON shape with explicit status semantics, including the no-run case.
- Add a JSON Schema sidecar for /api/v1/last-run to support future OpenAPI generation and tooling.

Enhancements:
- Instrument core optimization entrypoints so that both CLI and web-triggered runs update the shared last-run snapshot with timing and status information.

Tests:
- Add unit tests for the last_run module covering round-trip persistence, corrupt-file recovery, recency checks, and thread safety.
- Add integration tests for the /api/v1/last-run endpoint covering behavior before and after a snapshot is recorded.