### PR TITLE
fix: restore delete-on-stale behaviour for Open-Meteo forecast cache

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -416,6 +416,14 @@ class Forecast:
                 data = await self.set_cached_forecast_data(w_forecast_cache_path, data)
         else:
             data = await self.get_cached_forecast_data(w_forecast_cache_path)
+            if data is None:
+                # Stale Open-Meteo cache was deleted — fetch fresh data from API.
+                self.logger.info(
+                    "Stale Open-Meteo cache removed; fetching fresh forecast from API."
+                )
+                return await self._get_weather_open_meteo(
+                    w_forecast_cache_path, use_legacy_pvlib
+                )
         return data
 
     def _solcast_rate_limit_ok(self, max_calls: int = 8) -> bool:
@@ -1826,14 +1834,16 @@ class Forecast:
         self.logger.debug("get_prod_price_forecast returning:\n%s", df_final)
         return df_final
 
-    async def get_cached_forecast_data(self, w_forecast_cache_path) -> pd.DataFrame:
+    async def get_cached_forecast_data(self, w_forecast_cache_path) -> pd.DataFrame | None:
         r"""
         Get cached weather forecast data from file.
 
         :param w_forecast_cache_path: the path to file.
         :type method: Any
-        :return: The DataFrame containing the forecasted data
-        :rtype: pd.DataFrame
+        :return: The DataFrame containing the forecasted data, or ``None`` when
+            the cache is corrupt/missing or was intentionally deleted (e.g. stale
+            Open-Meteo cache).  Callers must handle the ``None`` case.
+        :rtype: pd.DataFrame | None
 
         """
         async with aiofiles.open(w_forecast_cache_path, "rb") as file:
@@ -1844,34 +1854,50 @@ class Forecast:
                 self.logger.error(
                     "Try running action `weather-forecast-cache` to pull new data from forecast API."
                 )
-                os.remove(w_forecast_cache_path)
-                return False
+                try:
+                    os.remove(w_forecast_cache_path)
+                except FileNotFoundError:
+                    pass
+                return None
             # Filter cached forecast data to match current forecast_dates start-end range
             if self.forecast_dates[0] in data.index and self.forecast_dates[-1] in data.index:
                 data = data.loc[self.forecast_dates[0] : self.forecast_dates[-1]]
                 self.logger.info("Retrieved forecast data from the previously saved cache.")
             else:
-                # Serve best-effort stale cache: reindex to requested dates,
-                # interpolate gaps, and zero-fill edges.  This is far better
-                # than deleting the cache and burning Solcast API quota.
-                self.logger.warning(
-                    "Cache does not fully cover the requested timeframe. "
-                    "Serving best-effort stale data (reindexed + zero-filled)."
-                )
-                combined_index = data.index.union(self.forecast_dates).sort_values()
-                data = data.reindex(combined_index)
-                data.interpolate(method="time", inplace=True)
-                data = data.reindex(self.forecast_dates)
+                if self.weather_forecast_method == "open-meteo":
+                    # Open-Meteo has no rate limits: delete the stale cache so
+                    # the next call fetches fresh data directly from the API.
+                    self.logger.warning(
+                        "Cache does not fully cover the requested timeframe. "
+                        "Removing stale Open-Meteo cache; fresh data will be fetched from the API."
+                    )
+                    try:
+                        os.remove(w_forecast_cache_path)
+                    except FileNotFoundError:
+                        pass
+                    return None
+                else:
+                    # Solcast and other rate-limited APIs: serve best-effort
+                    # stale data to avoid burning daily API quota.
+                    self.logger.warning(
+                        "Cache does not fully cover the requested timeframe. "
+                        "Serving best-effort stale data (reindexed + zero-filled). "
+                        "Cache preserved to protect API rate limits."
+                    )
+                    combined_index = data.index.union(self.forecast_dates).sort_values()
+                    data = data.reindex(combined_index)
+                    data.interpolate(method="time", inplace=True)
+                    data = data.reindex(self.forecast_dates)
 
-                irradiance_cols = [c for c in ["ghi", "dni", "dhi"] if c in data.columns]
-                other_cols = [c for c in data.columns if c not in irradiance_cols]
+                    irradiance_cols = [c for c in ["ghi", "dni", "dhi"] if c in data.columns]
+                    other_cols = [c for c in data.columns if c not in irradiance_cols]
 
-                if other_cols:
-                    data[other_cols] = data[other_cols].ffill().bfill()
-                if irradiance_cols:
-                    data[irradiance_cols] = data[irradiance_cols].fillna(0.0)
+                    if other_cols:
+                        data[other_cols] = data[other_cols].ffill().bfill()
+                    if irradiance_cols:
+                        data[irradiance_cols] = data[irradiance_cols].fillna(0.0)
 
-                data = data.fillna(0.0)
+                    data = data.fillna(0.0)
             return data
 
     async def set_cached_forecast_data(self, w_forecast_cache_path, data) -> pd.DataFrame:

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1514,6 +1514,91 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
             res = await self.fcst.get_weather_forecast(method="solcast")
             self.assertFalse(res)
 
+    async def test_get_cached_forecast_data_stale_open_meteo_deletes_cache(self):
+        """Stale Open-Meteo cache must be deleted and return False (no zero-fill).
+
+        Regression test for v0.17.3: get_cached_forecast_data() used to
+        reindex + zero-fill irradiance when the cache did not cover the full
+        requested timeframe.  For Open-Meteo (no rate limits) the correct
+        behaviour is to delete the stale pickle so the next call fetches fresh
+        data from the API.
+        """
+        w_forecast_cache_path = emhass_conf["data_path"] / "weather_forecast_data_stale_test.pkl"
+        # Build a cache that covers yesterday only (stale relative to forecast_dates)
+        yesterday = self.fcst.forecast_dates[0] - pd.Timedelta(days=1)
+        stale_index = pd.date_range(
+            start=yesterday,
+            periods=len(self.fcst.forecast_dates),
+            freq=self.fcst.freq,
+            tz=self.fcst.time_zone,
+        )
+        stale_data = pd.DataFrame({"ghi": 500.0, "dni": 400.0, "dhi": 100.0}, index=stale_index)
+        await self.fcst.set_cached_forecast_data(w_forecast_cache_path, stale_data)
+        self.assertTrue(w_forecast_cache_path.exists())
+
+        # Override method so get_cached_forecast_data sees "open-meteo"
+        original_method = self.fcst.weather_forecast_method
+        self.fcst.weather_forecast_method = "open-meteo"
+        try:
+            result = await self.fcst.get_cached_forecast_data(w_forecast_cache_path)
+        finally:
+            self.fcst.weather_forecast_method = original_method
+
+        # Must return None and delete the stale file
+        self.assertIsNone(result)
+        self.assertFalse(w_forecast_cache_path.exists(), "Stale Open-Meteo cache should be deleted")
+
+    async def test_get_cached_forecast_data_stale_solcast_zero_fills(self):
+        """Stale Solcast cache must be served as reindexed/zero-filled data.
+
+        For rate-limited providers (Solcast) the v0.17.3 stale-cache fallback
+        (reindex + zero-fill) must still be used to preserve daily API quota.
+        """
+        w_forecast_cache_path = emhass_conf["data_path"] / "weather_forecast_data_stale_solcast_test.pkl"
+        yesterday = self.fcst.forecast_dates[0] - pd.Timedelta(days=1)
+        stale_index = pd.date_range(
+            start=yesterday,
+            periods=len(self.fcst.forecast_dates),
+            freq=self.fcst.freq,
+            tz=self.fcst.time_zone,
+        )
+        stale_data = pd.DataFrame({"yhat": 1000.0}, index=stale_index)
+        await self.fcst.set_cached_forecast_data(w_forecast_cache_path, stale_data)
+
+        original_method = self.fcst.weather_forecast_method
+        self.fcst.weather_forecast_method = "solcast"
+        try:
+            result = await self.fcst.get_cached_forecast_data(w_forecast_cache_path)
+        finally:
+            self.fcst.weather_forecast_method = original_method
+            if w_forecast_cache_path.exists():
+                os.remove(w_forecast_cache_path)
+
+        # Must return a DataFrame (stale data served, file NOT deleted)
+        self.assertIsInstance(result, pd.DataFrame)
+        self.assertEqual(len(result), len(self.fcst.forecast_dates))
+        self.assertTrue(
+            (result.index == self.fcst.forecast_dates).all(),
+            "Stale Solcast cache index must match forecast_dates",
+        )
+        self.assertIn("yhat", result.columns, "Stale Solcast cache must include 'yhat' column")
+        # Stale data is served via reindex + time-interpolation (which extrapolates the last
+        # known constant value forward).  The result must be finite and non-NaN; the exact
+        # value equals the stale payload (1000.0) because interpolation extrapolates a
+        # constant series.
+        self.assertFalse(
+            result["yhat"].isna().any(),
+            "Stale Solcast cache should not contain NaNs in yhat",
+        )
+        self.assertTrue(
+            np.isfinite(result["yhat"].values).all(),
+            "Stale Solcast cache yhat values must be finite",
+        )
+        self.assertTrue(
+            (result["yhat"] == 1000.0).all(),
+            "Stale Solcast cache yhat should equal the extrapolated stale value (1000.0)",
+        )
+
     async def test_open_meteo_legacy_pvlib(self):
         """Test the use_legacy_pvlib=True path in open-meteo."""
         # Load mock data
@@ -1684,8 +1769,8 @@ class TestDstForecastDates(unittest.IsolatedAsyncioTestCase):
         hours (668 slots) instead of 168 hours (672 slots).
         The fix replaces all Timedelta additions in Forecast.__init__ with DateOffset.
         """
-        from unittest.mock import patch
         from datetime import datetime
+        from unittest.mock import patch
 
         # Spring-forward for Paris 2025: 2025-03-30 02:00 -> 03:00
         # Start at midnight so the full 7-day window crosses the transition
@@ -1739,8 +1824,8 @@ class TestDstForecastDates(unittest.IsolatedAsyncioTestCase):
 
     def test_forecast_dates_normal_day_equals_expected_slots(self):
         """On a normal day (no DST transition) forecast_dates has exactly N*24*(60/freq) slots."""
-        from unittest.mock import patch
         from datetime import datetime
+        from unittest.mock import patch
 
         # 2025-03-20 is a Thursday well before the spring-forward (2025-03-30),
         # so a 7-day window from 2025-03-20 to 2025-03-27 has no DST transition.


### PR DESCRIPTION
## Summary

Fixes a regression introduced in v0.17.3 where `get_cached_forecast_data()`
started zero-filling irradiance columns (GHI/DNI/DHI) when the cached
forecast did not cover the full requested timeframe.

This is correct behaviour for **rate-limited APIs** (e.g. Solcast) where
burning an extra API call just to refresh the cache is undesirable.
However, for **Open-Meteo** — which has no rate limits — it causes EMHASS
to optimise against a flat (zero) solar forecast, producing completely
wrong charge/discharge schedules.

## Changes

**`get_cached_forecast_data()`** — branch on `self.weather_forecast_method`:
- `"open-meteo"`: delete the stale pickle and return `False`, preserving
  the pre-v0.17.3 behaviour (fresh fetch on next call).
- all other methods: keep the v0.17.3 reindex + zero-fill path to protect
  rate-limited API quota.

**`_get_weather_open_meteo()`** — handle the new `False` return value from
`get_cached_forecast_data()` by immediately retrying the call, which will
now fetch fresh data from the Open-Meteo API since the stale pickle was
removed.

## How to reproduce

1. Let EMHASS run with `weather_forecast_method: open-meteo` and caching
   enabled until the cached JSON/pickle drifts out of the requested window
   (e.g. after midnight without an explicit cache refresh).
2. Call `/action/weather-forecast-cache`.
3. Observe all GHI / DNI / DHI values are 0.0 in the logged forecast.

With this fix, step 3 shows "Removing stale Open-Meteo cache; fresh data
will be fetched from the API" and the API is called immediately.

Closes #917

## Summary by Sourcery

Adjust forecast cache handling so Open-Meteo uses cache invalidation with refetch while rate-limited providers retain best-effort stale data, and extend tests to cover the distinct behaviours.

Bug Fixes:
- Restore delete-on-stale behaviour for Open-Meteo forecast cache to avoid zero-filled irradiance forecasts.
- Ensure rate-limited providers like Solcast continue to serve reindexed and zero-filled stale cache data instead of deleting it.

Enhancements:
- Allow get_cached_forecast_data to return None when cache files are missing, corrupt, or intentionally deleted and update callers to handle this.

Tests:
- Add regression tests covering stale cache handling for Open-Meteo and Solcast forecast providers.
- Align DST-related forecast date tests with standard import ordering.