### PR TITLE
fix(thermal): sense=null guard + thermal_config cooling dynamics

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -1439,10 +1439,11 @@ class Optimization:
         heating_rate = hc["heating_rate"]
         overshoot_temperature = hc.get("overshoot_temperature", None)
         sense = utils.normalize_heat_cool_mode(
-            hc.get("sense", "heat"),
+            hc.get("sense") or "heat",
             field_name="sense",
             context=f"Load {k} thermal_config",
         )
+        sense_coeff = 1 if sense == "heat" else -1
         nominal_power = self.optim_conf["nominal_power_of_deferrable_loads"][k]
 
         # Thermal Inertia Logic
@@ -1462,7 +1463,7 @@ class Optimization:
         constraints.append(
             predicted_temp[1 + L :]
             == predicted_temp[L:-1]
-            + (p_deferrable[: -1 - L] * heat_factor)
+            + (p_deferrable[: -1 - L] * sense_coeff * heat_factor)
             - (cool_factor * (predicted_temp[L:-1] - outdoor_temp[L:-1]))
         )
 
@@ -1525,7 +1526,6 @@ class Optimization:
         # Overshoot Logic
         penalty_expr = 0
         desired_temps_list = hc.get("desired_temperatures", [])
-        sense_coeff = 1 if sense == "heat" else -1
 
         if desired_temps_list and overshoot_temperature is not None:
             is_overshoot = cp.Variable(required_len, boolean=True, name=f"is_overshoot_{k}")
@@ -1649,7 +1649,7 @@ class Optimization:
 
         # Determine heat-flow direction: +1 for heating (pump adds heat), -1 for cooling (pump removes heat)
         sense = utils.normalize_heat_cool_mode(
-            hc.get("sense", "heat"),
+            hc.get("sense") or "heat",
             field_name="sense",
             context=f"Load {k} thermal_battery",
         )

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -454,7 +454,7 @@ def resolve_thermal_battery_cop(
         carnot_efficiency=hc.get("carnot_efficiency", 0.4),
         outdoor_temperature_forecast=outdoor_temperature_forecast,
         mode=normalize_heat_cool_mode(
-            hc.get("sense", "heat"),
+            hc.get("sense") or "heat",
             field_name="sense",
             context="thermal_battery",
         ),

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1122,7 +1122,7 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
                         "thermal_config": {
                             "start_temperature": 25,
                             "cooling_constant": 0.1,
-                            "heating_rate": -10,  # Negative for cooling capacity
+                            "heating_rate": 10,  # Positive; sense_coeff=-1 applied for cooling
                             "min_temperatures": [0] * 10,  # No min constraint
                             "max_temperatures": [
                                 None,
@@ -1152,6 +1152,12 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             self.optim_conf["nominal_power_of_deferrable_loads"][0]
             * pd.Series([0, 1, 0, 0, 0, 0, 0, 0, 0, 0], index=self.opt_res_dayahead.index),
             check_names=False,
+        )
+        # sense=cool + positive heating_rate must lower temperature when pump runs
+        temp = self.opt_res_dayahead["predicted_temp_heater0"]
+        assert temp.iloc[2] < temp.iloc[1], (
+            f"sense=cool + positive heating_rate must lower temperature; "
+            f"got temp[1]={temp.iloc[1]}, temp[2]={temp.iloc[2]}"
         )
 
     def test_thermal_management_penalty(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2577,6 +2577,13 @@ class TestResolveThermalBatteryCop(unittest.TestCase):
         self.assertIn("thermal_battery", str(ctx.exception))
         self.assertIn("invalid sense", str(ctx.exception))
 
+    def test_sense_null_falls_back_to_heat(self):
+        outdoor = np.array([0.0, 5.0])
+        expected = utils.calculate_cop_heatpump(35.0, 0.4, outdoor, mode="heat")
+        hc = {"sense": None, "supply_temperature": 35.0}
+        cops = utils.resolve_thermal_battery_cop(hc, outdoor, length=2)
+        np.testing.assert_array_almost_equal(cops, expected)
+
     def test_missing_both_efficiency_and_supply_temperature_raises(self):
         """At least one of efficiency or supply_temperature must be set."""
         hc = {"carnot_efficiency": 0.4}


### PR DESCRIPTION
Fixes #898.

Two post-merge fixes for the cooling support @mime24 added in #888.

**C2 — `sense: null` crashes with `ValueError`**

`hc.get("sense", "heat")` returns `None` when the key is present but null — the default only fires when the key is absent. `normalize_heat_cool_mode(None)` coerces to `"none"`, which is not in `{"heat", "cool"}`:

```
ValueError: thermal_battery: invalid sense 'None'. Expected 'heat' or 'cool'.
```

Replace `hc.get("sense", "heat")` with `hc.get("sense") or "heat"` at all three call sites (`utils.py:456`, `optimization.py:1441`, `optimization.py:1651`). Same fallback approach as #878 / #879.

**C1 — `sense=cool` + positive `heating_rate` warms instead of cools**

`sense_coeff` was computed inside the penalty block of `_add_thermal_load_constraints` but never applied to the temperature-dynamics constraint:

```python
# before
+ (p_deferrable[:-1-L] * heat_factor)   # sense_coeff absent
```

A user who sets `sense: cool` with a positive `heating_rate` (the natural way to express cooling capacity) sees their space warmed. `_add_thermal_battery_constraints` in the same file handles this correctly with `sense_coeff * q_input`. Moving `sense_coeff` up and applying it to the dynamics fixes it:

```python
# after
+ (p_deferrable[:-1-L] * sense_coeff * heat_factor)
```

### Tests

- `test_sense_null_falls_back_to_heat`: `{"sense": None, ...}` must not raise; COP must match `mode="heat"`. Fails pre-fix, passes post-fix.
- `test_thermal_management_cooling`: `heating_rate` changed from `-10` to `+10`. The negative value was a workaround that masked the bug (`-1 * 10 = -10` happened to match what the fix now makes explicit). Added an assertion that temperature decreases at the step where the pump runs. Infeasible pre-fix, passes post-fix.

`test_heatpump_mode_invalid_sense_raises` is unchanged; invalid strings still raise. `None` is a fall-back, not an error.

### AGENTS.md

§5 verify-before-done (teeth check on both fixes), §6 surgical (3 call sites + 1 dynamics line + two test files), §7 commit prefix `fix`.

Fix invited by @mime24 in the #888 thread.

## Summary by Sourcery

Fix thermal load and battery handling for cooling mode and nullable sense configuration, and extend tests to cover these behaviors.

Bug Fixes:
- Prevent crashes when thermal configuration uses a null sense by falling back to heat mode consistently.
- Ensure cooling-mode thermal load dynamics correctly reduce temperature when using a positive heating_rate.

Tests:
- Extend thermal management cooling test to assert temperature decreases when the pump runs with cooling configured via sense.
- Add a unit test verifying that a null sense falls back to heat behavior in thermal battery COP resolution.