### PR TITLE
fix: handle EOFError when reading pickle cache in web dashboard routes

### DIFF
--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -188,7 +188,14 @@ async def index():
     if (emhass_conf["data_path"] / injection_dict_file).exists():
         async with aiofiles.open(str(emhass_conf["data_path"] / injection_dict_file), "rb") as fid:
             content = await fid.read()
-            injection_dict = pickle.loads(content)
+            try:
+                injection_dict = pickle.loads(content)
+            except EOFError:
+                app.logger.warning(
+                    "The data container file is empty or incomplete (possible write race condition). "
+                    "Please launch an optimization task."
+                )
+                injection_dict = {}
     else:
         app.logger.info(
             "The data container dictionary is empty... Please launch an optimization task"
@@ -279,7 +286,14 @@ async def template_action():
     if (emhass_conf["data_path"] / injection_dict_file).exists():
         async with aiofiles.open(str(emhass_conf["data_path"] / injection_dict_file), "rb") as fid:
             content = await fid.read()
-            injection_dict = pickle.loads(content)
+            try:
+                injection_dict = pickle.loads(content)
+            except EOFError:
+                app.logger.warning(
+                    "The data container file is empty or incomplete (possible write race condition). "
+                    "Please launch an optimization task."
+                )
+                injection_dict = {}
     else:
         app.logger.warning("Unable to obtain plot data from {injection_dict_file}")
         app.logger.warning("Try running an launch an optimization task")


### PR DESCRIPTION
## Problem

When an optimization completes and the result pickle file (`injection_dict_file`) is being written, a concurrent `GET /` or `GET /template` request can open and read the file while it is still empty or only partially written. `pickle.loads()` raises `EOFError` in that case, causing the request to fail with a 500 error:

```
ERROR in app: Exception on request GET /
Traceback (most recent call last):
  ...
  File "/app/src/emhass/web_server.py", line 191, in index
    injection_dict = pickle.loads(content)
EOFError: Ran out of input
```

## Fix

Wrap both `pickle.loads(content)` calls in the `index` and `template` routes with `try/except EOFError`, falling back to an empty `injection_dict` — the same behaviour already used when the file does not exist at all. A warning is logged so the transient condition is still visible.

## Notes

- The optimization itself is unaffected; only the dashboard render fails
- Recovery is automatic on the next page load once the file is fully written
- A more robust long-term fix could use an atomic write (write to a temp file then rename), but this patch is minimal and safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent dashboard routes from returning 500 errors when the pickle cache file is read while empty or partially written by treating EOFError as a missing cache and falling back to an empty dictionary.