### PR TITLE
fix: deferrable single-constant pin firing on stringly-typed def_current_state (#873)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+LOCATION.md
 # ---> Python
 test.py
 # Legacy config yaml file

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1686,6 +1686,7 @@ async def treat_runtimeparams(
         # Define Helper Functions
         def _cast_bool(value):
             """Helper to cast string inputs to boolean safely."""
+            # ast.literal_eval('None') returns None without raising — explicit guard needed.
             if value is None:
                 return False
             try:

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1847,11 +1847,24 @@ async def treat_runtimeparams(
                     dcs = orjson.loads(dcs)
                 except Exception:
                     logger.warning(f"Could not parse def_current_state string: {dcs}")
-            # Check it's iterable before casting to bool
+            # Use _cast_bool (not bool()) so string 'False' → False, not True.
+            # bool('False') = True because non-empty strings are truthy in Python.
             if isinstance(dcs, list):
-                params["optim_conf"]["def_current_state"] = [bool(s) for s in dcs]
+                params["optim_conf"]["def_current_state"] = [_cast_bool(s) for s in dcs]
             else:
-                params["optim_conf"]["def_current_state"] = [bool(dcs)]
+                params["optim_conf"]["def_current_state"] = [_cast_bool(dcs)]
+
+        # set_deferrable_load_single_constant arrives via the generic associations.csv
+        # path as-is (may be a list of strings from runtimeparams JSON).  Apply the
+        # same _cast_bool coercion so 'False' → False, not True (#873, mirrors #876).
+        if "set_deferrable_load_single_constant" in runtimeparams.keys():
+            sdlsc = runtimeparams["set_deferrable_load_single_constant"]
+            if isinstance(sdlsc, list):
+                params["optim_conf"]["set_deferrable_load_single_constant"] = [
+                    _cast_bool(s) for s in sdlsc
+                ]
+            else:
+                params["optim_conf"]["set_deferrable_load_single_constant"] = [_cast_bool(sdlsc)]
 
         # Treat retrieve data from Home Assistant (retrieve_hass_conf) configuration parameters passed at runtime
         # Secrets passed at runtime

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1855,7 +1855,8 @@ async def treat_runtimeparams(
             if isinstance(dcs, list):
                 params["optim_conf"]["def_current_state"] = [_cast_bool(s) for s in dcs]
             else:
-                params["optim_conf"]["def_current_state"] = [_cast_bool(dcs)]
+                n_loads = len(params["optim_conf"]["nominal_power_of_deferrable_loads"])
+                params["optim_conf"]["def_current_state"] = [_cast_bool(dcs)] * n_loads
 
         # set_deferrable_load_single_constant arrives via the generic associations.csv
         # path as-is (may be a list of strings from runtimeparams JSON).  Apply the
@@ -1867,7 +1868,10 @@ async def treat_runtimeparams(
                     _cast_bool(s) for s in sdlsc
                 ]
             else:
-                params["optim_conf"]["set_deferrable_load_single_constant"] = [_cast_bool(sdlsc)]
+                n_loads = len(params["optim_conf"]["nominal_power_of_deferrable_loads"])
+                params["optim_conf"]["set_deferrable_load_single_constant"] = [
+                    _cast_bool(sdlsc)
+                ] * n_loads
 
         # Treat retrieve data from Home Assistant (retrieve_hass_conf) configuration parameters passed at runtime
         # Secrets passed at runtime

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1686,6 +1686,8 @@ async def treat_runtimeparams(
         # Define Helper Functions
         def _cast_bool(value):
             """Helper to cast string inputs to boolean safely."""
+            if value is None:
+                return False
             try:
                 return ast.literal_eval(str(value).capitalize())
             except (ValueError, SyntaxError):

--- a/tests/test_config_value_resilience.py
+++ b/tests/test_config_value_resilience.py
@@ -1,23 +1,14 @@
 """
-Parametrised resilience tests: stringly-typed and null config values.
+Resilience tests: stringly-typed config values, null inputs, and mask-builder edge cases.
 
-Extends the #882 prevention suite with runtime-path coverage: for every
-per-load-array parameter derived from param_definitions.json, inject bad
-runtime values (scalar "null", None element, string element) via
-treat_runtimeparams and assert the optimizer survives without raising.
+Parametrised suite (#901): for every optim_conf array parameter, inject bad runtime
+values (scalar null, None element, string element) via treat_runtimeparams and assert
+the optimizer survives without raising.  Guarded params MUST pass; unguarded bugs are
+xfail(strict=True).
 
-Design:
-- Param inventory loaded from param_definitions.json at collection time, so
-  future array-typed params are covered automatically without editing this file.
-- Only optim_conf params are exercised (associations.csv used to determine
-  category); retrieve_hass_conf / plant_conf params aren't accessed during
-  perform_optimization with defaults.
-- Guarded params (cost_forecast_per_deferrable_load) MUST pass — these lock
-  in the shipped fix as a class-level regression guard.
-- Unguarded bugs are xfail(strict=True): CI stays green, the gap is visible,
-  and the test flips to a live regression guard when the fix lands.
-
-AGENTS.md: test-only PR, no prod changes. Follows Section 7 commit convention.
+Specific regression guards (#873): def_current_state stringly-typed 'False' must not
+fire the single-constant pin; None elements must coerce to False; windows outside the
+horizon must deactivate the load.
 """
 
 import asyncio
@@ -44,6 +35,7 @@ logger, _ = utils.get_logger(__name__, emhass_conf, save_to_file=False)
 
 _VAR_LOAD_COST = "unit_load_cost"
 _VAR_PROD_PRICE = "unit_prod_price"
+
 
 # ─────────────────────────── param inventory ────────────────────────────────
 
@@ -161,7 +153,8 @@ async def _build_default_params() -> str:
 _PARAMS_JSON: str = asyncio.run(_build_default_params())
 _RHCONF, _OPTCONF, _PCONF = utils.get_yaml_parse(_PARAMS_JSON, logger)
 
-# ─────────────────────── parametrised resilience tests ──────────────────────
+
+# ─────────────────────────────── helpers ────────────────────────────────────
 
 
 def _make_forecast_inputs(rh_conf: dict, n: int = 48):
@@ -172,6 +165,41 @@ def _make_forecast_inputs(rh_conf: dict, n: int = 48):
     upp = np.full(n, 0.1)
     df = pd.DataFrame({_VAR_LOAD_COST: ulc, _VAR_PROD_PRICE: upp}, index=idx)
     return df, np.zeros(n), np.full(n, 1000.0), ulc, upp
+
+
+def _treat(rp_dict: dict):
+    """Run treat_runtimeparams with the given runtimeparams dict synchronously."""
+    rp_json = orjson.dumps(rp_dict).decode("utf-8")
+
+    async def _run():
+        return await utils.treat_runtimeparams(
+            rp_json,
+            _PARAMS_JSON,
+            _RHCONF,
+            _OPTCONF,
+            _PCONF,
+            "dayahead-optim",
+            logger,
+            emhass_conf,
+        )
+
+    return asyncio.run(_run())
+
+
+def _make_opt(rh_conf, opt_conf, pl_conf):
+    return Optimization(
+        rh_conf,
+        opt_conf,
+        pl_conf,
+        _VAR_LOAD_COST,
+        _VAR_PROD_PRICE,
+        "profit",
+        emhass_conf,
+        logger,
+    )
+
+
+# ─────────────────── parametrised resilience tests (#901) ───────────────────
 
 
 @pytest.mark.parametrize("param_name,bad_value", _CASES)
@@ -210,3 +238,90 @@ def test_stringly_typed_resilience(param_name: str, bad_value: object):
         logger,
     )
     opt.perform_optimization(df, p_pv, p_load, ulc, upp)
+
+
+# ── Test A: single-shot string-bool regression ───────────────────────────────
+
+
+def test_def_current_state_stringly_false_does_not_pin_window_open():
+    """A stringly-typed 'False' in def_current_state must NOT fire the pin.
+
+    Before the fix: bool('False') = True → pin sets lb_mask[:required_steps] = 1
+    → single-constant load starts at t=0 ignoring start_timesteps.
+    After the fix: _cast_bool('False') = False → no pin → window respected.
+    """
+    rp = {
+        # 2 loads (match default num_def_loads=2)
+        "nominal_power_of_deferrable_loads": [3000, 700],
+        "operating_hours_of_each_deferrable_load": [2, 1],
+        "start_timesteps_of_each_deferrable_load": [10, 0],
+        "end_timesteps_of_each_deferrable_load": [40, 0],
+        "set_deferrable_load_single_constant": ["True", "False"],
+        "treat_deferrable_load_as_semi_cont": [False, True],
+        # BUG TRIGGER: stringly-typed 'False' — bool('False') = True in Python
+        "def_current_state": ["False", "False"],
+    }
+
+    _, rh_conf, opt_conf, pl_conf = _treat(rp)
+
+    n = 48
+    df, p_pv, p_load, ulc, upp = _make_forecast_inputs(rh_conf, n)
+    opt = _make_opt(rh_conf, opt_conf, pl_conf)
+    res = opt.perform_optimization(df, p_pv, p_load, ulc, upp)
+
+    p_def0 = res["P_deferrable0"].values
+    pre_window_sum = p_def0[:10].sum()
+    assert pre_window_sum == 0, (
+        f"Load 0 must not run before its configured window (slot 10); "
+        f"pre-window power sum = {pre_window_sum:.1f} W "
+        f"(non-zero means spurious pin fired due to stringly-typed def_current_state)"
+    )
+
+
+# ── Test B: MPC rolling keystone ─────────────────────────────────────────────
+
+
+def test_def_current_state_stringly_false_no_spurious_pin_across_mpc_ticks():
+    """MPC rolling: stringly 'False' must not command load ON before the window start.
+
+    Simulates 3 consecutive MPC ticks (advancing start_timesteps by 1 each tick).
+    At each tick the first-slot result is the actual MPC command. If the pin fires
+    spuriously, the load is commanded ON immediately; the loop checks all 3 ticks.
+
+    This is the keystone test: a single-shot (Test A) might pass if the full-horizon
+    optimizer happens not to start the load at slot 0, but MPC's per-tick command is
+    unambiguous — slot 0 must be zero when the window hasn't opened yet.
+    """
+    for tick in range(3):
+        start_ts = 10 - tick  # window start approaches by 1 slot each tick
+        end_ts = 40 - tick
+
+        rp = {
+            "nominal_power_of_deferrable_loads": [3000, 700],
+            "operating_hours_of_each_deferrable_load": [2, 1],
+            "start_timesteps_of_each_deferrable_load": [start_ts, 0],
+            "end_timesteps_of_each_deferrable_load": [end_ts, 0],
+            "set_deferrable_load_single_constant": ["True", "False"],
+            "treat_deferrable_load_as_semi_cont": [False, True],
+            # Stringly-typed 'False' remains the same across ticks (not driven True)
+            "def_current_state": ["False", "False"],
+        }
+
+        _, rh_conf, opt_conf, pl_conf = _treat(rp)
+
+        # MPC state stays 'False' (no spurious start should have occurred)
+        assert opt_conf["def_current_state"][0] is False, (
+            f"Tick {tick}: def_current_state[0] should be False after coercion; "
+            f"got {opt_conf['def_current_state'][0]!r}"
+        )
+
+        n = 48
+        df, p_pv, p_load, ulc, upp = _make_forecast_inputs(rh_conf, n)
+        opt = _make_opt(rh_conf, opt_conf, pl_conf)
+        res = opt.perform_optimization(df, p_pv, p_load, ulc, upp)
+
+        current_tick_cmd = res["P_deferrable0"].values[0]
+        assert current_tick_cmd == 0, (
+            f"Tick {tick}: MPC current-slot command must be 0 "
+            f"(window starts at slot {start_ts}); got {current_tick_cmd:.1f} W"
+        )

--- a/tests/test_config_value_resilience.py
+++ b/tests/test_config_value_resilience.py
@@ -361,6 +361,30 @@ def test_def_current_state_null_elements_do_not_crash_optimizer():
     opt.perform_optimization(df, p_pv, p_load, ulc, upp)
 
 
+# ── Test E: scalar runtimeparams coercion ────────────────────────────────────
+
+
+def test_scalar_runtimeparams_coerce_to_bool():
+    """Scalar (non-list) def_current_state and set_deferrable_load_single_constant
+    values must coerce correctly — covers the else-branches in the handlers."""
+    rp = {
+        "nominal_power_of_deferrable_loads": [3000, 700],
+        "operating_hours_of_each_deferrable_load": [2, 1],
+        "start_timesteps_of_each_deferrable_load": [0, 0],
+        "end_timesteps_of_each_deferrable_load": [0, 0],
+        # Scalar bool (not list) — hits the else-branch in each handler
+        "def_current_state": False,
+        "set_deferrable_load_single_constant": False,
+    }
+    _, _, opt_conf, _ = _treat(rp)
+    assert opt_conf["def_current_state"] == [False], (
+        f"Scalar 'False' must coerce to [False]; got {opt_conf['def_current_state']!r}"
+    )
+    assert opt_conf["set_deferrable_load_single_constant"] == [False], (
+        f"Scalar 'False' must coerce to [False]; got {opt_conf['set_deferrable_load_single_constant']!r}"
+    )
+
+
 # ── Test C: horizon-outside-window regression guard ──────────────────────────
 
 

--- a/tests/test_config_value_resilience.py
+++ b/tests/test_config_value_resilience.py
@@ -19,7 +19,6 @@ import pathlib
 import numpy as np
 import orjson
 import pandas as pd
-import pytest
 
 from emhass import utils
 from emhass.optimization import Optimization
@@ -325,6 +324,41 @@ def test_def_current_state_stringly_false_no_spurious_pin_across_mpc_ticks():
             f"Tick {tick}: MPC current-slot command must be 0 "
             f"(window starts at slot {start_ts}); got {current_tick_cmd:.1f} W"
         )
+
+
+# ── Test D: null def_current_state coercion ──────────────────────────────────
+
+
+def test_def_current_state_null_elements_do_not_crash_optimizer():
+    """def_current_state arriving as [None, None] (HA JSON null) must coerce to
+    [False, False], not [None, None].
+
+    _cast_bool(None): str(None).capitalize() = 'None'; ast.literal_eval('None')
+    returns Python None (not an exception) → no fallback → None propagates.
+    Consumer _update_def_current_state_params (optimization.py:461-469) has an
+    explicit isinstance(state, bool|int|float) guard; None hits the else branch
+    and raises ValueError → optimization crash.
+    """
+    rp = {
+        "nominal_power_of_deferrable_loads": [3000, 700],
+        "operating_hours_of_each_deferrable_load": [2, 1],
+        "start_timesteps_of_each_deferrable_load": [10, 0],
+        "end_timesteps_of_each_deferrable_load": [40, 0],
+        "set_deferrable_load_single_constant": ["True", "False"],
+        "treat_deferrable_load_as_semi_cont": [False, True],
+        "def_current_state": [None, None],
+    }
+    _, rh_conf, opt_conf, pl_conf = _treat(rp)
+
+    assert opt_conf["def_current_state"] == [False, False], (
+        f"None must coerce to False; got {opt_conf['def_current_state']!r}"
+    )
+
+    # Full round-trip: optimizer must not raise ValueError on None state.
+    n = 48
+    df, p_pv, p_load, ulc, upp = _make_forecast_inputs(rh_conf, n)
+    opt = _make_opt(rh_conf, opt_conf, pl_conf)
+    opt.perform_optimization(df, p_pv, p_load, ulc, upp)
 
 
 # ── Test C: horizon-outside-window regression guard ──────────────────────────

--- a/tests/test_config_value_resilience.py
+++ b/tests/test_config_value_resilience.py
@@ -19,6 +19,7 @@ import pathlib
 import numpy as np
 import orjson
 import pandas as pd
+import pytest
 
 from emhass import utils
 from emhass.optimization import Optimization
@@ -366,7 +367,7 @@ def test_def_current_state_null_elements_do_not_crash_optimizer():
 
 def test_scalar_runtimeparams_coerce_to_bool():
     """Scalar (non-list) def_current_state and set_deferrable_load_single_constant
-    values must coerce correctly — covers the else-branches in the handlers."""
+    must coerce correctly and pad to num_def_loads — covers the else-branches."""
     rp = {
         "nominal_power_of_deferrable_loads": [3000, 700],
         "operating_hours_of_each_deferrable_load": [2, 1],
@@ -377,11 +378,12 @@ def test_scalar_runtimeparams_coerce_to_bool():
         "set_deferrable_load_single_constant": False,
     }
     _, _, opt_conf, _ = _treat(rp)
-    assert opt_conf["def_current_state"] == [False], (
-        f"Scalar 'False' must coerce to [False]; got {opt_conf['def_current_state']!r}"
+    assert opt_conf["def_current_state"] == [False, False], (
+        f"Scalar False must pad to [False, False] for 2 loads; got {opt_conf['def_current_state']!r}"
     )
-    assert opt_conf["set_deferrable_load_single_constant"] == [False], (
-        f"Scalar 'False' must coerce to [False]; got {opt_conf['set_deferrable_load_single_constant']!r}"
+    assert opt_conf["set_deferrable_load_single_constant"] == [False, False], (
+        f"Scalar False must pad to [False, False] for 2 loads; "
+        f"got {opt_conf['set_deferrable_load_single_constant']!r}"
     )
 
 

--- a/tests/test_config_value_resilience.py
+++ b/tests/test_config_value_resilience.py
@@ -325,3 +325,42 @@ def test_def_current_state_stringly_false_no_spurious_pin_across_mpc_ticks():
             f"Tick {tick}: MPC current-slot command must be 0 "
             f"(window starts at slot {start_ts}); got {current_tick_cmd:.1f} W"
         )
+
+
+# ── Test C: horizon-outside-window regression guard ──────────────────────────
+
+
+def test_window_entirely_outside_horizon_zeros_mask():
+    """A window configured entirely outside the optimization horizon must deactivate the load.
+
+    Regression guard for the fix merged in commit eea5d25 (upstream/master, May 27 2026):
+    when start_timesteps and end_timesteps both exceed n, window_mask must stay zero
+    (load cannot run this tick), NOT open the whole horizon.
+
+    This test is intentionally GREEN on current master; it locks in the correct behavior
+    that replaced the former `window_mask[:] = 1.0` fallback.
+    """
+    rp = {
+        "nominal_power_of_deferrable_loads": [3000, 700],
+        "operating_hours_of_each_deferrable_load": [2, 1],
+        # Both loads: window far outside the 48-slot horizon
+        "start_timesteps_of_each_deferrable_load": [200, 200],
+        "end_timesteps_of_each_deferrable_load": [220, 220],
+        "set_deferrable_load_single_constant": [False, False],
+        "treat_deferrable_load_as_semi_cont": [False, True],
+        "def_current_state": [False, False],
+    }
+
+    _, rh_conf, opt_conf, pl_conf = _treat(rp)
+
+    n = 48
+    df, p_pv, p_load, ulc, upp = _make_forecast_inputs(rh_conf, n)
+    opt = _make_opt(rh_conf, opt_conf, pl_conf)
+    res = opt.perform_optimization(df, p_pv, p_load, ulc, upp)
+
+    p_def0_total = res["P_deferrable0"].values.sum()
+    assert p_def0_total == 0, (
+        f"Load 0 must not run anywhere when its window [{rp['start_timesteps_of_each_deferrable_load'][0]}, "
+        f"{rp['end_timesteps_of_each_deferrable_load'][0]}] is outside the "
+        f"horizon [0, {n}]; got total power = {p_def0_total:.1f} W"
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1396,6 +1396,36 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(optim_conf_out["number_of_deferrable_loads"], 1)
         self.assertEqual(len(optim_conf_out["def_load_config"]), 1)
 
+    async def test_treat_runtimeparams_bool_coercion(self):
+        """_cast_bool None-guard and scalar-padding paths must be covered.
+
+        def_current_state=None hits `if value is None` in _cast_bool and the
+        scalar else-branch (padded to n_loads).  set_deferrable_load_single_constant
+        with a scalar bool hits its scalar else-branch identically.
+        """
+        params = await TestUtils.get_test_params()
+        params_json = orjson.dumps(params).decode("utf-8")
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+        runtimeparams_json = orjson.dumps(
+            {
+                "def_current_state": None,
+                "set_deferrable_load_single_constant": False,
+            }
+        ).decode("utf-8")
+        _, _, optim_conf_out, _ = await utils.treat_runtimeparams(
+            runtimeparams_json,
+            params_json,
+            retrieve_hass_conf,
+            optim_conf,
+            plant_conf,
+            "dayahead-optim",
+            logger,
+            emhass_conf,
+        )
+        n = len(optim_conf_out["nominal_power_of_deferrable_loads"])
+        self.assertEqual(optim_conf_out["def_current_state"], [False] * n)
+        self.assertEqual(optim_conf_out["set_deferrable_load_single_constant"], [False] * n)
+
     def test_param_to_config(self):
         """Test converting built params back to a flat config dictionary and masking secrets."""
         # Create a mock parameter dictionary with the required categories


### PR DESCRIPTION
## Problem
Since v0.17.3, single-constant deferrable loads with a future window are scheduled to start at t=0 instead of respecting `start_timesteps_of_each_deferrable_load`. Reported by @RikBast; confirmed across v0.17.3 / v0.17.4 / v0.17.5 with `prediction_horizon=192`, `start_timesteps=37`, `end_timesteps=57` (window fully inside horizon, so horizon-overflow is not the cause).

## Root cause
`def_current_state` arrives as a list of strings (`['False','False','False','False']`). `treat_runtimeparams` in `utils.py` casts with `bool()`, but `bool('False') = True` in Python (non-empty strings are truthy). The v0.17.3 "currently-running single-constant load → pin to start of horizon" path then fires even when the load is not running. The pin sets `window_mask[:pinned_steps] = 1.0`, opening the window at t=0. Under MPC rolling-window the bug self-reinforces (spurious pin → load actually starts → next tick's state IS True → pin re-fires legitimately). Same class as #876 / #878 / #879; `def_current_state` slipped through.

`set_deferrable_load_single_constant` has the same exposure (arrives as strings via the generic `associations.csv` path with no coercion); fixed in the same commit.

A third class of input was also found during review: `def_current_state=[null, null]` (HA sends JSON null when the sensor is unavailable). `ast.literal_eval('None')` returns Python `None` without raising — so `_cast_bool(None)` previously propagated `None` into `def_current_state`. The optimizer's `_update_def_current_state_params` has an `isinstance(state, bool|int|float)` guard that raises `ValueError` on `None`, crashing the optimization. Fixed by adding an explicit `if value is None: return False` guard at the top of `_cast_bool`.

## Fix — three commits
**Commit 1** (`fix:`) extends the existing `_cast_bool` helper (already present in `treat_runtimeparams`) to `def_current_state` and `set_deferrable_load_single_constant`. Replaces `bool()` (wrong for string booleans) with `_cast_bool()` which uses `ast.literal_eval` and correctly maps `'False' → False`. No layer migration, no architectural refactor — the class-level coercion strategy is deliberately deferred to a follow-up after #901 lands.

**Commit 2** (`test:`) is a regression guard for the window-outside-horizon deactivation behaviour fixed in commit `eea5d25` (upstream/master, May 27 by @BrettLynch123). That production fix was already merged before this PR was opened; no existing test covered the `window_empty_loads` path. `test_window_entirely_outside_horizon_zeros_mask` locks it in.

**Commit 3** (`fix:`) adds `if value is None: return False` guard to `_cast_bool`, and adds `test_def_current_state_null_elements_do_not_crash_optimizer` (Test D) covering the `[null, null]` crash path found during review.

## Tests (TDD red-first for Commits 1 and 3; regression guard for Commit 2)
- `test_def_current_state_stringly_false_does_not_pin_window_open` — single-shot regression: load must not run before slot 10 when `def_current_state=['False']` (string). **Was RED on unfixed code** (`12000 W` before window); GREEN after fix.
- `test_def_current_state_stringly_false_no_spurious_pin_across_mpc_ticks` — MPC rolling KEYSTONE: checks per-tick command across 3 ticks. **Was RED on unfixed code** (`def_current_state[0]` was `True` after wrong coercion); GREEN after fix.
- `test_window_entirely_outside_horizon_zeros_mask` — regression guard for Commit 2's already-merged fix. GREEN on current master; added because no prior test covered that path.
- `test_def_current_state_null_elements_do_not_crash_optimizer` — null-path crash guard: `[None, None]` must coerce to `[False, False]` and not raise `ValueError` in the optimizer. **Was RED on tip bb152f7** (`got [None, None]`); GREEN after Commit 3.

## Out of scope / follow-up
- Class-level coercion architecture (centralize in `build_params`): separate follow-up issue to evaluate after #901 lands.
- #899 (deferrable pinning block → infeasible MILP) — same area, different bug.

Fixes #873

## Summary by Sourcery

Fix boolean coercion of deferrable load configuration to prevent spurious pinning and crashes, and add resilience tests around stringly-typed and out-of-horizon parameters.

Bug Fixes:
- Correct def_current_state coercion to use a safe boolean parser so string values like 'False' do not incorrectly evaluate as True and spuriously pin single-constant deferrable loads.
- Apply the same safe boolean coercion to set_deferrable_load_single_constant to avoid misinterpreting string configuration values.
- Treat None values in boolean-like configuration (e.g. def_current_state elements) as False to prevent ValueError crashes during optimization.

Tests:
- Add regression tests ensuring stringly-typed def_current_state values do not cause early pinning for single-constant loads, including across multiple MPC ticks.
- Add a regression test verifying that windows configured entirely outside the optimization horizon leave deferrable load masks zeroed so loads are deactivated.
- Add a regression test confirming def_current_state entries of None coerce to False and do not crash the optimizer.