### PR TITLE
fix: LP retry silently skips battery/inverter constraints on cached-problem paths

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -3264,9 +3264,13 @@ class Optimization:
             # Re-apply main constraints
             self._add_main_power_balance_constraints(constraints_relaxed)
             # (Note: We reuse previous stress configs as they don't change with relaxation)
-            if inv_stress_conf:
+            # Guard on feature flags, not on the stress conf objects: stress conf is None
+            # on cached-problem retry paths (self.prob is not None), so guarding on the
+            # object itself would silently skip these constraints on every retry after the
+            # first call, leaving the relaxed problem without battery/inverter constraints.
+            if self.plant_conf.get("inverter_is_hybrid", False):
                 self._add_hybrid_inverter_constraints(constraints_relaxed, inv_stress_conf)
-            if batt_stress_conf:
+            if self.optim_conf.get("set_use_battery", False):
                 self._add_battery_constraints(constraints_relaxed, batt_stress_conf)
 
             if self.plant_conf["compute_curtailment"]:


### PR DESCRIPTION
## Problem

When `self.prob` is cached from a previous call, `inv_stress_conf` and `batt_stress_conf` remain `None` — they are only assigned inside the `if self.prob is None:` block. The LP relaxation retry path then guards on these objects:

```python
if inv_stress_conf:   # None on cache hit → False — hybrid inverter constraints SKIPPED
    self._add_hybrid_inverter_constraints(constraints_relaxed, inv_stress_conf)
if batt_stress_conf:  # None on cache hit → False — battery constraints SKIPPED
    self._add_battery_constraints(constraints_relaxed, batt_stress_conf)
```

After the first call, any LP retry runs without SOC limits, charge/discharge direction constraints, or DC-bus balance. The relaxed problem solves trivially with battery = 0 W everywhere, and that result is cached as `self.prob` — so subsequent runs return a flat zero battery schedule indefinitely.

## Reproduction

1. Set `set_use_battery: True` (or `inverter_is_hybrid: True`)
2. Trigger an optimisation that goes infeasible (tight SOC target, low-solar day, missing `inverter_ac_output_max`, etc.)
3. LP relaxation retry runs without battery constraints → battery = 0 W
4. Call optimisation again — `self.prob` is now the bad relaxed problem; returns 0 W every time until container restart

## Fix

Guard on the feature-flag config keys instead of the stress-config objects. Both `_add_battery_constraints` and `_add_hybrid_inverter_constraints` already handle a `None` stress-conf argument safely via their own internal `if batt_stress_conf and batt_stress_conf["active"]` checks.

## Impact

- **Battery users**: any system where an optimisation ever goes infeasible silently loses all battery scheduling on every subsequent run.
- **Hybrid inverter users**: the DC-bus balance constraint is missing from the relaxed problem, making the relaxed solution physically invalid.

## Summary by Sourcery

Bug Fixes:
- Prevent cached LP relaxation retries from silently omitting battery and hybrid inverter constraints by guarding on feature flags instead of stress configuration objects.