### PR TITLE
style: ruff-format logger call in optimization.py (#902)

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -2993,7 +2993,10 @@ class Optimization:
                     "Deferrable load %d: configured window [%d, %d] is entirely "
                     "outside the optimization horizon [0, %d]; deactivating "
                     "binary vars and energy constraint for this tick.",
-                    k, raw_start, raw_end, n,
+                    k,
+                    raw_start,
+                    raw_end,
+                    n,
                 )
             else:
                 # case (b): no window configured — allow operation everywhere


### PR DESCRIPTION
## What

Commit `eea5d25` (merged via #897) left a logger call in `src/emhass/optimization.py` near line 2993 with its arguments on one line, which `ruff format` rejects. The Code Quality Scan (`Check formatting`) has failed on `master` ever since, and that red check shows up on the CI of every open PR.

This runs `ruff format src/emhass/optimization.py`, which splits the logger arguments across lines. Formatting only, no logic change.

## Why

AGENTS.md requires code to pass `ruff format` before merge. This gets the Code Quality Scan back to green on `master` and clears the formatting check on open PRs.

Fixes #902.

## Summary by Sourcery

Reformat a logger warning call in optimization.py to comply with ruff formatting without changing behavior.

Enhancements:
- Adjust logger call argument layout in optimization.py to satisfy ruff-format style requirements.

CI:
- Unblock failing formatting check on master by resolving ruff-format violation in optimization.py.