### PR TITLE
fix: resolve llms.txt links via html_baseurl (#884)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # a list of builtin themes.
 #
 html_theme = "pydata_sphinx_theme"
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 html_theme_options = {
     "show_toc_level": 2,


### PR DESCRIPTION
## Problem
All links in the generated `llms.txt` (https://emhass.readthedocs.io/llms.txt) return 404.

## Root cause
`llms.txt` is generated by the `sphinx_llms_txt` extension, which builds source links as
`{html_baseurl}_sources/<doc>.md.txt`. With `html_baseurl` unset it defaults to `/`, so
links are root-absolute (`/_sources/intro.md.txt`). Read the Docs serves the docs under a
version prefix (`/en/latest/`), so those root paths 404 — the real files live at
`/en/latest/_sources/...`.

## Fix
Set `html_baseurl` from the Read the Docs canonical-URL env var in `docs/conf.py`:

```python
html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
```

On RTD builds `READTHEDOCS_CANONICAL_URL` resolves to e.g.
`https://emhass.readthedocs.io/en/latest/`, so the generated links become full absolute
URLs that resolve from any path (including the root-served `/llms.txt`). Local builds keep
the prior relative behaviour (no env var → `""` → `"/"` via the extension's trailing-slash
guard), so there is no regression. `html_baseurl` is also the idiomatic Sphinx setting for
canonical link tags and sitemaps.

## Verification
Full docs build not feasible locally (Python 3.14, emhass requires <3.13). Verified via
extension source: `sphinx_llms_txt/writer.py` line 138 reads
`base_url = self.config.get("html_baseurl", "/")` and line 54 uses it as
`"{base_url}_sources/{docname}..."`. With the fix, RTD env var supplies the full prefix;
without it, `""` normalises to `"/"` via the trailing-slash guard — identical to prior
unset behaviour.

Fixes #884.

## Summary by Sourcery

Documentation:
- Set the Sphinx html_baseurl from the READTHEDOCS_CANONICAL_URL environment variable to produce correct absolute links in generated documentation artifacts like llms.txt.