### PR TITLE
test: add schema-contract and defaults-smoke prevention tests (closes #869)

### DIFF
--- a/tests/test_defaults_smoke.py
+++ b/tests/test_defaults_smoke.py
@@ -1,0 +1,83 @@
+# tests/test_defaults_smoke.py
+import pathlib
+import unittest
+
+import numpy as np
+import orjson
+import pandas as pd
+
+from emhass import utils
+from emhass.optimization import Optimization
+
+root = pathlib.Path(utils.get_root(__file__, num_parent=2))
+emhass_conf = {
+    "data_path": root / "data/",
+    "root_path": root / "src/emhass/",
+    "defaults_path": root / "src/emhass/data/config_defaults.json",
+    "associations_path": root / "src/emhass/data/associations.csv",
+}
+logger, _ = utils.get_logger(__name__, emhass_conf, save_to_file=False)
+
+_VAR_LOAD_COST = "unit_load_cost"
+_VAR_PROD_PRICE = "unit_prod_price"
+
+
+class TestDefaultsSmoke(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        config = await utils.build_config(emhass_conf, logger, emhass_conf["defaults_path"])
+        _, secrets = await utils.build_secrets(emhass_conf, logger, no_response=True)
+        params = await utils.build_params(emhass_conf, secrets, config, logger)
+        self.params_json = orjson.dumps(params).decode("utf-8")
+        self.retrieve_hass_conf, self.optim_conf, self.plant_conf = utils.get_yaml_parse(
+            self.params_json, logger
+        )
+
+    def _make_forecast_inputs(self, n: int = 48):
+        """Build minimal constant-value forecast inputs."""
+        freq = self.retrieve_hass_conf["optimization_time_step"]
+        tz = self.retrieve_hass_conf["time_zone"]
+        idx = pd.date_range("2024-01-01", periods=n, freq=freq, tz=tz)
+        p_pv = np.zeros(n)
+        p_load = np.full(n, 1000.0)
+        ulc = np.full(n, 0.2)
+        upp = np.full(n, 0.1)
+        df = pd.DataFrame({_VAR_LOAD_COST: ulc, _VAR_PROD_PRICE: upp}, index=idx)
+        return df, p_pv, p_load, ulc, upp
+
+    def _build_and_run(self, retrieve_hass_conf, optim_conf, plant_conf):
+        df, p_pv, p_load, ulc, upp = self._make_forecast_inputs()
+        opt = Optimization(
+            retrieve_hass_conf,
+            optim_conf,
+            plant_conf,
+            _VAR_LOAD_COST,
+            _VAR_PROD_PRICE,
+            "profit",
+            emhass_conf,
+            logger,
+        )
+        opt.perform_optimization(df, p_pv, p_load, ulc, upp)
+
+    def test_perform_optimization_with_in_code_defaults_runs(self):
+        """Optimization built from the default-config pipeline must not raise."""
+        self._build_and_run(self.retrieve_hass_conf, self.optim_conf, self.plant_conf)
+
+    async def test_perform_optimization_with_config_defaults_json_runs(self):
+        """Optimization after treat_runtimeparams with config_defaults must not raise.
+
+        Exercises the treat_runtimeparams -> compile_heat_topology guard path.
+        Pre-#878 with heat_topology as the string "null" + old truthy guard raised
+        AttributeError before reaching perform_optimization.
+        """
+        runtimeparams_json = orjson.dumps({}).decode("utf-8")
+        _, retrieve_hass_conf, optim_conf, plant_conf = await utils.treat_runtimeparams(
+            runtimeparams_json,
+            self.params_json,
+            self.retrieve_hass_conf,
+            self.optim_conf,
+            self.plant_conf,
+            "dayahead-optim",
+            logger,
+            emhass_conf,
+        )
+        self._build_and_run(retrieve_hass_conf, optim_conf, plant_conf)

--- a/tests/test_defaults_smoke.py
+++ b/tests/test_defaults_smoke.py
@@ -1,4 +1,3 @@
-# tests/test_defaults_smoke.py
 import pathlib
 import unittest
 

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -1,4 +1,3 @@
-# tests/test_schema_contract.py
 import json
 import re
 from pathlib import Path

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -107,9 +107,7 @@ def test_config_defaults_keys_match_param_definitions():
     pd = json.loads(
         Path("src/emhass/static/data/param_definitions.json").read_text(encoding="utf-8")
     )
-    cd = json.loads(
-        Path("src/emhass/data/config_defaults.json").read_text(encoding="utf-8")
-    )
+    cd = json.loads(Path("src/emhass/data/config_defaults.json").read_text(encoding="utf-8"))
 
     pd_flat: dict[str, str] = {}
     for section_entries in pd.values():

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -1,0 +1,151 @@
+# tests/test_schema_contract.py
+import json
+import re
+from pathlib import Path
+
+# Keys in config_defaults.json with no param_definitions.json entry.
+# These are ML-subsystem parameters not represented in the UI schema.
+_KNOWN_UNDECLARED_DEFAULTS = frozenset({
+    "data_path",
+    "deferrable_load_groups",
+    "model_type",
+    "num_lags",
+    "perform_backtest",
+    "sklearn_model",
+    "split_date_delta",
+    "var_model",
+})
+
+# Keys whose default value type doesn't match their declared input type.
+# Pre-existing mismatches outside the scope of the #876/#879 bug-wave.
+_KNOWN_TYPE_MISMATCHES = frozenset({
+    "load_peak_hour_periods",  # declared array.time, default is dict
+})
+
+# Mapping from param_definitions "input" type to acceptable Python types for defaults.
+_INPUT_TYPE_TO_PY_TYPES: dict[str, tuple[type, ...]] = {
+    "int":              (int, type(None)),
+    "float":            (int, float, type(None)),
+    "string":           (str, type(None)),
+    "boolean":          (bool,),
+    "time":             (str, type(None)),
+    "select":           (str, type(None)),
+    "array.int":        (list, type(None)),
+    "array.float":      (list, type(None)),
+    "array.string":     (list, type(None)),
+    "array.boolean":    (list, type(None)),
+    "array.time":       (list, type(None)),
+    "array.array.float": (list, type(None)),
+    "object":           (dict, type(None)),
+}
+
+
+def _extract_function_body(js_src: str, fn_name: str) -> str:
+    """Return the body of `function fn_name(...)` from a JS source string.
+
+    Uses brace counting; assumes the function declaration is well-formed.
+    """
+    m = re.search(rf"function\s+{re.escape(fn_name)}\s*\([^)]*\)\s*\{{", js_src)
+    if not m:
+        raise AssertionError(f"function {fn_name!r} not found in JS source")
+    start = m.end()
+    depth = 1
+    i = start
+    while i < len(js_src) and depth > 0:
+        if js_src[i] == "{":
+            depth += 1
+        elif js_src[i] == "}":
+            depth -= 1
+        i += 1
+    return js_src[start : i - 1]
+
+
+def test_param_definitions_input_types_have_renderer_cases():
+    """Every distinct 'input' value in param_definitions.json must have a
+    matching case in the buildParamElement switch in configuration_script.js.
+
+    Pre-#872 master would have failed with {'array.array.float', 'object'}
+    missing from the switch.
+    """
+    pd_path = Path("src/emhass/static/data/param_definitions.json")
+    pd = json.loads(pd_path.read_text(encoding="utf-8"))
+
+    declared_inputs: set[str] = set()
+    for section_entries in pd.values():
+        for name, definition in section_entries.items():
+            input_type = definition.get("input")
+            assert input_type is not None, f"{name!r} has no 'input' field"
+            declared_inputs.add(input_type)
+
+    js_path = Path("src/emhass/static/configuration_script.js")
+    js_src = js_path.read_text(encoding="utf-8")
+    fn_body = _extract_function_body(js_src, "buildParamElement")
+    cases = set(re.findall(r'case\s+"([^"]+)"\s*:', fn_body))
+
+    missing = declared_inputs - cases
+    assert not missing, (
+        f"param_definitions.json declares input types with no matching case in "
+        f"buildParamElement: {sorted(missing)}. "
+        f"Add a case in src/emhass/static/configuration_script.js or "
+        f"remove the input type from param_definitions.json."
+    )
+
+
+def test_config_defaults_keys_match_param_definitions():
+    """Every key in config_defaults.json must have a param_definitions.json entry,
+    and its default value must be type-compatible with the declared 'input' type.
+
+    Targeted check: an 'object' input with default value 'null' (the string)
+    instead of JSON null will fail — this is the #876 footgun.
+
+    Known pre-existing exceptions are in _KNOWN_UNDECLARED_DEFAULTS and
+    _KNOWN_TYPE_MISMATCHES; new violations will cause this test to fail.
+    """
+    pd = json.loads(
+        Path("src/emhass/static/data/param_definitions.json").read_text(encoding="utf-8")
+    )
+    cd = json.loads(
+        Path("src/emhass/data/config_defaults.json").read_text(encoding="utf-8")
+    )
+
+    pd_flat: dict[str, str] = {}
+    for section_entries in pd.values():
+        for name, definition in section_entries.items():
+            pd_flat[name] = definition["input"]
+
+    # Check 1: every config_defaults key must appear in param_definitions
+    new_undeclared = (set(cd.keys()) - set(pd_flat.keys())) - _KNOWN_UNDECLARED_DEFAULTS
+    assert not new_undeclared, (
+        f"config_defaults.json keys with no entry in param_definitions.json: "
+        f"{sorted(new_undeclared)}. "
+        f"Add an entry to src/emhass/static/data/param_definitions.json."
+    )
+
+    # Check 2: each default value's Python type must match the declared input type
+    mismatches: list[str] = []
+    for key, default_value in cd.items():
+        if key not in pd_flat or key in _KNOWN_TYPE_MISMATCHES:
+            continue
+        input_type = pd_flat[key]
+        acceptable = _INPUT_TYPE_TO_PY_TYPES.get(input_type)
+        if acceptable is None:
+            mismatches.append(f"{key}: unknown input type {input_type!r}")
+            continue
+        # Targeted #876 footgun: string "null" for an object-typed param
+        if input_type == "object" and default_value == "null":
+            mismatches.append(
+                f"{key}: default is the string 'null', not JSON null — "
+                f"callers expecting a dict will crash (the #876 footgun)"
+            )
+            continue
+        if not isinstance(default_value, acceptable):
+            mismatches.append(
+                f"{key}: default is {type(default_value).__name__} {default_value!r}, "
+                f"declared input is {input_type!r} "
+                f"(expected one of {[t.__name__ for t in acceptable]})"
+            )
+
+    assert not mismatches, (
+        "config_defaults.json has values incompatible with their declared input type:\n  - "
+        + "\n  - ".join(mismatches)
+    )

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -43,15 +43,19 @@ _INPUT_TYPE_TO_PY_TYPES: dict[str, tuple[type, ...]] = {
 }
 
 
-def _extract_function_body(js_src: str, fn_name: str) -> str:
-    """Return the body of `function fn_name(...)` from a JS source string.
+def _extract_switch_body(js_src: str, fn_name: str) -> str:
+    """Return the body of the first switch block inside fn_name.
 
-    Uses brace counting; assumes the function declaration is well-formed.
+    Narrower than full-function extraction: brace-counts only the switch
+    block, so extra braces in the surrounding function don't matter.
     """
-    m = re.search(rf"function\s+{re.escape(fn_name)}\s*\([^)]*\)\s*\{{", js_src)
-    if not m:
+    fn_m = re.search(rf"function\s+{re.escape(fn_name)}\s*\([^)]*\)\s*\{{", js_src)
+    if not fn_m:
         raise AssertionError(f"function {fn_name!r} not found in JS source")
-    start = m.end()
+    sw_m = re.search(r"\bswitch\s*\([^)]+\)\s*\{", js_src[fn_m.end() :])
+    if not sw_m:
+        raise AssertionError(f"no switch statement found in function {fn_name!r}")
+    start = fn_m.end() + sw_m.end()
     depth = 1
     i = start
     while i < len(js_src) and depth > 0:
@@ -82,8 +86,8 @@ def test_param_definitions_input_types_have_renderer_cases():
 
     js_path = Path("src/emhass/static/configuration_script.js")
     js_src = js_path.read_text(encoding="utf-8")
-    fn_body = _extract_function_body(js_src, "buildParamElement")
-    cases = set(re.findall(r'case\s+"([^"]+)"\s*:', fn_body))
+    switch_body = _extract_switch_body(js_src, "buildParamElement")
+    cases = set(re.findall(r'case\s+"([^"]+)"\s*:', switch_body))
 
     missing = declared_inputs - cases
     assert not missing, (
@@ -122,16 +126,20 @@ def test_config_defaults_keys_match_param_definitions():
         f"Add an entry to src/emhass/static/data/param_definitions.json."
     )
 
-    # Check 2: each default value's Python type must match the declared input type
+    # Check 2: every input type declared in param_definitions must be mapped
+    unmapped = set(pd_flat.values()) - set(_INPUT_TYPE_TO_PY_TYPES.keys())
+    assert not unmapped, (
+        f"param_definitions.json uses input types not in _INPUT_TYPE_TO_PY_TYPES: "
+        f"{sorted(unmapped)}. Add them to the mapping in test_schema_contract.py."
+    )
+
+    # Check 3: each default value's Python type must match the declared input type
     mismatches: list[str] = []
     for key, default_value in cd.items():
         if key not in pd_flat or key in _KNOWN_TYPE_MISMATCHES:
             continue
         input_type = pd_flat[key]
-        acceptable = _INPUT_TYPE_TO_PY_TYPES.get(input_type)
-        if acceptable is None:
-            mismatches.append(f"{key}: unknown input type {input_type!r}")
-            continue
+        acceptable = _INPUT_TYPE_TO_PY_TYPES[input_type]
         # Targeted #876 footgun: string "null" for an object-typed param
         if input_type == "object" and default_value == "null":
             mismatches.append(

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -4,38 +4,42 @@ from pathlib import Path
 
 # Keys in config_defaults.json with no param_definitions.json entry.
 # These are ML-subsystem parameters not represented in the UI schema.
-_KNOWN_UNDECLARED_DEFAULTS = frozenset({
-    "data_path",
-    "deferrable_load_groups",
-    "model_type",
-    "num_lags",
-    "perform_backtest",
-    "sklearn_model",
-    "split_date_delta",
-    "var_model",
-})
+_KNOWN_UNDECLARED_DEFAULTS = frozenset(
+    {
+        "data_path",
+        "deferrable_load_groups",
+        "model_type",
+        "num_lags",
+        "perform_backtest",
+        "sklearn_model",
+        "split_date_delta",
+        "var_model",
+    }
+)
 
 # Keys whose default value type doesn't match their declared input type.
 # Pre-existing mismatches outside the scope of the #876/#879 bug-wave.
-_KNOWN_TYPE_MISMATCHES = frozenset({
-    "load_peak_hour_periods",  # declared array.time, default is dict
-})
+_KNOWN_TYPE_MISMATCHES = frozenset(
+    {
+        "load_peak_hour_periods",  # declared array.time, default is dict
+    }
+)
 
 # Mapping from param_definitions "input" type to acceptable Python types for defaults.
 _INPUT_TYPE_TO_PY_TYPES: dict[str, tuple[type, ...]] = {
-    "int":              (int, type(None)),
-    "float":            (int, float, type(None)),
-    "string":           (str, type(None)),
-    "boolean":          (bool,),
-    "time":             (str, type(None)),
-    "select":           (str, type(None)),
-    "array.int":        (list, type(None)),
-    "array.float":      (list, type(None)),
-    "array.string":     (list, type(None)),
-    "array.boolean":    (list, type(None)),
-    "array.time":       (list, type(None)),
+    "int": (int, type(None)),
+    "float": (int, float, type(None)),
+    "string": (str, type(None)),
+    "boolean": (bool,),
+    "time": (str, type(None)),
+    "select": (str, type(None)),
+    "array.int": (list, type(None)),
+    "array.float": (list, type(None)),
+    "array.string": (list, type(None)),
+    "array.boolean": (list, type(None)),
+    "array.time": (list, type(None)),
     "array.array.float": (list, type(None)),
-    "object":           (dict, type(None)),
+    "object": (dict, type(None)),
 }
 
 


### PR DESCRIPTION
Add schema-contract pytest tests guarding against the bug class behind #869.

## Why

Three bugs in the v0.17.3 wave (#869, #876, #879) all came from the same gap: no
automated check that cross-file contracts are consistent, and no check that a
vanilla install actually runs to completion. All three surfaced after release.

In #876 you asked what could catch this class of issue, and @lutorm suggested
running the optimization with defaults to confirm it doesn't crash. This PR
ships both: a static schema contract and a behavioral smoke test.

## What changed

Two new test files. No production code changes, no new dependencies.

### Layer 1 — static schema contract (`tests/test_schema_contract.py`)

stdlib-only, two tests:

- `test_param_definitions_input_types_have_renderer_cases` — parses
  `param_definitions.json` and `configuration_script.js`, asserts every
  distinct `input` value has a matching `case` in the `buildParamElement` switch.
  Would have failed on pre-#872 master with `{'array.array.float', 'object'}` missing.
- `test_config_defaults_keys_match_param_definitions` — asserts every key in
  `config_defaults.json` has a `param_definitions` entry and a type-compatible
  default. Includes a targeted check for the #876 footgun: a `"null"` string
  where `input: "object"` expects a dict.

### Layer 2 — defaults-load behavioral smoke (`tests/test_defaults_smoke.py`)

Two `perform_optimization` calls that must complete without exception:

- `test_perform_optimization_with_in_code_defaults_runs` — builds `Optimization`
  from the defaults pipeline with constant forecast inputs.
- `test_perform_optimization_with_config_defaults_json_runs` — routes through
  `treat_runtimeparams` with empty runtimeparams first (covering the
  `compile_heat_topology` guard path), then runs `perform_optimization`.

Both would have caught #876 and #879 before merge. Assertion is crash-or-not
only — no output-value checks, to avoid solver-flake coupling.

## Why two layers

Layer 1 catches schema drift: the data files diverge from each other.
Layer 2 catches consumer drift: the schema looks consistent but the Python
consumer panics on a valid default. #876 and #879 both had self-consistent
schemas; Layer 1 alone wouldn't have flagged them.

## Out of scope

- Headless browser smoke for `/configuration` — possible follow-up
- Process changes (PR template, AGENTS.md echo phrase) — separate proposal
- Coverage of every runtime-params path — smoke is intentionally narrow

## Verification

Both layers pass on current master (post-#872, post-#878). Pre-#872 master would
have failed the renderer-cases test. Pre-#878 master running the JSON-defaults
smoke would have crashed in `treat_runtimeparams` on `heat_topology: "null"`.

New tests integrate via the existing `pytest tests/` call in
`.github/workflows/python-test.yml` — no workflow changes needed.

Closes #869 (prevention follow-up; the regression itself was fixed in #872).
References #876, #878, #879.

> AGENTS.md read and followed. New files only; no production code changes.

## Summary by Sourcery

Add automated tests to guard against schema inconsistencies and crashes when running optimizations with default configuration values.

Tests:
- Add schema contract tests ensuring every declared input type has a matching UI renderer case and that config default keys and types align with parameter definitions, with known exceptions whitelisted.
- Add asynchronous smoke tests that run the optimization pipeline using both in-code defaults and JSON config defaults to ensure they complete without raising exceptions.