### PR TITLE
fix(test): pin load_forecast_method in test_load_deactivation_zero_operating_timesteps (#856)

### DIFF
--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -3977,6 +3977,7 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
                 "set_use_battery": True,
                 "treat_deferrable_load_as_semi_cont": [True, True],
                 "set_deferrable_load_single_constant": [True, True],
+                "load_forecast_method": "naive",  # pin: test asserts against naive load-curve; default may shift, see #856
             }
         )
         self.opt = self.create_optimization()


### PR DESCRIPTION
## Summary

Fixes #856.

Pins `load_forecast_method = "naive"` in the test fixture for `test_load_deactivation_zero_operating_timesteps`, decoupling the assertion from `config_defaults.json` default-drift. The bisect on #856 traced the regression to merged PR #845 (config-defaults Option-B alignment), and isolation showed that the single root cause is `load_forecast_method: "naive" → "typical"`. The test was inheriting the default at test-time. Pinning is preferable to updating the expected value to 5, because the test then survives any future default re-tune in either direction.

See #856 for the bisect output, root-cause isolation steps, and full mechanism write-up.

## Changes

`tests/test_optimization.py`: one-line addition to `optim_conf.update({...})` in `test_load_deactivation_zero_operating_timesteps`.

## Notes

Gate 0 (simplify pre-PR quality pass) N/A for 1-line test-fixture pin.

The `inverter_ac_output_max: 5000 → 0` and `inverter_ac_input_max: 5000 → 0` changes in #845 also look problematic per `optimization.py:1031-1080` (`0` constrains hybrid inverter to zero AC throughput, the `None` fallback to inverter-model lookup never fires). Not the cause of this test failure but worth a separate look; mentioned in the #856 side-note.

No behaviour change for production code. Doc-comment in the test points the next reader at #856 for context.

## Summary by Sourcery

Tests:
- Pin `load_forecast_method` to `"naive"` in `test_load_deactivation_zero_operating_timesteps` so the test remains stable when configuration defaults change.