### PR TITLE
fix: atomic, lock-serialized writes to shared entities/metadata.json

### DIFF
--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -18,6 +18,13 @@ from emhass.utils import set_df_index_freq
 
 logger = logging.getLogger(__name__)
 
+# Serializes the read-modify-write of the shared entities/metadata.json across
+# every RetrieveHass instance in this process. Concurrent publishes (e.g. the
+# day-ahead, MPC and HWC pipelines) otherwise interleave on their await points
+# and corrupt the single shared index. Module-level so it is shared by all
+# instances; binds to the running loop on first use (Python >= 3.10).
+_metadata_lock = asyncio.Lock()
+
 header_accept = "application/json"
 header_auth = "Bearer"
 hass_url = "http://supervisor/core/api"
@@ -1401,11 +1408,16 @@ class RetrieveHass:
                 async with aiofiles.open(entities_path / (entity_id + ".json"), "w") as file:
                     await file.write(orjson.dumps(parsed, option=orjson.OPT_INDENT_2).decode())
 
-                # Save the required metadata to json file
+                # Save the required metadata to json file. The whole
+                # read-modify-write is serialized with a process-wide lock and
+                # committed via an atomic os.replace, so concurrent publishes
+                # sharing this file can neither interleave nor observe a
+                # truncated/half-written document.
                 metadata_path = entities_path / "metadata.json"
-                if os.path.isfile(metadata_path):
-                    async with aiofiles.open(metadata_path) as file:
-                        content = await file.read()
+                async with _metadata_lock:
+                    if os.path.isfile(metadata_path):
+                        async with aiofiles.open(metadata_path) as file:
+                            content = await file.read()
                         try:
                             metadata = orjson.loads(content)
                         except orjson.JSONDecodeError:
@@ -1413,13 +1425,16 @@ class RetrieveHass:
                                 f"Corrupted metadata file found at {metadata_path}. Creating a new one."
                             )
                             metadata = {}
-                            # Rename the corrupted file to metadata_corrupt.json
+                            # Quarantine the corrupted file; tolerate it already
+                            # having been moved by a concurrent process.
                             corrupt_path = entities_path / "metadata_corrupt.json"
-                            os.rename(metadata_path, corrupt_path)
-                else:
-                    metadata = {}
+                            try:
+                                os.replace(metadata_path, corrupt_path)
+                            except FileNotFoundError:
+                                pass
+                    else:
+                        metadata = {}
 
-                async with aiofiles.open(metadata_path, "w") as file:
                     # Save entity metadata, key = entity_id
                     metadata[entity_id] = {
                         "name": data_df.name,
@@ -1435,7 +1450,16 @@ class RetrieveHass:
                         "lowest_time_step"
                     ] > int(self.freq.seconds / 60):
                         metadata["lowest_time_step"] = int(self.freq.seconds / 60)
-                    await file.write(orjson.dumps(metadata, option=orjson.OPT_INDENT_2).decode())
+
+                    # Atomic commit: write to a per-process temp file then
+                    # os.replace, so a concurrent reader always sees a complete
+                    # document (old or new, never a partial write).
+                    tmp_path = metadata_path.with_name(f"metadata.json.{os.getpid()}.tmp")
+                    async with aiofiles.open(tmp_path, "w") as file:
+                        await file.write(
+                            orjson.dumps(metadata, option=orjson.OPT_INDENT_2).decode()
+                        )
+                    os.replace(tmp_path, metadata_path)
 
                     self.logger.debug("Saved " + entity_id + " to json file")
 

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -6,6 +6,7 @@ import datetime
 import os
 import pathlib
 import pickle
+import tempfile
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -738,8 +739,10 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
 
             # Mock os.path.isfile to return False (triggers new metadata file creation)
             with patch("os.path.isfile", return_value=False):
-                # Mock pathlib.Path.mkdir to avoid file system errors
-                with patch("pathlib.Path.mkdir"):
+                # Mock pathlib.Path.mkdir to avoid file system errors, and
+                # os.replace since aiofiles.open is mocked (no real temp file is
+                # written for the atomic metadata commit to move into place).
+                with patch("pathlib.Path.mkdir"), patch("os.replace") as mock_replace:
                     # FIX: Pass dont_post=True to bypass network failure and force response_ok=True
                     # This ensures the save_entities logic block is actually reached
                     response, data = await self.rh.post_data(
@@ -753,6 +756,12 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
                         save_entities=True,
                         dont_post=True,
                     )
+                    # The metadata is committed atomically: a temp file is
+                    # os.replace'd into metadata.json (never an in-place write).
+                    mock_replace.assert_called_once()
+                    tmp_src, dest = mock_replace.call_args.args
+                    self.assertTrue(str(tmp_src).endswith(".tmp"))
+                    self.assertEqual(pathlib.Path(dest).name, "metadata.json")
         finally:
             # Restore path to prevent polluting other tests
             self.rh.emhass_conf["data_path"] = original_path
@@ -778,6 +787,149 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
 
             self.assertFalse(response.ok)
             self.assertEqual(response.status_code, 500)
+
+    async def test_concurrent_save_entities_metadata_integrity(self):
+        """Concurrent publishes that share entities/metadata.json must not
+        corrupt it. The read-modify-write is serialized by a process-wide lock
+        and committed via an atomic os.replace, so the final file is always
+        valid JSON containing every published entity (regression for the
+        shared-state race between the dh/mpc/hwc pipelines)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.rh.emhass_conf["data_path"] = pathlib.Path(tmpdir)
+            # get_data_from_file=True skips the network POST but still reaches
+            # the save_entities block (response_ok is forced True).
+            self.rh.get_data_from_file = True
+
+            data_df = pd.Series(
+                [100.0, 200.0],
+                index=pd.date_range("2024-01-01", periods=2, freq="30min"),
+            )
+            data_df.name = "test_data"
+
+            entity_ids = [f"sensor.race_test_{i}" for i in range(25)]
+
+            async def publish(entity_id):
+                await self.rh.post_data(
+                    data_df,
+                    0,
+                    entity_id,
+                    "power",
+                    "W",
+                    entity_id,
+                    "power",
+                    save_entities=True,
+                    dont_post=True,
+                )
+
+            # Fire them all concurrently so their await points interleave.
+            await asyncio.gather(*(publish(e) for e in entity_ids))
+
+            entities_path = pathlib.Path(tmpdir) / "entities"
+            metadata_path = entities_path / "metadata.json"
+            self.assertTrue(metadata_path.is_file())
+
+            # Must parse cleanly: no concatenated or truncated documents.
+            with open(metadata_path, "rb") as f:
+                metadata = orjson.loads(f.read())
+
+            # Every concurrently-published entity must survive (no lost writes).
+            for entity_id in entity_ids:
+                self.assertIn(entity_id, metadata)
+
+            # The atomic commit must not leave temp files behind.
+            leftover = list(entities_path.glob("metadata.json.*.tmp"))
+            self.assertEqual(leftover, [])
+
+    async def test_save_entities_recovers_from_corrupt_metadata(self):
+        """A pre-existing, unparseable metadata.json must be quarantined to
+        metadata_corrupt.json and replaced by a fresh, valid index containing
+        the entity being published (recovery branch of the shared-state race
+        handling)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.rh.emhass_conf["data_path"] = pathlib.Path(tmpdir)
+            self.rh.get_data_from_file = True
+
+            entities_path = pathlib.Path(tmpdir) / "entities"
+            entities_path.mkdir(parents=True)
+            metadata_path = entities_path / "metadata.json"
+            # Two concatenated documents: exactly the corruption the fix targets.
+            garbage = b'{"sensor.old": {}}\n{"sensor.old": {}}\n'
+            metadata_path.write_bytes(garbage)
+
+            data_df = pd.Series(
+                [100.0, 200.0],
+                index=pd.date_range("2024-01-01", periods=2, freq="30min"),
+            )
+            data_df.name = "test_data"
+
+            await self.rh.post_data(
+                data_df,
+                0,
+                "sensor.recovered",
+                "power",
+                "W",
+                "Recovered",
+                "power",
+                save_entities=True,
+                dont_post=True,
+            )
+
+            # The corrupt file is quarantined verbatim ...
+            corrupt_path = entities_path / "metadata_corrupt.json"
+            self.assertTrue(corrupt_path.is_file())
+            self.assertEqual(corrupt_path.read_bytes(), garbage)
+
+            # ... and metadata.json is rebuilt as a valid index with the entity.
+            with open(metadata_path, "rb") as f:
+                metadata = orjson.loads(f.read())
+            self.assertIn("sensor.recovered", metadata)
+            self.assertNotIn("sensor.old", metadata)
+
+    async def test_corrupt_quarantine_tolerates_lost_race(self):
+        """If a concurrent process already moved the corrupt metadata file, the
+        FileNotFoundError from the quarantine os.replace is swallowed and the
+        publish still rebuilds a valid index."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.rh.emhass_conf["data_path"] = pathlib.Path(tmpdir)
+            self.rh.get_data_from_file = True
+
+            entities_path = pathlib.Path(tmpdir) / "entities"
+            entities_path.mkdir(parents=True)
+            metadata_path = entities_path / "metadata.json"
+            metadata_path.write_bytes(b"not json{{{")
+
+            data_df = pd.Series(
+                [100.0, 200.0],
+                index=pd.date_range("2024-01-01", periods=2, freq="30min"),
+            )
+            data_df.name = "test_data"
+
+            real_replace = os.replace
+
+            def replace_side_effect(src, dst):
+                # Simulate the corrupt file having vanished out from under us;
+                # let the final atomic commit proceed for real.
+                if pathlib.Path(dst).name == "metadata_corrupt.json":
+                    raise FileNotFoundError(src)
+                return real_replace(src, dst)
+
+            with patch("os.replace", side_effect=replace_side_effect):
+                response, _ = await self.rh.post_data(
+                    data_df,
+                    0,
+                    "sensor.x",
+                    "power",
+                    "W",
+                    "X",
+                    "power",
+                    save_entities=True,
+                    dont_post=True,
+                )
+
+            self.assertTrue(response.ok)
+            with open(metadata_path, "rb") as f:
+                metadata = orjson.loads(f.read())
+            self.assertIn("sensor.x", metadata)
 
     async def test_session_lazy_initialization(self):
         """Test that session is lazily initialized on first use."""


### PR DESCRIPTION
## Problem

`RetrieveHass.post_data` does a read-modify-write of the single shared `/data/entities/metadata.json` **once per entity**, non-atomically (`aiofiles.open(metadata_path, "w")` truncates in place, then writes).

When two publishes overlap — e.g. the day-ahead, per-minute MPC, and any third `entity_save` publisher sharing `/data/entities/` — their read-modify-writes interleave on the async await points, producing lost entries or a concatenated/truncated index. The corruption handler then does `os.rename(metadata.json, metadata_corrupt.json)`, which itself races a second mover and raises `FileNotFoundError`, surfacing as an HTTP 500. This is latent even in the stock DH-vs-MPC setup; it's just rare because DH runs on a slow cadence.

Observed symptoms:

    orjson.JSONDecodeError: unexpected content after document
    orjson.JSONDecodeError: Input is a zero-length, empty document
    FileNotFoundError: '.../metadata.json' -> '.../metadata_corrupt.json'

## Fix

- Serialize the whole read-modify-write with a **process-wide `asyncio.Lock`** (module-level, shared by all `RetrieveHass` instances in the event loop).
- **Atomic commit**: write to a per-process temp file then `os.replace`, so a concurrent reader always sees a complete document (old or new, never a partial write).
- Replace the racy recovery `os.rename` with `os.replace` guarded against `FileNotFoundError`.

## Tests

- New `test_concurrent_save_entities_metadata_integrity` fires 25 concurrent `save_entities` publishes against a real temp dir and asserts `metadata.json` stays valid JSON, contains every entity, and leaves no temp files. It reproduces the original `JSONDecodeError` / `FileNotFoundError` against the pre-fix code.
- Updated `test_post_data_extended` to also patch `os.replace` (it mocks `aiofiles.open`, so no real temp file exists to move).
- Full `test_retrieve_hass` suite passes (25 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure concurrent writes to the shared entities metadata file are serialized and atomic to prevent corruption and race-induced failures.

Bug Fixes:
- Protect concurrent updates to entities/metadata.json with a process-wide asyncio lock to avoid interleaved read-modify-write corruption.
- Replace non-atomic in-place writes and racy renames of metadata.json with atomic temp-file os.replace operations that tolerate missing source files.

Tests:
- Add a stress test that performs many concurrent save_entities operations against a real temporary directory and verifies metadata.json remains valid, complete, and without leftover temp files.
- Extend the existing post_data test to mock os.replace alongside filesystem operations so it remains compatible with the new atomic write logic.