### PR TITLE
feat: add /healthz liveness/readiness endpoint

### DIFF
--- a/docs/api/healthz.schema.json
+++ b/docs/api/healthz.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/davidusb-geek/emhass/docs/api/healthz.schema.json",
+  "title": "EMHASS /healthz response",
+  "description": "Liveness/readiness probe response. HTTP 200 => status 'ok'; HTTP 503 => status 'degraded'. Health is recency-only; last-run correctness is reported in last_run_status but does not affect status.",
+  "type": "object",
+  "required": ["status", "boot_ts", "last_run_ts", "last_run_status", "versions"],
+  "additionalProperties": false,
+  "properties": {
+    "status": {"type": "string", "enum": ["ok", "degraded"]},
+    "boot_ts": {"type": ["string", "null"], "description": "ISO-8601 UTC (Z) server boot timestamp"},
+    "last_run_ts": {"type": ["string", "null"], "description": "ISO-8601 UTC (Z) timestamp of the most recent optimization run, or null if none"},
+    "last_run_status": {
+      "type": ["string", "null"],
+      "enum": ["ok", "infeasible", "error", null],
+      "description": "Raw correctness of the last run (diagnostic only; does not affect status)"
+    },
+    "versions": {
+      "type": "object",
+      "required": ["emhass", "python", "schema_version"],
+      "additionalProperties": false,
+      "properties": {
+        "emhass": {"type": "string"},
+        "python": {"type": "string"},
+        "schema_version": {"type": "string"}
+      }
+    }
+  }
+}

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -5,7 +5,9 @@ import asyncio
 import logging
 import os
 import pickle
+import platform
 import re
+from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
@@ -97,6 +99,8 @@ def _health_verdict(has_run: bool, stale: bool) -> tuple[str, int]:
 @app.before_serving
 async def before_serving():
     """Initialize EMHASS before starting to serve requests."""
+    # Capture boot timestamp first, so /healthz reports it even if initialize() fails.
+    app.config["boot_ts"] = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
     # Initialize the application
     try:
         await initialize()
@@ -668,6 +672,47 @@ async def api_v1_last_run():
         response_body = snap
 
     response = await make_response(orjson.dumps(response_body))
+    response.headers["Content-Type"] = "application/json"
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+@app.route("/healthz", methods=["GET"])
+async def healthz():
+    """Liveness/readiness probe for container watchdogs.
+
+    HTTP 200 status:"ok"       -> a run exists (and is within ?max_age_seconds= if given)
+    HTTP 503 status:"degraded" -> no run yet, or the run is older than the requested window
+
+    Recency-only: an infeasible/errored last solve is still a healthy server; the raw
+    result is reported as last_run_status for diagnostics. Unauthenticated, read-only.
+    Schema: docs/api/healthz.schema.json (JSON Schema draft 2020-12).
+    """
+    raw = request.args.get("max_age_seconds")
+    try:
+        max_age = int(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        max_age = None  # graceful-ignore: a 400 would read as "unhealthy" to a watchdog
+    snap = last_run.read(emhass_conf["data_path"])
+    has_run = snap is not None
+    stale = (
+        max_age is not None
+        and has_run
+        and not last_run.is_recent(emhass_conf["data_path"], max_age)
+    )
+    status, code = _health_verdict(has_run, stale)
+    body = {
+        "status": status,
+        "boot_ts": app.config.get("boot_ts"),
+        "last_run_ts": snap.get("timestamp") if snap else None,
+        "last_run_status": snap.get("status") if snap else None,
+        "versions": {
+            "emhass": last_run.emhass_version(),
+            "python": platform.python_version(),
+            "schema_version": EMHASS_SCHEMA_VERSION,
+        },
+    }
+    response = await make_response(orjson.dumps(body), code)
     response.headers["Content-Type"] = "application/json"
     response.headers["Cache-Control"] = "no-store"
     return response

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -78,6 +78,21 @@ def mark_safe(value):
 templates.filters["mark_safe"] = mark_safe
 
 
+def _health_verdict(has_run: bool, stale: bool) -> tuple[str, int]:
+    """Map run-existence + staleness to (status, http_code).
+
+    Recency-only: last-run correctness (infeasible/error) does NOT affect the
+    health verdict. ``has_run`` is False when no optimization has ever completed;
+    ``stale`` is True only when a freshness window was requested and the last run
+    falls outside it.
+    """
+    if not has_run:
+        return "degraded", 503
+    if stale:
+        return "degraded", 503
+    return "ok", 200
+
+
 # Register async startup and shutdown handlers
 @app.before_serving
 async def before_serving():

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -888,5 +888,25 @@ class TestBootTs(unittest.IsolatedAsyncioTestCase):
         self.assertRegex(boot_ts, r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
 
+class TestHealthzSchema(unittest.TestCase):
+    """The /healthz response JSON Schema doc exists and is well-formed (AC-4)."""
+
+    def test_schema_file_is_valid_json_with_required_props(self):
+        import json
+        from pathlib import Path
+
+        schema_path = Path(__file__).resolve().parents[1] / "docs" / "api" / "healthz.schema.json"
+        self.assertTrue(schema_path.exists(), f"missing {schema_path}")
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        self.assertIn("$schema", schema)
+        props = schema["properties"]
+        for key in ("status", "boot_ts", "last_run_ts", "last_run_status", "versions"):
+            self.assertIn(key, props)
+        self.assertEqual(
+            set(props["versions"]["properties"].keys()),
+            {"emhass", "python", "schema_version"},
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -877,12 +877,19 @@ class TestHealthz(unittest.IsolatedAsyncioTestCase):
 
 
 class TestBootTs(unittest.IsolatedAsyncioTestCase):
-    """Proves before_serving captures an ISO-8601 Z boot_ts even if init fails (AC-4)."""
+    """Proves before_serving captures an ISO-8601 Z boot_ts even if init fails (AC-4).
 
-    async def test_before_serving_sets_iso_z_boot_ts(self):
+    Calls before_serving() directly with a failing initialize() rather than running
+    the real lifespan: this tests Decision #3 (boot_ts is set before the try block, so
+    it survives an init failure) without invoking the real logging setup, which would
+    mutate global "emhass" logger state and leak into other tests.
+    """
+
+    @patch("emhass.web_server.initialize", new_callable=AsyncMock)
+    async def test_before_serving_sets_boot_ts_even_if_initialize_fails(self, mock_init):
+        mock_init.side_effect = RuntimeError("init boom")
         web_server.app.config.pop("boot_ts", None)
-        async with web_server.app.test_app():  # fires before_serving lifespan
-            pass
+        await web_server.before_serving()  # before_serving catches the init error and continues
         boot_ts = web_server.app.config.get("boot_ts")
         self.assertIsNotNone(boot_ts)
         self.assertRegex(boot_ts, r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -778,5 +778,115 @@ class TestHealthVerdict(unittest.TestCase):
         self.assertEqual(web_server._health_verdict(has_run=True, stale=False), ("ok", 200))
 
 
+class TestHealthz(unittest.IsolatedAsyncioTestCase):
+    """Integration tests for GET /healthz (AC-4)."""
+
+    async def asyncSetUp(self):
+        self.client = web_server.app.test_client()
+        self.original_conf = web_server.emhass_conf.copy()
+        web_server.emhass_conf = {"data_path": pathlib.Path(tempfile.mkdtemp())}
+        # before_serving may not run under test_client(); set boot_ts explicitly
+        web_server.app.config["boot_ts"] = "2026-05-29T08:00:00Z"
+
+    async def asyncTearDown(self):
+        web_server.emhass_conf = self.original_conf
+
+    def _snap(self, status="ok", ts="2026-05-29T09:55:00Z"):
+        return {
+            "status": status,
+            "timestamp": ts,
+            "action": "dayahead-optim",
+            "stage_times": {},
+            "duration_total_seconds": 1.0,
+            "emhass_version": "0.17.5",
+            "schema_version": "1.0",
+            "infeasible": status == "infeasible",
+            "error_message": None,
+        }
+
+    @patch("emhass.web_server.last_run.emhass_version", return_value="0.17.5")
+    @patch("emhass.web_server.last_run.read")
+    async def test_ok_when_run_exists(self, mock_read, _mock_ver):
+        mock_read.return_value = self._snap()
+        resp = await self.client.get("/healthz")
+        self.assertEqual(resp.status_code, 200)
+        body = await resp.get_json()
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["last_run_ts"], "2026-05-29T09:55:00Z")
+        self.assertEqual(body["last_run_status"], "ok")
+        self.assertEqual(body["boot_ts"], "2026-05-29T08:00:00Z")
+
+    @patch("emhass.web_server.last_run.emhass_version", return_value="0.17.5")
+    @patch("emhass.web_server.last_run.read", return_value=None)
+    async def test_no_run_is_degraded_503(self, _mock_read, _mock_ver):
+        resp = await self.client.get("/healthz")
+        self.assertEqual(resp.status_code, 503)
+        body = await resp.get_json()
+        self.assertEqual(body["status"], "degraded")
+        self.assertIsNone(body["last_run_ts"])
+        self.assertIsNone(body["last_run_status"])
+
+    @patch("emhass.web_server.last_run.emhass_version", return_value="0.17.5")
+    @patch("emhass.web_server.last_run.is_recent", return_value=False)
+    @patch("emhass.web_server.last_run.read")
+    async def test_stale_with_threshold_is_503(self, mock_read, _mock_recent, _mock_ver):
+        mock_read.return_value = self._snap(ts="2020-01-01T00:00:00Z")
+        resp = await self.client.get("/healthz?max_age_seconds=60")
+        self.assertEqual(resp.status_code, 503)
+        body = await resp.get_json()
+        self.assertEqual(body["status"], "degraded")
+
+    @patch("emhass.web_server.last_run.emhass_version", return_value="0.17.5")
+    @patch("emhass.web_server.last_run.is_recent", return_value=True)
+    @patch("emhass.web_server.last_run.read")
+    async def test_fresh_with_threshold_is_200(self, mock_read, _mock_recent, _mock_ver):
+        mock_read.return_value = self._snap()
+        resp = await self.client.get("/healthz?max_age_seconds=999999")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual((await resp.get_json())["status"], "ok")
+
+    @patch("emhass.web_server.last_run.emhass_version", return_value="0.17.5")
+    @patch("emhass.web_server.last_run.read")
+    async def test_infeasible_last_run_is_still_healthy(self, mock_read, _mock_ver):
+        # correctness != health: an infeasible solve must NOT flip to 503
+        mock_read.return_value = self._snap(status="infeasible")
+        resp = await self.client.get("/healthz")
+        self.assertEqual(resp.status_code, 200)
+        body = await resp.get_json()
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["last_run_status"], "infeasible")
+
+    @patch("emhass.web_server.last_run.emhass_version", return_value="0.17.5")
+    @patch("emhass.web_server.last_run.read")
+    async def test_invalid_threshold_is_ignored(self, mock_read, _mock_ver):
+        mock_read.return_value = self._snap()
+        resp = await self.client.get("/healthz?max_age_seconds=abc")
+        self.assertEqual(resp.status_code, 200)  # graceful-ignore, falls back to existence check
+        self.assertEqual((await resp.get_json())["status"], "ok")
+
+    @patch("emhass.web_server.last_run.emhass_version", return_value="0.17.5")
+    @patch("emhass.web_server.last_run.read")
+    async def test_versions_block_and_headers(self, mock_read, _mock_ver):
+        mock_read.return_value = self._snap()
+        resp = await self.client.get("/healthz")
+        body = await resp.get_json()
+        self.assertEqual(set(body["versions"].keys()), {"emhass", "python", "schema_version"})
+        self.assertEqual(body["versions"]["emhass"], "0.17.5")
+        self.assertEqual(resp.headers["Cache-Control"], "no-store")
+        self.assertEqual(resp.headers["Content-Type"], "application/json")
+
+
+class TestBootTs(unittest.IsolatedAsyncioTestCase):
+    """Proves before_serving captures an ISO-8601 Z boot_ts even if init fails (AC-4)."""
+
+    async def test_before_serving_sets_iso_z_boot_ts(self):
+        web_server.app.config.pop("boot_ts", None)
+        async with web_server.app.test_app():  # fires before_serving lifespan
+            pass
+        boot_ts = web_server.app.config.get("boot_ts")
+        self.assertIsNotNone(boot_ts)
+        self.assertRegex(boot_ts, r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -906,13 +906,15 @@ class TestHealthzSchema(unittest.TestCase):
         self.assertTrue(schema_path.exists(), f"missing {schema_path}")
         schema = json.loads(schema_path.read_text(encoding="utf-8"))
         self.assertIn("$schema", schema)
+        top_level = {"status", "boot_ts", "last_run_ts", "last_run_status", "versions"}
+        version_keys = {"emhass", "python", "schema_version"}
         props = schema["properties"]
-        for key in ("status", "boot_ts", "last_run_ts", "last_run_status", "versions"):
+        for key in top_level:
             self.assertIn(key, props)
-        self.assertEqual(
-            set(props["versions"]["properties"].keys()),
-            {"emhass", "python", "schema_version"},
-        )
+        self.assertEqual(set(props["versions"]["properties"].keys()), version_keys)
+        # required must list the contract keys, else a property is silently optional
+        self.assertTrue(top_level.issubset(schema["required"]))
+        self.assertTrue(version_keys.issubset(props["versions"]["required"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -765,5 +765,18 @@ class TestAPIV1LastRun(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(body["error_message"], "Solver failed to converge")
 
 
+class TestHealthVerdict(unittest.TestCase):
+    """Unit tests for the pure _health_verdict helper (AC-4). Recency-only."""
+
+    def test_no_run_is_degraded_503(self):
+        self.assertEqual(web_server._health_verdict(has_run=False, stale=False), ("degraded", 503))
+
+    def test_stale_run_is_degraded_503(self):
+        self.assertEqual(web_server._health_verdict(has_run=True, stale=True), ("degraded", 503))
+
+    def test_fresh_run_is_ok_200(self):
+        self.assertEqual(web_server._health_verdict(has_run=True, stale=False), ("ok", 200))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Adds `GET /healthz`, a read-only unauthenticated liveness/readiness probe for container
watchdogs (Docker HEALTHCHECK, k8s probes, agent introspection).

- HTTP **200** `status:"ok"` when an optimization run exists (and, if `?max_age_seconds=N`
  is supplied, is within that window).
- HTTP **503** `status:"degraded"` when no run has completed yet, or the last run is older
  than the requested window.
- **Recency-only:** an infeasible/errored last solve is still a healthy server — the raw
  result is reported as `last_run_status` for diagnostics but never flips the verdict
  (correctness lives in `/api/v1/last-run`).
- Body also returns `boot_ts`, `last_run_ts`, and a minimal `versions` block
  (`emhass`, `python`, `schema_version`).

Mirrors the `/api/v1/last-run` (#851) house style; reuses `emhass.last_run`
(`read`/`is_recent`/`emhass_version`). Response schema: `docs/api/healthz.schema.json`.

## Why

EMHASS runs as a long-lived container but exposes no machine-readable liveness/readiness
surface; watchdogs must scrape HTML or parse logs. `/healthz` gives an HTTP status code an
orchestrator can act on, kept separate from last-run correctness.

## Design notes

- Unauthenticated + read-only, matching every existing route (no auth primitive exists).
- No staleness threshold is assumed — EMHASS can't know user run-cadence (5-min MPC …
  daily). Staleness is opt-in via `?max_age_seconds=`; a malformed value is ignored (a 400
  would read as "unhealthy" to a watchdog).
- `boot_ts` captured in `before_serving` before init, so it survives an init failure.

## Tests

`tests/test_web_server.py`: ok / no-run / stale / fresh-with-threshold /
infeasible-still-healthy / invalid-threshold-ignored / versions+headers, plus
`_health_verdict` unit tests and a before_serving boot_ts test.

## Out of scope

cvxpy/solver versions; auth; Docker HEALTHCHECK wiring; metrics endpoint — separate follow-ups.

## Summary by Sourcery

Add a /healthz liveness/readiness endpoint exposing server and last-run health state for container watchdogs.

New Features:
- Expose a new unauthenticated GET /healthz endpoint reporting server health, last optimization run status, and version metadata.

Enhancements:
- Record a boot timestamp during startup so it is available even if initialization fails.

Documentation:
- Add a JSON Schema document describing the /healthz response payload.

Tests:
- Add unit and integration tests for the /healthz endpoint, health verdict helper, boot timestamp behavior, and the healthz response JSON schema.