### PR TITLE
optimization: deactivate deferrables whose [start, end] is entirely outside the horizon

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -2918,6 +2918,13 @@ class Optimization:
         # Update Window Mask Parameters for Deferrable Loads
         # This allows warm-starting even when time windows change
         n = len(p_pv)
+        # Track which loads have a configured-but-empty window so we can
+        # also deactivate their binary vars and energy constraints below.
+        # An empty window means the user's [start, end] is entirely outside
+        # [0, n] — emitting binaries / energy constraints for these loads
+        # would make the MILP either infeasible (forcing the relaxed-LP
+        # fallback) or unnecessarily large.
+        window_empty_loads: set[int] = set()
         for k in range(min(num_deferrable_loads, len(self.param_window_masks))):
             # Calculate validated window bounds
             if def_total_timestep and def_total_timestep[k] > 0:
@@ -2935,12 +2942,37 @@ class Optimization:
                     n,
                 )
 
-            # Build the window mask: 0 outside window, 1 inside window
+            # Detect user-configured-but-empty window. We distinguish three
+            # cases:
+            #   (a) User explicitly configured [start, end] entirely outside
+            #       [0, n] — e.g. start=600, end=800, n=576. validate clamps
+            #       both to n, so def_end == def_start == n. Treat as empty.
+            #   (b) User left start and end at the defaults (typically both 0)
+            #       — treat as "no window restriction", mask = all-1.
+            #   (c) Valid window inside the horizon — mask = 1 inside, 0 outside.
+            raw_start = def_start_timestep[k] if k < len(def_start_timestep) else 0
+            raw_end = def_end_timestep[k] if k < len(def_end_timestep) else 0
+            user_configured_window = (raw_start > 0 or raw_end > 0) and raw_start <= raw_end
+            effective_window_size = max(0, min(n, raw_end) - max(0, raw_start))
+
+            # Build the window mask
             window_mask = np.zeros(n)
             if def_end > def_start:
+                # case (c): valid window inside horizon
                 window_mask[def_start:def_end] = 1.0
+            elif user_configured_window and effective_window_size <= 0:
+                # case (a): structurally empty window — load can never operate.
+                # Mask stays zero, and remember k so the load-active and energy
+                # constraints get deactivated too.
+                window_empty_loads.add(k)
+                self.logger.info(
+                    "Deferrable load %d: configured window [%d, %d] is entirely "
+                    "outside the optimization horizon [0, %d]; deactivating "
+                    "binary vars and energy constraint for this tick.",
+                    k, raw_start, raw_end, n,
+                )
             else:
-                # If window is invalid or full horizon, allow operation everywhere
+                # case (b): no window configured — allow operation everywhere
                 window_mask[:] = 1.0
 
             self.param_window_masks[k].value = window_mask
@@ -2989,8 +3021,12 @@ class Optimization:
                 target_energy = 0.0
                 constraint_active = False
 
-            # Set energy constraint parameters
-            if constraint_active:
+            # Set energy constraint parameters. Force-relax the constraint if
+            # the load's configured window is entirely outside the horizon
+            # (window_empty_loads, populated above) — the load can never run,
+            # so emitting a target-energy constraint would force infeasibility
+            # and trigger the relaxed-LP fallback.
+            if constraint_active and k not in window_empty_loads:
                 self.param_target_energy[k].value = target_energy
                 self.param_energy_active[k].value = 1.0  # Constraint is active
             else:
@@ -2999,7 +3035,7 @@ class Optimization:
 
             # For single-constant (binary) loads, set the required timesteps
             is_single_const = self.optim_conf["set_deferrable_load_single_constant"][k]
-            if is_single_const and constraint_active:
+            if is_single_const and constraint_active and k not in window_empty_loads:
                 self.param_required_timesteps[k].value = required_timesteps
                 self.param_timesteps_active[k].value = 1.0  # Constraint is active
             else:
@@ -3068,7 +3104,8 @@ class Optimization:
                     self.param_running_lb[k].value = np.zeros(n)
                     self.param_already_running_sc[k].value = 0.0
 
-        # Update load active parameters: deactivate non-thermal loads with 0 operating timesteps
+        # Update load active parameters: deactivate non-thermal loads with 0 operating timesteps,
+        # OR with a configured window that's entirely outside the optimization horizon.
         # Thermal loads (thermal_config, thermal_battery) are always active since they're
         # driven by temperature constraints, not operating timesteps.
         for k in range(min(num_deferrable_loads, len(self.param_load_active))):
@@ -3076,13 +3113,23 @@ class Optimization:
             has_operating_requirement = (
                 def_total_timestep and k < len(def_total_timestep) and def_total_timestep[k] > 0
             ) or (def_total_hours and k < len(def_total_hours) and def_total_hours[k] > 0)
-            if is_thermal or has_operating_requirement:
+            window_outside_horizon = k in window_empty_loads
+            if is_thermal:
+                # Thermal loads are still driven by temperature constraints
+                # even if their configured window is outside the horizon.
+                self.param_load_active[k].value = 1.0
+            elif has_operating_requirement and not window_outside_horizon:
                 self.param_load_active[k].value = 1.0
             else:
                 self.param_load_active[k].value = 0.0
-                self.logger.debug(
-                    f"Deferrable load {k}: deactivated (no operating timesteps, not thermal)"
-                )
+                if window_outside_horizon:
+                    self.logger.debug(
+                        f"Deferrable load {k}: deactivated (configured window outside horizon)"
+                    )
+                else:
+                    self.logger.debug(
+                        f"Deferrable load {k}: deactivated (no operating timesteps, not thermal)"
+                    )
 
         # Initialize stress config variables (needed by retry path even when
         # self.prob is cached from a previous call, see #770)


### PR DESCRIPTION
## Motivation

See #896 for the bug, reproducer, and impact. tl;dr: a deferrable
load whose configured `[start, end]` is outside the horizon gets a
window mask of all-1.0 (opposite of what the user asked) and stays in
the MILP as an active load, often triggering the relaxed-LP fallback.

## Change

`src/emhass/optimization.py::perform_optimization`: distinguish three
window cases in the parameter-update path:

- **(a)** User configured `[start, end]` outside `[0, n]`
  (post-clamping: `def_end == def_start == n` AND `raw_start > 0`):
  - Window mask stays all-0 (do NOT fall through to all-1)
  - `param_target_energy[k]` constraint deactivated
  - `param_required_timesteps[k]` constraint deactivated
  - `param_load_active[k] = 0` for non-thermal loads (prunes binaries
    — extends PR #744's pattern)
  - INFO log noting the deactivation so users can see why their
    load isn't scheduled
- **(b)** User left defaults — existing "allow everywhere" behaviour
- **(c)** Valid window inside horizon — existing "mask 1 inside,
  0 outside" behaviour

Thermal loads (`thermal_config`, `thermal_battery`) are kept active
even with an empty configured window because they're driven by
temperature constraints, not operating-timestep requirements — same
exception the existing thermal-load handling already makes elsewhere.

## Verification

Reproducer: 3 deferrables, one with `def_start_timestep = horizon + 24`
and `def_end_timestep = horizon + 224`.

| Metric | Before | After |
| --- | ---: | ---: |
| MPC wall (affected scenario) | ~10 s | ~0.9 s |
| Relaxed-LP fallback engaged? | yes | no |
| Load 2 scheduled to run inside horizon? | yes (wrong) | no (correct) |
| `optim_status` | `Optimal` (wrong answer) | `Optimal` (correct answer) |

Corpus replay (36 synthetic MPC payloads spanning clear day, cloudy,
evening peak, overnight, varied deferrable windows): zero tolerance
violations on all scenarios except the affected one (which is **expected
to differ** — the new schedule is the correct one).

Three case branches clearly commented inline in
`perform_optimization` so the intent is preserved for future
readers.

## Risk + rollback

- The (b) and (c) cases are unchanged
- The (a) case was previously producing incorrect schedules; the new
  behaviour matches the user's stated configuration
- Public API: unchanged
- Schema impact on `opt_res`: unchanged (a load that doesn't run just
  has zeros in its `P_deferrable_k` column)
- New config keys: none
- Rollback: revert the single commit

## References

Closes #896

Extends the binary-pruning pattern introduced in PR #744 to the
window-outside-horizon case.

## Summary by Sourcery

Deactivate deferrable loads whose configured time window lies entirely outside the optimization horizon, preventing them from contributing binaries or energy constraints and aligning the schedule with user intent.

Bug Fixes:
- Avoid scheduling deferrable loads inside the horizon when their configured [start, end] window is fully outside the optimization horizon.
- Prevent infeasibility and relaxed-LP fallback caused by emitting energy and timestep constraints for loads that can never operate within the horizon.

Enhancements:
- Log informative messages when deferrable loads are deactivated due to their configured window being outside the horizon.
- Extend existing load-activation logic to treat empty configured windows similarly to loads with no operating timesteps while preserving thermal load behavior.