### PR TITLE
fix(utils): guard string-null heat_topology in compile_heat_topology and treat_runtimeparams

### DIFF
--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -506,6 +506,8 @@ def compile_heat_topology(topology: dict) -> dict:
     consumers targeting unknown storage all raise ValueError with the
     offending field path.
     """
+    if not isinstance(topology, dict) or not topology:
+        return {}
     sources = topology.get("sources", []) or []
     storage = topology.get("storage", []) or []
     consumers = topology.get("consumers", []) or []
@@ -1886,48 +1888,57 @@ async def treat_runtimeparams(
     # config because runtimeparams have already been merged above.
     heat_topology = optim_conf.get("heat_topology")
     if heat_topology:
-        try:
-            compiled = compile_heat_topology(heat_topology)
-        except ValueError as e:
-            logger.error("heat_topology compile failed: %s", e)
-            raise
-        # Merge compiled fields into optim_conf, allowing user-set fields to win
-        # for things the compiler always populates (e.g. operating_hours).
-        for key, val in compiled.items():
-            if key not in optim_conf or optim_conf[key] in (None, [], {}):
-                optim_conf[key] = val
-            else:
-                # For the structural fields we ALWAYS want compiled values
-                # (otherwise the compiled def_load_config doesn't match
-                # number_of_deferrable_loads, etc.)
-                if key in {
-                    "number_of_deferrable_loads",
-                    "def_load_config",
-                    "shared_thermal_tanks",
-                    "deferrable_load_groups",
-                    "nominal_power_of_deferrable_loads",
-                    "minimum_power_of_deferrable_loads",
-                    "treat_deferrable_load_as_semi_cont",
-                    "cost_forecast_per_deferrable_load",
-                    # All per-load arrays must match number_of_deferrable_loads,
-                    # which the compiler sets - so override any defaults.
-                    "set_deferrable_load_single_constant",
-                    "set_deferrable_startup_penalty",
-                    "set_deferrable_max_startups",
-                    "operating_hours_of_each_deferrable_load",
-                    "start_timesteps_of_each_deferrable_load",
-                    "end_timesteps_of_each_deferrable_load",
-                    "is_electric_load",
-                }:
+        if not isinstance(heat_topology, dict):
+            logger.warning(
+                "heat_topology is set but is %s, not a dict (value: %r). "
+                "Treating as 'no topology'. Use JSON null (not the string \"null\") "
+                "or omit the key to disable.",
+                type(heat_topology).__name__,
+                heat_topology,
+            )
+        else:
+            try:
+                compiled = compile_heat_topology(heat_topology)
+            except ValueError as e:
+                logger.error("heat_topology compile failed: %s", e)
+                raise
+            # Merge compiled fields into optim_conf, allowing user-set fields to win
+            # for things the compiler always populates (e.g. operating_hours).
+            for key, val in compiled.items():
+                if key not in optim_conf or optim_conf[key] in (None, [], {}):
                     optim_conf[key] = val
-        params["optim_conf"] = optim_conf
-        logger.info(
-            "heat_topology compiled: %d sources, %d storage, %d flows, %d groups",
-            len(heat_topology.get("sources", [])),
-            len(heat_topology.get("storage", [])),
-            len(heat_topology.get("flows", [])),
-            len(heat_topology.get("actuator_groups", [])),
-        )
+                else:
+                    # For the structural fields we ALWAYS want compiled values
+                    # (otherwise the compiled def_load_config doesn't match
+                    # number_of_deferrable_loads, etc.)
+                    if key in {
+                        "number_of_deferrable_loads",
+                        "def_load_config",
+                        "shared_thermal_tanks",
+                        "deferrable_load_groups",
+                        "nominal_power_of_deferrable_loads",
+                        "minimum_power_of_deferrable_loads",
+                        "treat_deferrable_load_as_semi_cont",
+                        "cost_forecast_per_deferrable_load",
+                        # All per-load arrays must match number_of_deferrable_loads,
+                        # which the compiler sets - so override any defaults.
+                        "set_deferrable_load_single_constant",
+                        "set_deferrable_startup_penalty",
+                        "set_deferrable_max_startups",
+                        "operating_hours_of_each_deferrable_load",
+                        "start_timesteps_of_each_deferrable_load",
+                        "end_timesteps_of_each_deferrable_load",
+                        "is_electric_load",
+                    }:
+                        optim_conf[key] = val
+            params["optim_conf"] = optim_conf
+            logger.info(
+                "heat_topology compiled: %d sources, %d storage, %d flows, %d groups",
+                len(heat_topology.get("sources", [])),
+                len(heat_topology.get("storage", [])),
+                len(heat_topology.get("flows", [])),
+                len(heat_topology.get("actuator_groups", [])),
+            )
 
     # Serialize the final params
     params = orjson.dumps(params, default=str).decode()

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1887,58 +1887,57 @@ async def treat_runtimeparams(
     # it down to flat optim_conf primitives. Runtime override wins over static
     # config because runtimeparams have already been merged above.
     heat_topology = optim_conf.get("heat_topology")
-    if heat_topology:
-        if not isinstance(heat_topology, dict):
-            logger.warning(
-                "heat_topology is set but is %s, not a dict (value: %r). "
-                "Treating as 'no topology'. Use JSON null (not the string \"null\") "
-                "or omit the key to disable.",
-                type(heat_topology).__name__,
-                heat_topology,
-            )
-        else:
-            try:
-                compiled = compile_heat_topology(heat_topology)
-            except ValueError as e:
-                logger.error("heat_topology compile failed: %s", e)
-                raise
-            # Merge compiled fields into optim_conf, allowing user-set fields to win
-            # for things the compiler always populates (e.g. operating_hours).
-            for key, val in compiled.items():
-                if key not in optim_conf or optim_conf[key] in (None, [], {}):
+    if isinstance(heat_topology, dict) and heat_topology:
+        try:
+            compiled = compile_heat_topology(heat_topology)
+        except ValueError as e:
+            logger.error("heat_topology compile failed: %s", e)
+            raise
+        # Merge compiled fields into optim_conf, allowing user-set fields to win
+        # for things the compiler always populates (e.g. operating_hours).
+        for key, val in compiled.items():
+            if key not in optim_conf or optim_conf[key] in (None, [], {}):
+                optim_conf[key] = val
+            else:
+                # For the structural fields we ALWAYS want compiled values
+                # (otherwise the compiled def_load_config doesn't match
+                # number_of_deferrable_loads, etc.)
+                if key in {
+                    "number_of_deferrable_loads",
+                    "def_load_config",
+                    "shared_thermal_tanks",
+                    "deferrable_load_groups",
+                    "nominal_power_of_deferrable_loads",
+                    "minimum_power_of_deferrable_loads",
+                    "treat_deferrable_load_as_semi_cont",
+                    "cost_forecast_per_deferrable_load",
+                    # All per-load arrays must match number_of_deferrable_loads,
+                    # which the compiler sets - so override any defaults.
+                    "set_deferrable_load_single_constant",
+                    "set_deferrable_startup_penalty",
+                    "set_deferrable_max_startups",
+                    "operating_hours_of_each_deferrable_load",
+                    "start_timesteps_of_each_deferrable_load",
+                    "end_timesteps_of_each_deferrable_load",
+                    "is_electric_load",
+                }:
                     optim_conf[key] = val
-                else:
-                    # For the structural fields we ALWAYS want compiled values
-                    # (otherwise the compiled def_load_config doesn't match
-                    # number_of_deferrable_loads, etc.)
-                    if key in {
-                        "number_of_deferrable_loads",
-                        "def_load_config",
-                        "shared_thermal_tanks",
-                        "deferrable_load_groups",
-                        "nominal_power_of_deferrable_loads",
-                        "minimum_power_of_deferrable_loads",
-                        "treat_deferrable_load_as_semi_cont",
-                        "cost_forecast_per_deferrable_load",
-                        # All per-load arrays must match number_of_deferrable_loads,
-                        # which the compiler sets - so override any defaults.
-                        "set_deferrable_load_single_constant",
-                        "set_deferrable_startup_penalty",
-                        "set_deferrable_max_startups",
-                        "operating_hours_of_each_deferrable_load",
-                        "start_timesteps_of_each_deferrable_load",
-                        "end_timesteps_of_each_deferrable_load",
-                        "is_electric_load",
-                    }:
-                        optim_conf[key] = val
-            params["optim_conf"] = optim_conf
-            logger.info(
-                "heat_topology compiled: %d sources, %d storage, %d flows, %d groups",
-                len(heat_topology.get("sources", [])),
-                len(heat_topology.get("storage", [])),
-                len(heat_topology.get("flows", [])),
-                len(heat_topology.get("actuator_groups", [])),
-            )
+        params["optim_conf"] = optim_conf
+        logger.info(
+            "heat_topology compiled: %d sources, %d storage, %d flows, %d groups",
+            len(heat_topology.get("sources", [])),
+            len(heat_topology.get("storage", [])),
+            len(heat_topology.get("flows", [])),
+            len(heat_topology.get("actuator_groups", [])),
+        )
+    elif heat_topology:
+        logger.warning(
+            "heat_topology is set but is %s, not a dict (value: %r). "
+            "Treating as 'no topology'. Use JSON null (not the string \"null\") "
+            "or omit the key to disable.",
+            type(heat_topology).__name__,
+            heat_topology,
+        )
 
     # Serialize the final params
     params = orjson.dumps(params, default=str).decode()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1327,6 +1327,31 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIs(out["passed_data"]["ignore_pv_feedback_during_curtailment"], True)
 
+    async def test_treat_runtimeparams_handles_string_null_heat_topology(self):
+        """String "null" heat_topology must not crash; warning logged; no compiled fields merged."""
+        params = await TestUtils.get_test_params()
+        params["optim_conf"]["heat_topology"] = "null"
+        params_json = orjson.dumps(params).decode("utf-8")
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+        original_num_loads = optim_conf["number_of_deferrable_loads"]
+
+        runtimeparams_json = orjson.dumps({}).decode("utf-8")
+
+        with self.assertLogs(logger, level="WARNING") as log_cm:
+            _, _, optim_conf_out, _ = await treat_runtimeparams(
+                runtimeparams_json,
+                params_json,
+                retrieve_hass_conf,
+                optim_conf,
+                plant_conf,
+                "dayahead-optim",
+                logger,
+                emhass_conf,
+            )
+
+        self.assertEqual(optim_conf_out["number_of_deferrable_loads"], original_num_loads)
+        self.assertTrue(any("heat_topology" in m for m in log_cm.output))
+
     def test_param_to_config(self):
         """Test converting built params back to a flat config dictionary and masking secrets."""
         # Create a mock parameter dictionary with the required categories
@@ -3476,6 +3501,16 @@ class TestCompileHeatTopology(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             utils.compile_heat_topology(topo)
         self.assertIn("missing", str(ctx.exception))
+
+    def test_compile_heat_topology_rejects_non_dict(self):
+        """Non-dict inputs (string "null", None, "") must return {} without raising."""
+        self.assertEqual(utils.compile_heat_topology("null"), {})
+        self.assertEqual(utils.compile_heat_topology(None), {})
+        self.assertEqual(utils.compile_heat_topology(""), {})
+
+    def test_compile_heat_topology_rejects_empty_dict(self):
+        """Empty dict must return {} without raising."""
+        self.assertEqual(utils.compile_heat_topology({}), {})
 
 
 class TestRuntimeBanner(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1352,6 +1352,50 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(optim_conf_out["number_of_deferrable_loads"], original_num_loads)
         self.assertTrue(any("heat_topology" in m for m in log_cm.output))
 
+    async def test_treat_runtimeparams_compiles_valid_heat_topology(self):
+        """Valid dict heat_topology is compiled and merged into optim_conf."""
+        params = await TestUtils.get_test_params()
+        topo = {
+            "sources": [
+                {
+                    "id": "boiler",
+                    "type": "gas",
+                    "efficiency": 0.9,
+                    "nominal_power": 10000,
+                    "min_power": 2000,
+                }
+            ],
+            "storage": [
+                {
+                    "id": "tank",
+                    "volume": 0.1,
+                    "start_temperature": 35,
+                    "min_temperature": [25] * 48,
+                    "max_temperature": [60] * 48,
+                    "thermal_loss": 0.05,
+                }
+            ],
+            "flows": [{"from": "boiler", "to": "tank"}],
+        }
+        params["optim_conf"]["heat_topology"] = topo
+        params_json = orjson.dumps(params).decode("utf-8")
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+
+        runtimeparams_json = orjson.dumps({}).decode("utf-8")
+        _, _, optim_conf_out, _ = await treat_runtimeparams(
+            runtimeparams_json,
+            params_json,
+            retrieve_hass_conf,
+            optim_conf,
+            plant_conf,
+            "dayahead-optim",
+            logger,
+            emhass_conf,
+        )
+
+        self.assertEqual(optim_conf_out["number_of_deferrable_loads"], 1)
+        self.assertEqual(len(optim_conf_out["def_load_config"]), 1)
+
     def test_param_to_config(self):
         """Test converting built params back to a flat config dictionary and masking secrets."""
         # Create a mock parameter dictionary with the required categories


### PR DESCRIPTION
Fixes #876.

## Root cause

`compile_heat_topology` is typed `dict -> dict` but gets called from
`treat_runtimeparams` without a runtime type check. The guard
`if heat_topology:` filters out `None`, `{}`, `""` — but not a non-empty
string like `"null"`. That reaches `topology.get(...)` and crashes.

Same gap as #869 (JS-side `Object.values(null)` on the same feature, fixed
in #872).

## What changed

Two guards in `src/emhass/utils.py`:

1. `compile_heat_topology` — early return `{}` on non-dict or empty input.
2. `treat_runtimeparams` — `isinstance(heat_topology, dict)` check before
   compiling; logs a warning when a non-dict value is seen and skips the
   compile path. Optimization proceeds as if no topology was set.

Four new tests in `tests/test_utils.py`:

- `compile_heat_topology` rejects non-dict inputs (`"null"`, `None`, `""`) and empty dict, returning `{}` without raising.
- `treat_runtimeparams` with `"heat_topology": "null"` logs a warning, skips compilation, and leaves `optim_conf` untouched.
- `treat_runtimeparams` with a valid `heat_topology` dict still compiles correctly and merges the expected fields (happy-path coverage).

## Why both layers?

Callee guard keeps `compile_heat_topology` safe regardless of the caller.
The caller-side warning is there because users need to know *why* topology is
being skipped — `"null"` vs JSON null is an easy mistake with some add-on UI
forms and a silent skip would leave them confused.

## Verification

Full pytest suite passes locally. New tests fail on unpatched `utils.py` and
pass after. No JSON / template / JS changes.

## Conventions

Followed the contribution conventions in `AGENTS.md` for this change (scope
discipline, draft-first, surgical edits in `utils.py` only).

## Summary by Sourcery

Guard heat topology handling against invalid string/null inputs and ensure runtime parameter processing remains robust and observable when topology is misconfigured.

Bug Fixes:
- Prevent crashes in compile_heat_topology when called with non-dict or empty inputs by returning an empty topology.
- Avoid failures in treat_runtimeparams when heat_topology is a string value like "null" by skipping compilation and logging a warning.

Tests:
- Add tests verifying compile_heat_topology safely handles non-dict and empty dict inputs.
- Add tests covering treat_runtimeparams behavior for string "null" heat_topology and for valid heat topology compilation and merge into optim_conf.
