### PR TITLE
fix(ci): skip SonarQube Scan on fork PRs (#857)

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -44,6 +44,7 @@ jobs:
           verbose: true
 
       - name: SonarQube Scan
+        if: github.event.pull_request.head.repo.fork == false
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

Closes #857.

Adds `if: github.event.pull_request.head.repo.fork == false` to the `SonarQube Scan` step in `.github/workflows/codecov.yaml`, so the step is skipped on fork-based pull requests. Same-repo PRs and `master` pushes still run Sonar as before.

Maintainer pre-approval in #857: `Yes we can just treat this with option a)`.

## Changes

`.github/workflows/codecov.yaml`: one-line `if:` condition added to the SonarQube Scan step. No other changes.

## Notes

Gate 0 (pre-PR simplify pass) N/A for 1-line workflow conditional.

The `pull_request` trigger remains unchanged (no switch to `pull_request_target`, which would be a security anti-pattern for code-quality scans per #857's analysis).

After merge, fork-based PRs will no longer show the Sonar step red, removing a persistent source of false-positive CI noise for external contributors.

## Summary by Sourcery

CI:
- Add a conditional to the SonarQube Scan step so it only runs for non-fork pull requests and master branch pushes.