### PR TITLE
feat: constant-efficiency mode for thermal_battery (gas / oil / district)

### DIFF
--- a/docs/thermal_battery.md
+++ b/docs/thermal_battery.md
@@ -68,6 +68,22 @@ These parameters define the basic thermal battery system:
     * Example: `0.42`
     * See the calibration section below for how to determine this
 
+### Constant-efficiency mode (gas boiler, oil burner, district heating)
+
+The default thermal battery model uses a Carnot-based COP that varies with outdoor temperature - appropriate for heat pumps. Non-electric heat sources (gas boilers, oil burners, district heating) convert input power to heat at a roughly constant efficiency that does not depend on outdoor temperature. For these sources, set the `efficiency` parameter:
+
+* **efficiency**: Optional constant energy-conversion factor (output thermal kW / input kW). When set, EMHASS skips the Carnot COP calculation and uses this flat value for every timestep. `supply_temperature` and `carnot_efficiency` become optional in this mode.
+    * Typical values:
+        * Modern condensing gas boiler: 0.90-0.95
+        * Standard gas boiler: 0.85-0.90
+        * Oil burner: 0.80-0.90
+        * District heating substation: 0.95-0.98
+        * Direct electric heater: 1.0
+    * Example: `0.9` for a condensing gas boiler
+    * When both `efficiency` and heat-pump fields are present, `efficiency` takes precedence.
+
+Configure one `thermal_battery` per source-target pair to model hybrid systems. For example, a gas boiler serving both a heating buffer and a DHW tank is two `def_load_config` entries (one per target), grouped via `deferrable_load_groups` with `mutual_exclusion: true` and `max_power` equal to the boiler's modulating maximum if the two targets share the same physical actuator.
+
 ### Heating demand calculation
 
 EMHASS needs to know how much heat your building requires. There are two methods to calculate this, and EMHASS automatically selects the appropriate method based on which parameters you provide.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ emhass = { workspace = true }
 [tool.uv]
 default-groups = "all"
 package = true
-override-dependencies = ["yarl!=1.24.1"]
+override-dependencies = ["yarl<1.24"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/emhass"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ emhass = { workspace = true }
 [tool.uv]
 default-groups = "all"
 package = true
+override-dependencies = ["yarl!=1.24.1"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/emhass"]

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -571,19 +571,17 @@ class Optimization:
                     )
 
                 # Compute derived arrays
-                supply_temperature = hc["supply_temperature"]
                 indoor_target_temp = hc.get(
                     "indoor_target_temperature",
                     min_temps[0] if min_temps else 20.0,
                 )
 
-                # Heatpump COPs
-                heatpump_cops = utils.calculate_cop_heatpump(
-                    supply_temperature=supply_temperature,
-                    carnot_efficiency=hc.get("carnot_efficiency", 0.4),
-                    outdoor_temperature_forecast=outdoor_temp.tolist(),
+                # Conversion factors per timestep (Carnot COP for heat pumps,
+                # flat value for constant-efficiency sources like gas boilers).
+                heatpump_cops = utils.resolve_thermal_battery_cop(
+                    hc, outdoor_temp, length=n
                 )
-                params["heatpump_cops"].value = np.array(heatpump_cops[:n])
+                params["heatpump_cops"].value = np.array(heatpump_cops)
 
                 # Thermal losses and heating demand
                 base_loss = hc.get("thermal_loss", 0.045)
@@ -1519,8 +1517,9 @@ class Optimization:
         hc = def_load_config["thermal_battery"]
         required_len = self.num_timesteps
 
-        # Structural parameters (don't change between MPC iterations)
-        supply_temperature = hc["supply_temperature"]
+        # Structural parameters (don't change between MPC iterations).
+        # supply_temperature / efficiency requirement is validated by
+        # resolve_thermal_battery_cop further down (single source of truth).
         volume = hc["volume"]
         min_temperatures_list = hc["min_temperatures"]
         max_temperatures_list = hc["max_temperatures"]
@@ -1556,12 +1555,10 @@ class Optimization:
             start_temp_float = float(params["start_temp"].value)
 
             # Compute and set derived parameter values
-            cops = utils.calculate_cop_heatpump(
-                supply_temperature=supply_temperature,
-                carnot_efficiency=hc.get("carnot_efficiency", 0.4),
-                outdoor_temperature_forecast=outdoor_temp_arr.tolist(),
+            cops = utils.resolve_thermal_battery_cop(
+                hc, outdoor_temp_arr, length=required_len
             )
-            params["heatpump_cops"].value = np.array(cops[:required_len])
+            params["heatpump_cops"].value = np.array(cops)
 
             # Check for hot water tank mode (draw_off_demand present)
             # draw_off_demand units: kWh per timestep (same as heating_demand from
@@ -1664,11 +1661,9 @@ class Optimization:
             outdoor_temp_arr = self._get_clean_outdoor_temp(data_opt, required_len)
 
             heatpump_cops = np.array(
-                utils.calculate_cop_heatpump(
-                    supply_temperature=supply_temperature,
-                    carnot_efficiency=hc.get("carnot_efficiency", 0.4),
-                    outdoor_temperature_forecast=outdoor_temp_arr.tolist(),
-                )[:required_len]
+                utils.resolve_thermal_battery_cop(
+                    hc, outdoor_temp_arr, length=required_len
+                )
             )
 
             # Check for hot water tank mode (draw_off_demand present)

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import shutil
 import time
+from collections.abc import Sequence
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -235,6 +236,71 @@ def calculate_cop_heatpump(
     cop_values = np.clip(cop_values, 1.0, 8.0)
 
     return cop_values
+
+
+def resolve_thermal_battery_cop(
+    hc: dict,
+    outdoor_temperature_forecast: Sequence[float] | np.ndarray | pd.Series | None,
+    length: int | None = None,
+) -> np.ndarray:
+    """
+    Resolve the per-timestep energy-conversion factor for a thermal_battery heat source.
+
+    The thermal_battery model treats the conversion factor uniformly as a COP-like
+    multiplier on input power: `Q_thermal = COP * P_in / 1000 * dt`. Two source types
+    are supported:
+
+    - Heat pump (default): COP is computed via the Carnot formula and varies with
+      the outdoor temperature. Requires `supply_temperature` in `hc`; uses
+      `carnot_efficiency` (default 0.4).
+    - Constant-efficiency source (gas boiler, oil burner, district heating, etc.):
+      `efficiency` in `hc` is used as a flat conversion factor for every timestep.
+      `supply_temperature` is not required and outdoor temperature is ignored. The
+      constant value passes through Carnot bounds intentionally (typical 0.85-0.95
+      for combustion sources).
+
+    :param hc: The thermal_battery sub-config dict from def_load_config.
+    :param outdoor_temperature_forecast: Outdoor temperature forecast in degrees
+        Celsius. Required in heat-pump mode. In constant-efficiency mode it is
+        ignored and may be ``None`` provided ``length`` is given explicitly.
+    :param length: Number of timesteps in the returned array. Mandatory when
+        ``outdoor_temperature_forecast`` is ``None``; otherwise truncates or
+        passes through the forecast length when set, or returns the full forecast
+        length when unset.
+    :return: Numpy array of conversion factors, one per timestep.
+    """
+    if "efficiency" in hc and hc["efficiency"] is not None:
+        efficiency = float(hc["efficiency"])
+        if efficiency <= 0:
+            raise ValueError(
+                f"thermal_battery 'efficiency' must be positive, got {efficiency}"
+            )
+        if length is None:
+            if outdoor_temperature_forecast is None:
+                raise ValueError(
+                    "resolve_thermal_battery_cop in constant-efficiency mode "
+                    "requires 'length' when outdoor_temperature_forecast is None"
+                )
+            length = len(outdoor_temperature_forecast)
+        return np.full(length, efficiency)
+
+    supply_temperature = hc.get("supply_temperature")
+    if supply_temperature is None:
+        raise ValueError(
+            "thermal_battery requires either 'efficiency' (constant-efficiency mode) "
+            "or 'supply_temperature' (heat-pump mode)"
+        )
+    if outdoor_temperature_forecast is None:
+        raise ValueError(
+            "resolve_thermal_battery_cop in heat-pump mode requires "
+            "outdoor_temperature_forecast"
+        )
+    cops = calculate_cop_heatpump(
+        supply_temperature=supply_temperature,
+        carnot_efficiency=hc.get("carnot_efficiency", 0.4),
+        outdoor_temperature_forecast=outdoor_temperature_forecast,
+    )
+    return cops if length is None else cops[:length]
 
 
 def calculate_thermal_loss_signed(

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -16,6 +16,7 @@ from pandas.testing import assert_series_equal
 from emhass.forecast import Forecast
 from emhass.optimization import Optimization
 from emhass.retrieve_hass import RetrieveHass
+from emhass import utils
 from emhass.utils import (
     build_config,
     build_params,
@@ -2384,6 +2385,80 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         self.assertIn("P_deferrable0", opt_res.columns)
 
     # --- Thermal Battery Inertia Tests ---
+
+    def test_thermal_battery_flat_efficiency_mode(self):
+        """Gas-source / constant-efficiency thermal_battery solves successfully.
+
+        When 'efficiency' is set on the thermal_battery sub-config, the optimizer
+        treats the heat source as a constant-efficiency converter (gas boiler, oil
+        burner, district heating, etc.) rather than a temperature-dependent heat
+        pump. supply_temperature is optional in this mode.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        # Varying outdoor temperature - should NOT influence the conversion factor
+        # in flat-efficiency mode.
+        self.df_input_data_dayahead["outdoor_temperature_forecast"] = [
+            10.0 + 8.0 * np.sin(i * np.pi / 12) for i in range(48)
+        ]
+
+        opt_res = self.run_optimization_with_config(
+            [
+                {
+                    "thermal_battery": {
+                        "start_temperature": 20.0,
+                        "efficiency": 0.9,  # flat gas-boiler efficiency
+                        "volume": 50.0,
+                        "specific_heating_demand": 100.0,
+                        "area": 100.0,
+                        "min_temperatures": [18.0] * 48,
+                        "max_temperatures": [22.0] * 48,
+                    }
+                },
+            ]
+        )
+
+        # Optimization succeeds and deferrable power column is present
+        self.assertIn("P_deferrable0", opt_res.columns)
+        self.assertGreaterEqual(opt_res["P_deferrable0"].sum(), 0)
+
+    def test_thermal_battery_efficiency_overrides_carnot(self):
+        """When 'efficiency' is set, the Carnot calc is bypassed even if
+        supply_temperature and carnot_efficiency are also present."""
+        outdoor = np.array([0.0, 5.0, 10.0, 15.0])
+
+        flat = utils.resolve_thermal_battery_cop(
+            {"efficiency": 0.9, "supply_temperature": 35.0, "carnot_efficiency": 0.4},
+            outdoor,
+            length=4,
+        )
+        # Flat array regardless of supply_temperature/carnot_efficiency presence
+        np.testing.assert_array_almost_equal(flat, np.full(4, 0.9))
+
+    def test_thermal_battery_missing_source_field_raises(self):
+        """A thermal_battery config with neither supply_temperature nor efficiency
+        raises a clear ValueError at constraint-build time."""
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        self.df_input_data_dayahead["outdoor_temperature_forecast"] = 10.0
+
+        with self.assertRaises(ValueError) as ctx:
+            self.run_optimization_with_config(
+                [
+                    {
+                        "thermal_battery": {
+                            "start_temperature": 20.0,
+                            # neither supply_temperature nor efficiency
+                            "volume": 50.0,
+                            "specific_heating_demand": 100.0,
+                            "area": 100.0,
+                            "min_temperatures": [18.0] * 48,
+                            "max_temperatures": [22.0] * 48,
+                        }
+                    },
+                ]
+            )
+        msg = str(ctx.exception)
+        self.assertIn("supply_temperature", msg)
+        self.assertIn("efficiency", msg)
 
     def test_thermal_battery_inertia_backward_compat(self):
         """Test that thermal_inertia_time_constant=0 produces identical results to omitting it."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2378,6 +2378,101 @@ class TestHeatingDemand(unittest.TestCase):
         self.assertAlmostEqual(loss_manual_warm, -base_loss, places=6)
 
 
+class TestResolveThermalBatteryCop(unittest.TestCase):
+    """Tests for the dispatch helper that picks between Carnot COP and flat efficiency."""
+
+    def test_efficiency_mode_returns_flat_array(self):
+        """When 'efficiency' is set, return a flat conversion-factor array."""
+        hc = {"efficiency": 0.9}
+        outdoor = np.array([0.0, 5.0, 10.0, 15.0])
+        cops = utils.resolve_thermal_battery_cop(hc, outdoor, length=4)
+        np.testing.assert_array_almost_equal(cops, np.full(4, 0.9))
+
+    def test_efficiency_mode_ignores_outdoor_temperature(self):
+        """Flat efficiency does not vary with outdoor temperature."""
+        hc = {"efficiency": 0.85}
+        hot = utils.resolve_thermal_battery_cop(hc, np.array([20.0] * 6), length=6)
+        cold = utils.resolve_thermal_battery_cop(hc, np.array([-15.0] * 6), length=6)
+        np.testing.assert_array_almost_equal(hot, cold)
+        self.assertTrue(np.all(hot == 0.85))
+
+    def test_efficiency_mode_does_not_require_supply_temperature(self):
+        """Constant-efficiency mode works without a supply_temperature field."""
+        hc = {"efficiency": 0.9}  # no supply_temperature, no carnot_efficiency
+        cops = utils.resolve_thermal_battery_cop(hc, np.array([5.0, 5.0]), length=2)
+        np.testing.assert_array_almost_equal(cops, np.array([0.9, 0.9]))
+
+    def test_heatpump_mode_falls_back_to_carnot(self):
+        """When 'efficiency' is not set, fall back to the existing Carnot COP."""
+        hc = {"supply_temperature": 35.0, "carnot_efficiency": 0.4}
+        outdoor = np.array([5.0])
+        cops = utils.resolve_thermal_battery_cop(hc, outdoor, length=1)
+        expected = utils.calculate_cop_heatpump(35.0, 0.4, outdoor)
+        np.testing.assert_array_almost_equal(cops, expected)
+
+    def test_heatpump_mode_default_carnot_efficiency(self):
+        """carnot_efficiency defaults to 0.4 when not set."""
+        hc_explicit = {"supply_temperature": 35.0, "carnot_efficiency": 0.4}
+        hc_implicit = {"supply_temperature": 35.0}
+        outdoor = np.array([0.0, 5.0, 10.0])
+        cops_explicit = utils.resolve_thermal_battery_cop(hc_explicit, outdoor, length=3)
+        cops_implicit = utils.resolve_thermal_battery_cop(hc_implicit, outdoor, length=3)
+        np.testing.assert_array_almost_equal(cops_explicit, cops_implicit)
+
+    def test_missing_both_efficiency_and_supply_temperature_raises(self):
+        """At least one of efficiency or supply_temperature must be set."""
+        hc = {"carnot_efficiency": 0.4}
+        outdoor = np.array([5.0])
+        with self.assertRaises(ValueError) as ctx:
+            utils.resolve_thermal_battery_cop(hc, outdoor, length=1)
+        self.assertIn("efficiency", str(ctx.exception))
+        self.assertIn("supply_temperature", str(ctx.exception))
+
+    def test_nonpositive_efficiency_raises(self):
+        """efficiency must be strictly positive."""
+        for bad in (0.0, -0.5):
+            hc = {"efficiency": bad}
+            with self.assertRaises(ValueError) as ctx:
+                utils.resolve_thermal_battery_cop(hc, np.array([5.0]), length=1)
+            self.assertIn("positive", str(ctx.exception))
+
+    def test_length_truncation_in_heatpump_mode(self):
+        """When `length` is given, the returned array is truncated."""
+        hc = {"supply_temperature": 35.0}
+        outdoor = np.array([0.0, 5.0, 10.0, 15.0, 20.0])
+        cops = utils.resolve_thermal_battery_cop(hc, outdoor, length=3)
+        self.assertEqual(len(cops), 3)
+
+    def test_length_none_returns_full_forecast(self):
+        """When `length` is None, return the full forecast length."""
+        hc = {"supply_temperature": 35.0}
+        outdoor = np.array([0.0, 5.0, 10.0])
+        cops = utils.resolve_thermal_battery_cop(hc, outdoor, length=None)
+        self.assertEqual(len(cops), 3)
+
+    def test_efficiency_mode_accepts_outdoor_none_when_length_given(self):
+        """Constant-efficiency mode ignores outdoor; passing None is allowed
+        when `length` is supplied explicitly."""
+        hc = {"efficiency": 0.9}
+        cops = utils.resolve_thermal_battery_cop(hc, None, length=4)
+        np.testing.assert_array_almost_equal(cops, np.full(4, 0.9))
+
+    def test_efficiency_mode_outdoor_none_without_length_raises(self):
+        """Constant-efficiency mode with outdoor=None and length=None is
+        ambiguous and raises with a clear message."""
+        hc = {"efficiency": 0.9}
+        with self.assertRaises(ValueError) as ctx:
+            utils.resolve_thermal_battery_cop(hc, None, length=None)
+        self.assertIn("length", str(ctx.exception))
+
+    def test_heatpump_mode_outdoor_none_raises(self):
+        """Heat-pump mode requires outdoor temperature; None must raise."""
+        hc = {"supply_temperature": 35.0}
+        with self.assertRaises(ValueError) as ctx:
+            utils.resolve_thermal_battery_cop(hc, None, length=3)
+        self.assertIn("outdoor_temperature_forecast", str(ctx.exception))
+
+
 class TestRuntimeBanner(unittest.TestCase):
     def test_log_runtime_banner_logs_info(self):
         from emhass.utils import log_runtime_banner


### PR DESCRIPTION
## Problem

`thermal_battery` currently assumes a heat-pump source: the COP is computed
with Carnot physics based on `outdoor_temperature_forecast` and
`supply_temperature`. Non-electric sources (gas boilers, oil burners, district
heating substations) don't have a Carnot COP - they convert primary energy at
a roughly flat efficiency. To model hybrid heating where one tank is fed by a
heat pump and another by a gas boiler, EMHASS needs to support both source
types behind the same `thermal_battery` interface.

## Change

Adds an optional `efficiency` field on the `thermal_battery` sub-config. When
set, EMHASS uses a flat per-timestep conversion factor instead of computing
Carnot COP. Existing configs (Carnot path) are unchanged.

A new helper `utils.resolve_thermal_battery_cop()` dispatches between the two
modes:

- if `efficiency` is present → flat array `[efficiency] * n_timesteps`
- else → existing `calculate_cop_heatpump()` path

All three COP call sites in `optimization.py` (`_add_thermal_battery_*`
methods, both per-load and shared paths) route through the helper.
`supply_temperature` is no longer hard-required; either it or `efficiency`
must be present, otherwise a clear `ValueError` is raised.

## Compatibility

- Existing configs with `supply_temperature` (and optional
  `carnot_efficiency`) keep working exactly as before. The helper picks the
  Carnot path when `efficiency` is missing.
- All 27 existing `thermal_battery` tests pass.
- No changes to optim_conf cache key shape.

## Test plan

- [x] `pytest tests/test_utils.py::TestResolveThermalBatteryCop` (9 unit
      tests: flat efficiency, both fields present, missing both,
      negative-value validation, etc.)
- [x] `pytest tests/test_optimization.py -k "thermal_battery and efficiency"`
      (3 integration tests: optimizer solves with flat efficiency,
      efficiency overrides Carnot when both set, missing-both raises)
- [x] `pytest tests/test_optimization.py` - all 32 thermal_battery tests pass
- [x] No new ruff errors (pre-existing F841 + I001 in upstream code are
      unchanged)

## Docs

New "Constant-efficiency mode" section in `docs/thermal_battery.md` with
typical efficiency values (gas 0.92, oil 0.85, district 0.95) and a note on
modelling hybrid systems via per-target `thermal_battery` configs combined
with `deferrable_load_groups`.

## Related

This is the first in a small chain of additive changes that, together,
enable hybrid heating modelling (heat pump + gas boiler, shared tanks,
weather-compensated supply temperature). Each change is independently
useful and shipped as a focused PR.

Refs #539.

## Summary by Sourcery

Add support for constant-efficiency heat sources in the thermal_battery model alongside existing Carnot-based heat-pump mode.

New Features:
- Allow thermal_battery to use a flat efficiency parameter as a constant energy-conversion factor for non-heat-pump sources such as gas, oil, or district heating.
- Introduce a resolve_thermal_battery_cop helper that selects between Carnot COP and flat-efficiency modes based on the thermal_battery configuration.

Enhancements:
- Relax thermal_battery configuration so that either supply_temperature or efficiency is required, improving flexibility and error messaging.
- Update optimization logic to use the unified COP resolver for both per-load and shared thermal_battery constraints.
- Extend thermal_battery documentation with guidance and typical values for constant-efficiency sources and hybrid system modelling.

Tests:
- Add unit tests for the COP resolver helper covering flat-efficiency, Carnot, length handling, and validation cases.
- Add integration tests to ensure constant-efficiency thermal_battery configurations solve correctly, override Carnot when both are set, and raise errors when required fields are missing.