### PR TITLE
optimization: parameterise battery_*_power_max for cache stability

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -254,6 +254,8 @@ class OptimizationCache:
         plant_runtime_keys = {
             "soc_init",
             "battery_target_state_of_charge",
+            "battery_charge_power_max",
+            "battery_discharge_power_max",
         }
         # Optim conf parameters that don't affect problem structure
         # (parameterized via CVXPY Parameters, solver options, or forecast method selection)
@@ -1181,6 +1183,10 @@ async def set_input_data_dict(
                 # Update CVXPY Parameters for thermal start temperatures
                 # This is critical: updating optim_conf alone doesn't change baked-in constraint values
                 opt.update_thermal_start_temps(optim_conf)
+                # Same idea for battery power limits — they participate in
+                # constraints via cp.Parameter and need the runtime value
+                # propagated even on a cache hit.
+                opt.update_battery_power_limits(plant_conf)
             # Update runtime-configurable solver options from optim_conf
             # These don't affect problem structure, so they're safe to update on cached object
             runtime_solver_opts = [

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -159,6 +159,21 @@ class Optimization:
         self.param_soc_init = cp.Parameter(nonneg=True, name="soc_init")
         self.param_soc_final = cp.Parameter(nonneg=True, name="soc_final")
 
+        # Battery power limits — parameterised so SoC-derated values arriving
+        # via runtimeparams update without invalidating the OptimizationCache.
+        self.param_battery_charge_power_max = cp.Parameter(
+            nonneg=True, name="battery_charge_power_max"
+        )
+        self.param_battery_discharge_power_max = cp.Parameter(
+            nonneg=True, name="battery_discharge_power_max"
+        )
+        self.param_battery_charge_power_max.value = float(
+            plant_conf.get("battery_charge_power_max", 0)
+        )
+        self.param_battery_discharge_power_max.value = float(
+            plant_conf.get("battery_discharge_power_max", 0)
+        )
+
         # SOC recovery parameters
         self._init_soc_recovery_params()
 
@@ -469,6 +484,23 @@ class Optimization:
                     f"Invalid def_current_state value at index {k}: {state!r}. "
                     "Expected one of {{True, False, 0, 1, 0.0, 1.0}}."
                 )
+
+    def update_battery_power_limits(self, plant_conf: dict) -> None:
+        """
+        Update battery charge/discharge power-limit Parameters from plant_conf.
+
+        Called on cache hit to sync runtime power-limit values without
+        rebuilding constraints. Mirrors update_thermal_start_temps.
+
+        :param plant_conf: The plant configuration containing
+            battery_charge_power_max / battery_discharge_power_max
+        """
+        new_charge_max = float(plant_conf.get("battery_charge_power_max", 0) or 0)
+        new_discharge_max = float(plant_conf.get("battery_discharge_power_max", 0) or 0)
+        if self.param_battery_charge_power_max.value != new_charge_max:
+            self.param_battery_charge_power_max.value = new_charge_max
+        if self.param_battery_discharge_power_max.value != new_discharge_max:
+            self.param_battery_discharge_power_max.value = new_discharge_max
 
     def update_thermal_start_temps(self, optim_conf: dict) -> None:
         """
@@ -851,14 +883,10 @@ class Optimization:
         # Battery power variables
         if self.optim_conf["set_use_battery"]:
             vars_dict["p_sto_pos"] = cp.Variable(n, nonneg=True, name="p_sto_pos")
-            constraints.append(
-                vars_dict["p_sto_pos"] <= self.plant_conf["battery_discharge_power_max"]
-            )
+            constraints.append(vars_dict["p_sto_pos"] <= self.param_battery_discharge_power_max)
 
             vars_dict["p_sto_neg"] = cp.Variable(n, nonpos=True, name="p_sto_neg")
-            constraints.append(
-                vars_dict["p_sto_neg"] >= -np.abs(self.plant_conf["battery_charge_power_max"])
-            )
+            constraints.append(vars_dict["p_sto_neg"] >= -self.param_battery_charge_power_max)
             vars_dict["soc_low_recovered"] = cp.Variable(n, boolean=True, name="soc_low_recovered")
             vars_dict["soc_high_recovered"] = cp.Variable(
                 n, boolean=True, name="soc_high_recovered"
@@ -1243,8 +1271,8 @@ class Optimization:
         cap = self.plant_conf["battery_nominal_energy_capacity"]
         eff_dis = self.plant_conf["battery_discharge_efficiency"]
         eff_chg = self.plant_conf["battery_charge_efficiency"]
-        max_dis = self.plant_conf["battery_discharge_power_max"]
-        max_chg = self.plant_conf["battery_charge_power_max"]  # This is usually positive in config
+        max_dis = self.param_battery_discharge_power_max
+        max_chg = self.param_battery_charge_power_max  # nonneg cp.Parameter
         soc_low_recovered = self.vars["soc_low_recovered"]
         soc_high_recovered = self.vars["soc_high_recovered"]
         min_energy = self.plant_conf["battery_minimum_state_of_charge"] * cap
@@ -2924,6 +2952,12 @@ class Optimization:
         if self.optim_conf["set_use_battery"]:
             self.param_soc_init.value = soc_init
             self.param_soc_final.value = soc_final
+            self.param_battery_charge_power_max.value = float(
+                self.plant_conf["battery_charge_power_max"]
+            )
+            self.param_battery_discharge_power_max.value = float(
+                self.plant_conf["battery_discharge_power_max"]
+            )
             low_gap_wh = max(
                 0.0,
                 (self.plant_conf["battery_minimum_state_of_charge"] - soc_init)
@@ -3171,6 +3205,9 @@ class Optimization:
             constraints = self.constraints[:]
 
             if self.optim_conf["set_use_battery"]:
+                # Raw plant_conf read: stress cost is gated on battery_stress_cost>0
+                # (off by default) and the value is only used to size PWL segments
+                # at build time, so runtime parameterisation isn't needed here.
                 p_batt_max = max(
                     self.plant_conf.get("battery_discharge_power_max", 0),
                     self.plant_conf.get("battery_charge_power_max", 0),

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -4007,8 +4007,13 @@ class TestOptimizationCacheIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(opt_2.param_def_current_state[0].value, 1.0)
         self.assertEqual(opt_2.param_def_current_state[1].value, 0.0)
 
-    async def test_cache_miss_on_battery_power_limit_change(self):
-        """Test that changing battery_discharge_power_max causes cache MISS (via plant_conf_hash)."""
+    async def test_cache_hit_on_battery_power_limit_change(self):
+        """Test that changing battery_discharge_power_max keeps cache HIT.
+
+        Both battery power limits live in plant_runtime_keys and are wired
+        through to cp.Parameters whose .value is updated per solve, so a
+        change shouldn't invalidate the cached Optimization instance.
+        """
         base_rt = {
             "pv_power_forecast": [100 * (i + 1) for i in range(10)],
             "load_power_forecast": [200] * 10,
@@ -4022,7 +4027,9 @@ class TestOptimizationCacheIntegration(unittest.IsolatedAsyncioTestCase):
         opt_1 = (await self._run_set_input(base_rt))["opt"]
         opt_2 = (await self._run_set_input({**base_rt, "battery_discharge_power_max": 9999}))["opt"]
 
-        self.assertIsNot(opt_1, opt_2, "battery_discharge_power_max change must cause cache MISS")
+        self.assertIs(opt_1, opt_2, "battery_discharge_power_max change must keep cache HIT")
+        # And the new value has been propagated to the CVXPY Parameter
+        self.assertAlmostEqual(float(opt_2.param_battery_discharge_power_max.value), 9999.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

See #908 for context. Briefly: `battery_charge_power_max` and
`battery_discharge_power_max` are passed in `runtimeparams` from MPC
callers and may legitimately vary tick-to-tick (BMS-derated values
near a SoC rail). They currently participate in `plant_conf_hash` and
force a full CVXPY rebuild on every change, even though they're not
structural — only scalar coefficients on constraint RHS.

## Change

Two related fixes mirroring the existing `param_soc_init` pattern.

`src/emhass/optimization.py`:

1. Add `param_battery_charge_power_max` and
   `param_battery_discharge_power_max` as `cp.Parameter(nonneg=True)`
   in `Optimization.__init__` (~line 159, beside the existing
   `param_soc_init` / `param_soc_final`), initialised from
   `plant_conf`.

2. Replace raw `self.plant_conf["battery_*_power_max"]` dict lookups
   in active battery constraints with the new parameter references
   (`p_sto_pos <= …discharge_power_max`, `p_sto_neg >= -…charge_power_max`,
   and the `max_dis` / `max_chg` Big-M coefficients in the
   `set_optim_problem_with_battery` path).

3. Assign `.value` per solve at the same spot
   `param_soc_init.value` is already updated.

The stress-cost path is intentionally left as a raw dict lookup with
an inline comment — gated on `battery_stress_cost > 0` (unset in
default configs), only used to size PWL segments at build time.

`src/emhass/command_line.py`:

4. Add both keys to `plant_runtime_keys` (the set introduced in #893
   for `soc_init` and `battery_target_state_of_charge`).

## Risk + rollback

- All four changes are additive (new parameters, new set-element
  entries; no removals or renames)
- Public API: unchanged
- Schema impact on `opt_res`: unchanged — identical optimization
  output for identical inputs
- New config keys: none
- Existing cache-hit branch already reassigns `opt.plant_conf`, so the
  `.value` write at solve time picks up the new value without a new
  sync method
- Rollback: revert the single commit
- Reasoning preserved in code comments inline with the changes

Closes #908.

## Summary by Sourcery

Parameterize battery power limit configuration values as CVXPY runtime parameters to improve optimization cache stability when these limits change tick-to-tick.

Enhancements:
- Introduce CVXPY parameters for battery charge and discharge power limits and wire them into battery power and Big-M constraints instead of reading static config values.
- Update per-solve logic to refresh battery power limit parameter values from the current plant configuration.
- Expand the set of runtime-only plant configuration keys in the command-line tooling to include the battery power limit fields so they no longer influence the optimization cache key.