### PR TITLE
feat: add openapi.json + auto-generation and drift check

### DIFF
--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Generate src/emhass/static/openapi.json from the EMHASS route map + schema sources.
+
+Stdlib only. Run: python scripts/generate_openapi.py
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+_ATOMIC = {
+    "string": {"type": "string"},
+    "int": {"type": "integer"},
+    "float": {"type": "number"},
+    "boolean": {"type": "boolean"},
+    "time": {"type": "string"},
+    "object": {"type": "object"},
+}
+
+
+def _base_schema(base: str, param: dict) -> dict:
+    if base == "select":
+        return {"type": "string", "enum": list(param.get("select_options", []))}
+    if base in _ATOMIC:
+        return dict(_ATOMIC[base])
+    raise SystemExit(
+        f"generate_openapi: unknown input base type {base!r} (param input={param.get('input')!r})"
+    )
+
+
+def _input_to_schema(input_str: str, param: dict) -> dict:
+    """Map a param_definitions `input` string + param dict to an OpenAPI schema.
+
+    For array.* inputs, the param `default_value` is the per-element scalar template,
+    so it is placed on items.default; scalars get `default` directly. title/description/
+    x-unit annotate the outermost property.
+    """
+    parts = input_str.split(".")
+    leaf = _base_schema(parts[-1], param)
+    dv = param.get("default_value", None)
+    if dv is not None:
+        leaf["default"] = dv
+    schema = leaf
+    for _ in parts[:-1]:          # one wrap per leading "array"
+        schema = {"type": "array", "items": schema}
+    if param.get("friendly_name"):
+        schema["title"] = param["friendly_name"]
+    desc = (param.get("Description") or "").strip()
+    unit = param.get("unit")
+    if unit and unit not in ("none", ""):
+        schema["x-unit"] = unit
+        desc = (desc + f" (unit: {unit})").strip()
+    if desc:
+        schema["description"] = desc
+    return schema

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -86,13 +86,18 @@ def build_config_component(param_defs: dict) -> dict:
     return {"type": "object", "properties": props}
 
 
+def _normalise_path(rule: str) -> str:
+    """Convert a Werkzeug rule to OpenAPI path style: ``<x>`` / ``<conv:x>`` -> ``{x}``."""
+    return re.sub(r"<(?:[^:<>]+:)?([^<>]+)>", r"{\1}", rule)
+
+
 def discovered_routes() -> set[tuple[str, str]]:
     """Return {(path, METHOD)} from the live Quart url_map. Normalises <x> -> {x}."""
     from emhass.web_server import app
 
     out: set[tuple[str, str]] = set()
     for rule in app.url_map.iter_rules():
-        path = re.sub(r"<(?:[^:<>]+:)?([^<>]+)>", r"{\1}", rule.rule)
+        path = _normalise_path(rule.rule)
         for method in rule.methods or set():
             if method in ("HEAD", "OPTIONS"):
                 continue

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -198,3 +198,20 @@ def build_spec() -> dict:
         "paths": paths,
         "components": {"schemas": components},
     }
+
+
+def generate() -> dict:
+    assert_no_undocumented(discovered_routes(), CURATED, SKIP)
+    return build_spec()
+
+
+def main(argv=None) -> int:
+    argparse.ArgumentParser(description="Generate EMHASS openapi.json").parse_args(argv)
+    spec = generate()
+    _OUT.write_text(json.dumps(spec, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"wrote {_OUT.relative_to(_REPO)} ({len(spec['paths'])} paths)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -108,3 +108,93 @@ def assert_no_undocumented(routes: set, curated: dict, skip: set) -> None:
             raise SystemExit(
                 f"generate_openapi: undocumented route {method} {path} — add to CURATED or SKIP"
             )
+
+
+_REPO = Path(__file__).resolve().parents[1]
+_PARAM_DEFS = _REPO / "src" / "emhass" / "static" / "data" / "param_definitions.json"
+_LAST_RUN_SCHEMA = _REPO / "docs" / "api" / "v1" / "last-run.schema.json"
+_HEALTHZ_SCHEMA = _REPO / "docs" / "api" / "healthz.schema.json"
+_OUT = _REPO / "src" / "emhass" / "static" / "openapi.json"
+
+_PLAN_OUTPUT_DOC = (
+    "https://github.com/davidusb-geek/emhass/blob/master/docs/plan_output_schema.md"
+)
+
+
+def _load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data.pop("$schema", None)   # not meaningful inside an openapi component
+    data.pop("$id", None)
+    return data
+
+
+def _schema_version() -> str:
+    from emhass.command_line import EMHASS_SCHEMA_VERSION
+
+    return EMHASS_SCHEMA_VERSION
+
+
+def build_spec() -> dict:
+    param_defs = json.loads(_PARAM_DEFS.read_text(encoding="utf-8"))
+    components = {
+        "Config": build_config_component(param_defs),
+        "LastRun": _load_json(_LAST_RUN_SCHEMA),
+        "Healthz": _load_json(_HEALTHZ_SCHEMA),
+    }
+    config_ref = {"$ref": "#/components/schemas/Config"}
+
+    def json_ct(schema: dict) -> dict:
+        return {"content": {"application/json": {"schema": schema}}}
+
+    paths = {
+        "/get-config": {"get": {"summary": "Current config", "responses": {
+            "201": {"description": "Config JSON", **json_ct(config_ref)}}}},
+        "/get-config/defaults": {"get": {"summary": "Default config", "responses": {
+            "201": {"description": "Default config JSON", **json_ct(config_ref)}}}},
+        "/set-config": {"post": {"summary": "Save config",
+            "requestBody": json_ct(config_ref),
+            "responses": {"201": {"description": "Saved"},
+                          "400": {"description": "Empty/invalid config"},
+                          "500": {"description": "Save failure"}}}},
+        "/get-json": {"post": {"summary": "Convert legacy YAML config to JSON",
+            "requestBody": {"content": {"text/plain": {"schema": {"type": "string"}}}},
+            "responses": {"201": {"description": "Config JSON", **json_ct(config_ref)},
+                          "400": {"description": "YAML parse failure"},
+                          "500": {"description": "Conversion failure"}}}},
+        "/action/{action_name}": {"post": {"summary": "Run an EMHASS action",
+            "parameters": [{"name": "action_name", "in": "path", "required": True,
+                            "schema": {"type": "string"}}],
+            "requestBody": json_ct({"type": "object", "additionalProperties": True}),
+            "responses": {
+                "201": {"description": "Optimization plan",
+                        "content": {"application/json": {"schema": {"type": "object"}}},
+                        "externalDocs": {"description": "Plan output field reference",
+                                         "url": _PLAN_OUTPUT_DOC}},
+                "400": {"description": "Action failure"}}}},
+        "/api/v1/last-run": {"get": {"summary": "Most recent run metadata", "responses": {
+            "200": {"description": "Last-run envelope",
+                    **json_ct({"$ref": "#/components/schemas/LastRun"})}}}},
+        "/healthz": {"get": {"summary": "Liveness/readiness probe", "responses": {
+            "200": {"description": "Ready", **json_ct({"$ref": "#/components/schemas/Healthz"})},
+            "503": {"description": "Not ready", **json_ct({"$ref": "#/components/schemas/Healthz"})}}}},
+    }
+
+    # filter CURATED paths down to what actually exists in url_map (e.g. /healthz pre-AC-4)
+    live = {p for p, _ in discovered_routes()}
+    paths = {p: v for p, v in paths.items() if p in live}
+
+    return {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "EMHASS API",
+            "version": _schema_version(),
+            "description": (
+                "Machine-readable contract for the EMHASS JSON API. `default` values are "
+                "sourced from param_definitions.json (the maintainer-declared source of "
+                "truth); runtime currently loads config_defaults.json, which is kept aligned "
+                "but not enforced in code."
+            ),
+        },
+        "paths": paths,
+        "components": {"schemas": components},
+    }

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -186,6 +186,12 @@ def build_spec(routes: set | None = None) -> dict:
         "/action/{action_name}": {
             "post": {
                 "summary": "Run an EMHASS action",
+                # externalDocs belongs on the Operation Object in OpenAPI 3.1
+                # (not on a Response Object — strict validators reject the latter).
+                "externalDocs": {
+                    "description": "Plan output field reference",
+                    "url": _PLAN_OUTPUT_DOC,
+                },
                 "parameters": [
                     {
                         "name": "action_name",
@@ -199,10 +205,6 @@ def build_spec(routes: set | None = None) -> dict:
                     "201": {
                         "description": "Optimization plan",
                         "content": {"application/json": {"schema": {"type": "object"}}},
-                        "externalDocs": {
-                            "description": "Plan output field reference",
-                            "url": _PLAN_OUTPUT_DOC,
-                        },
                     },
                     "400": {"description": "Action failure"},
                 },

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -152,13 +152,13 @@ def build_spec(routes: set | None = None) -> dict:
         "/get-config": {
             "get": {
                 "summary": "Current config",
-                "responses": {"201": {"description": "Config JSON", **json_ct(config_ref)}},
+                "responses": {"200": {"description": "Config JSON", **json_ct(config_ref)}},
             }
         },
         "/get-config/defaults": {
             "get": {
                 "summary": "Default config",
-                "responses": {"201": {"description": "Default config JSON", **json_ct(config_ref)}},
+                "responses": {"200": {"description": "Default config JSON", **json_ct(config_ref)}},
             }
         },
         "/set-config": {
@@ -166,7 +166,7 @@ def build_spec(routes: set | None = None) -> dict:
                 "summary": "Save config",
                 "requestBody": json_ct(config_ref),
                 "responses": {
-                    "201": {"description": "Saved"},
+                    "200": {"description": "Saved"},
                     "400": {"description": "Empty/invalid config"},
                     "500": {"description": "Save failure"},
                 },
@@ -177,7 +177,7 @@ def build_spec(routes: set | None = None) -> dict:
                 "summary": "Convert legacy YAML config to JSON",
                 "requestBody": {"content": {"text/plain": {"schema": {"type": "string"}}}},
                 "responses": {
-                    "201": {"description": "Config JSON", **json_ct(config_ref)},
+                    "200": {"description": "Config JSON", **json_ct(config_ref)},
                     "400": {"description": "YAML parse failure"},
                     "500": {"description": "Conversion failure"},
                 },
@@ -202,7 +202,7 @@ def build_spec(routes: set | None = None) -> dict:
                 ],
                 "requestBody": json_ct({"type": "object", "additionalProperties": True}),
                 "responses": {
-                    "201": {
+                    "200": {
                         "description": "Optimization plan",
                         "content": {"application/json": {"schema": {"type": "object"}}},
                     },

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -53,3 +53,17 @@ def _input_to_schema(input_str: str, param: dict) -> dict:
     if desc:
         schema["description"] = desc
     return schema
+
+
+def build_config_component(param_defs: dict) -> dict:
+    """Flatten param_definitions sections into a single OpenAPI object schema.
+
+    Raises if a param key appears in more than one section (don't silently overwrite).
+    """
+    props: dict = {}
+    for params in param_defs.values():
+        for key, param in params.items():
+            if key in props:
+                raise SystemExit(f"generate_openapi: duplicate param key {key!r} across sections")
+            props[key] = _input_to_schema(param["input"], param)
+    return {"type": "object", "properties": props}

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -6,7 +6,24 @@ Stdlib only. Run: python scripts/generate_openapi.py
 
 import argparse
 import json
+import re
 from pathlib import Path
+
+# HTML/UI + framework routes excluded from the JSON-API contract.
+# `/static/{filename}` is Quart's auto-registered asset endpoint (not an API surface);
+# the others are the browser config/landing/template pages.
+SKIP = {"/", "/index", "/template", "/configuration", "/static/{filename}"}
+
+# path -> set of documented methods (used by both the guard and the path assembly).
+CURATED = {
+    "/get-config": {"GET"},
+    "/get-config/defaults": {"GET"},
+    "/set-config": {"POST"},
+    "/get-json": {"POST"},
+    "/action/{action_name}": {"POST"},
+    "/api/v1/last-run": {"GET"},
+    "/healthz": {"GET"},
+}
 
 _ATOMIC = {
     "string": {"type": "string"},
@@ -67,3 +84,27 @@ def build_config_component(param_defs: dict) -> dict:
                 raise SystemExit(f"generate_openapi: duplicate param key {key!r} across sections")
             props[key] = _input_to_schema(param["input"], param)
     return {"type": "object", "properties": props}
+
+
+def discovered_routes() -> set[tuple[str, str]]:
+    """Return {(path, METHOD)} from the live Quart url_map. Normalises <x> -> {x}."""
+    from emhass.web_server import app
+
+    out: set[tuple[str, str]] = set()
+    for rule in app.url_map.iter_rules():
+        path = re.sub(r"<(?:[^:<>]+:)?([^<>]+)>", r"{\1}", rule.rule)
+        for method in rule.methods or set():
+            if method in ("HEAD", "OPTIONS"):
+                continue
+            out.add((path, method))
+    return out
+
+
+def assert_no_undocumented(routes: set, curated: dict, skip: set) -> None:
+    for path, method in routes:
+        if path in skip:
+            continue
+        if path not in curated or method not in curated[path]:
+            raise SystemExit(
+                f"generate_openapi: undocumented route {method} {path} — add to CURATED or SKIP"
+            )

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -58,7 +58,7 @@ def _input_to_schema(input_str: str, param: dict) -> dict:
     if dv is not None:
         leaf["default"] = dv
     schema = leaf
-    for _ in parts[:-1]:          # one wrap per leading "array"
+    for _ in parts[:-1]:  # one wrap per leading "array"
         schema = {"type": "array", "items": schema}
     if param.get("friendly_name"):
         schema["title"] = param["friendly_name"]
@@ -116,14 +116,12 @@ _LAST_RUN_SCHEMA = _REPO / "docs" / "api" / "v1" / "last-run.schema.json"
 _HEALTHZ_SCHEMA = _REPO / "docs" / "api" / "healthz.schema.json"
 _OUT = _REPO / "src" / "emhass" / "static" / "openapi.json"
 
-_PLAN_OUTPUT_DOC = (
-    "https://github.com/davidusb-geek/emhass/blob/master/docs/plan_output_schema.md"
-)
+_PLAN_OUTPUT_DOC = "https://github.com/davidusb-geek/emhass/blob/master/docs/plan_output_schema.md"
 
 
 def _load_json(path: Path) -> dict:
     data = json.loads(path.read_text(encoding="utf-8"))
-    data.pop("$schema", None)   # not meaningful inside an openapi component
+    data.pop("$schema", None)  # not meaningful inside an openapi component
     data.pop("$id", None)
     return data
 
@@ -147,36 +145,91 @@ def build_spec() -> dict:
         return {"content": {"application/json": {"schema": schema}}}
 
     paths = {
-        "/get-config": {"get": {"summary": "Current config", "responses": {
-            "201": {"description": "Config JSON", **json_ct(config_ref)}}}},
-        "/get-config/defaults": {"get": {"summary": "Default config", "responses": {
-            "201": {"description": "Default config JSON", **json_ct(config_ref)}}}},
-        "/set-config": {"post": {"summary": "Save config",
-            "requestBody": json_ct(config_ref),
-            "responses": {"201": {"description": "Saved"},
-                          "400": {"description": "Empty/invalid config"},
-                          "500": {"description": "Save failure"}}}},
-        "/get-json": {"post": {"summary": "Convert legacy YAML config to JSON",
-            "requestBody": {"content": {"text/plain": {"schema": {"type": "string"}}}},
-            "responses": {"201": {"description": "Config JSON", **json_ct(config_ref)},
-                          "400": {"description": "YAML parse failure"},
-                          "500": {"description": "Conversion failure"}}}},
-        "/action/{action_name}": {"post": {"summary": "Run an EMHASS action",
-            "parameters": [{"name": "action_name", "in": "path", "required": True,
-                            "schema": {"type": "string"}}],
-            "requestBody": json_ct({"type": "object", "additionalProperties": True}),
-            "responses": {
-                "201": {"description": "Optimization plan",
+        "/get-config": {
+            "get": {
+                "summary": "Current config",
+                "responses": {"201": {"description": "Config JSON", **json_ct(config_ref)}},
+            }
+        },
+        "/get-config/defaults": {
+            "get": {
+                "summary": "Default config",
+                "responses": {"201": {"description": "Default config JSON", **json_ct(config_ref)}},
+            }
+        },
+        "/set-config": {
+            "post": {
+                "summary": "Save config",
+                "requestBody": json_ct(config_ref),
+                "responses": {
+                    "201": {"description": "Saved"},
+                    "400": {"description": "Empty/invalid config"},
+                    "500": {"description": "Save failure"},
+                },
+            }
+        },
+        "/get-json": {
+            "post": {
+                "summary": "Convert legacy YAML config to JSON",
+                "requestBody": {"content": {"text/plain": {"schema": {"type": "string"}}}},
+                "responses": {
+                    "201": {"description": "Config JSON", **json_ct(config_ref)},
+                    "400": {"description": "YAML parse failure"},
+                    "500": {"description": "Conversion failure"},
+                },
+            }
+        },
+        "/action/{action_name}": {
+            "post": {
+                "summary": "Run an EMHASS action",
+                "parameters": [
+                    {
+                        "name": "action_name",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": json_ct({"type": "object", "additionalProperties": True}),
+                "responses": {
+                    "201": {
+                        "description": "Optimization plan",
                         "content": {"application/json": {"schema": {"type": "object"}}},
-                        "externalDocs": {"description": "Plan output field reference",
-                                         "url": _PLAN_OUTPUT_DOC}},
-                "400": {"description": "Action failure"}}}},
-        "/api/v1/last-run": {"get": {"summary": "Most recent run metadata", "responses": {
-            "200": {"description": "Last-run envelope",
-                    **json_ct({"$ref": "#/components/schemas/LastRun"})}}}},
-        "/healthz": {"get": {"summary": "Liveness/readiness probe", "responses": {
-            "200": {"description": "Ready", **json_ct({"$ref": "#/components/schemas/Healthz"})},
-            "503": {"description": "Not ready", **json_ct({"$ref": "#/components/schemas/Healthz"})}}}},
+                        "externalDocs": {
+                            "description": "Plan output field reference",
+                            "url": _PLAN_OUTPUT_DOC,
+                        },
+                    },
+                    "400": {"description": "Action failure"},
+                },
+            }
+        },
+        "/api/v1/last-run": {
+            "get": {
+                "summary": "Most recent run metadata",
+                "responses": {
+                    "200": {
+                        "description": "Last-run envelope",
+                        **json_ct({"$ref": "#/components/schemas/LastRun"}),
+                    }
+                },
+            }
+        },
+        "/healthz": {
+            "get": {
+                "summary": "Liveness/readiness probe",
+                "responses": {
+                    "200": {
+                        "description": "Ready",
+                        **json_ct({"$ref": "#/components/schemas/Healthz"}),
+                    },
+                    "503": {
+                        "description": "Not ready",
+                        **json_ct({"$ref": "#/components/schemas/Healthz"}),
+                    },
+                },
+            }
+        },
     }
 
     # filter CURATED paths down to what actually exists in url_map (e.g. /healthz pre-AC-4)

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -132,7 +132,11 @@ def _schema_version() -> str:
     return EMHASS_SCHEMA_VERSION
 
 
-def build_spec() -> dict:
+def build_spec(routes: set | None = None) -> dict:
+    # `routes` lets the caller pass an already-discovered set (avoids importing
+    # emhass.web_server twice per generation); falls back to discovery when called standalone.
+    if routes is None:
+        routes = discovered_routes()
     param_defs = json.loads(_PARAM_DEFS.read_text(encoding="utf-8"))
     components = {
         "Config": build_config_component(param_defs),
@@ -233,7 +237,7 @@ def build_spec() -> dict:
     }
 
     # filter CURATED paths down to what actually exists in url_map (e.g. /healthz pre-AC-4)
-    live = {p for p, _ in discovered_routes()}
+    live = {p for p, _ in routes}
     paths = {p: v for p, v in paths.items() if p in live}
 
     return {
@@ -254,8 +258,9 @@ def build_spec() -> dict:
 
 
 def generate() -> dict:
-    assert_no_undocumented(discovered_routes(), CURATED, SKIP)
-    return build_spec()
+    routes = discovered_routes()
+    assert_no_undocumented(routes, CURATED, SKIP)
+    return build_spec(routes)
 
 
 def main(argv=None) -> int:

--- a/src/emhass/static/openapi.json
+++ b/src/emhass/static/openapi.json
@@ -100,6 +100,10 @@
     "/action/{action_name}": {
       "post": {
         "summary": "Run an EMHASS action",
+        "externalDocs": {
+          "description": "Plan output field reference",
+          "url": "https://github.com/davidusb-geek/emhass/blob/master/docs/plan_output_schema.md"
+        },
         "parameters": [
           {
             "name": "action_name",
@@ -129,10 +133,6 @@
                   "type": "object"
                 }
               }
-            },
-            "externalDocs": {
-              "description": "Plan output field reference",
-              "url": "https://github.com/davidusb-geek/emhass/blob/master/docs/plan_output_schema.md"
             }
           },
           "400": {

--- a/src/emhass/static/openapi.json
+++ b/src/emhass/static/openapi.json
@@ -10,7 +10,7 @@
       "get": {
         "summary": "Current config",
         "responses": {
-          "201": {
+          "200": {
             "description": "Config JSON",
             "content": {
               "application/json": {
@@ -27,7 +27,7 @@
       "get": {
         "summary": "Default config",
         "responses": {
-          "201": {
+          "200": {
             "description": "Default config JSON",
             "content": {
               "application/json": {
@@ -53,7 +53,7 @@
           }
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "Saved"
           },
           "400": {
@@ -78,7 +78,7 @@
           }
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "Config JSON",
             "content": {
               "application/json": {
@@ -125,7 +125,7 @@
           }
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "Optimization plan",
             "content": {
               "application/json": {

--- a/src/emhass/static/openapi.json
+++ b/src/emhass/static/openapi.json
@@ -1,0 +1,1126 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "EMHASS API",
+    "version": "1.0",
+    "description": "Machine-readable contract for the EMHASS JSON API. `default` values are sourced from param_definitions.json (the maintainer-declared source of truth); runtime currently loads config_defaults.json, which is kept aligned but not enforced in code."
+  },
+  "paths": {
+    "/get-config": {
+      "get": {
+        "summary": "Current config",
+        "responses": {
+          "201": {
+            "description": "Config JSON",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Config"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/get-config/defaults": {
+      "get": {
+        "summary": "Default config",
+        "responses": {
+          "201": {
+            "description": "Default config JSON",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Config"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/set-config": {
+      "post": {
+        "summary": "Save config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Config"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Saved"
+          },
+          "400": {
+            "description": "Empty/invalid config"
+          },
+          "500": {
+            "description": "Save failure"
+          }
+        }
+      }
+    },
+    "/get-json": {
+      "post": {
+        "summary": "Convert legacy YAML config to JSON",
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Config JSON",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Config"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "YAML parse failure"
+          },
+          "500": {
+            "description": "Conversion failure"
+          }
+        }
+      }
+    },
+    "/action/{action_name}": {
+      "post": {
+        "summary": "Run an EMHASS action",
+        "parameters": [
+          {
+            "name": "action_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Optimization plan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "externalDocs": {
+              "description": "Plan output field reference",
+              "url": "https://github.com/davidusb-geek/emhass/blob/master/docs/plan_output_schema.md"
+            }
+          },
+          "400": {
+            "description": "Action failure"
+          }
+        }
+      }
+    },
+    "/api/v1/last-run": {
+      "get": {
+        "summary": "Most recent run metadata",
+        "responses": {
+          "200": {
+            "description": "Last-run envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LastRun"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/healthz": {
+      "get": {
+        "summary": "Liveness/readiness probe",
+        "responses": {
+          "200": {
+            "description": "Ready",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Healthz"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Not ready",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Healthz"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Config": {
+        "type": "object",
+        "properties": {
+          "costfun": {
+            "type": "string",
+            "enum": [
+              "profit",
+              "cost",
+              "self-consumption"
+            ],
+            "default": "profit",
+            "title": "Cost function",
+            "description": "Define the type of cost function."
+          },
+          "sensor_power_photovoltaics": {
+            "type": "string",
+            "default": "sensor.power_photovoltaics",
+            "title": "Sensor power photovoltaic",
+            "description": "This is the name of the photovoltaic power-produced sensor in Watts from Home Assistant. For example: ‘sensor.power_photovoltaics’."
+          },
+          "sensor_power_photovoltaics_forecast": {
+            "type": "string",
+            "default": "sensor.p_pv_forecast",
+            "title": "Sensor power photovoltaic forecast",
+            "description": "This is the name of the photovoltaic forecast sensor in Watts from Home Assistant. For example: ‘sensor.p_pv_forecast’."
+          },
+          "sensor_power_load_no_var_loads": {
+            "type": "string",
+            "default": "sensor.power_load_no_var_loads",
+            "title": "Sensor power loads with no variable loads",
+            "description": "The name of the household power consumption sensor in Watts from Home Assistant. The deferrable loads that we will want to include in the optimization problem should be subtracted from this sensor in HASS. For example: ‘sensor.power_load_no_var_loads’"
+          },
+          "sensor_replace_zero": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "sensor.power_photovoltaics"
+            },
+            "title": "Sensor to replace NAN values with 0s",
+            "description": "The list of retrieved variables that we would want to replace NANs (if they exist) with zeros."
+          },
+          "sensor_linear_interp": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "sensor.power_photovoltaics"
+            },
+            "title": "Sensor to replace NAN values with linear interpolation",
+            "description": "The list of retrieved variables that we would want to interpolate NANs values using linear interpolation"
+          },
+          "ssl_no_verify": {
+            "type": "boolean",
+            "default": false,
+            "title": "SSL no verify",
+            "description": "Set to true to disable SSL verification when connecting to Home Assistant. Useful if using self-signed certificates (HTTPS with IP address)."
+          },
+          "use_websocket": {
+            "type": "boolean",
+            "default": false,
+            "title": "Use Home Assistant websocket for data retrieval",
+            "description": "Enable Home Assistant websocket as data source instead of Home Assistant API. This allows for longer historical data retention and better performance for machine learning models."
+          },
+          "use_influxdb": {
+            "type": "boolean",
+            "default": false,
+            "title": "Use InfluxDB (1.x) for data retrieval",
+            "description": "Enable InfluxDB as data source instead of Home Assistant API. This allows for longer historical data retention and better performance for machine learning models. Only supports version 1.x."
+          },
+          "influxdb_host": {
+            "type": "string",
+            "default": "localhost",
+            "title": "InfluxDB host",
+            "description": "The IP address or hostname of your InfluxDB instance. Defaults to localhost."
+          },
+          "influxdb_port": {
+            "type": "integer",
+            "default": 8086,
+            "title": "InfluxDB port",
+            "x-unit": "count",
+            "description": "The port number for your InfluxDB instance. Defaults to 8086. (unit: count)"
+          },
+          "influxdb_database": {
+            "type": "string",
+            "default": "homeassistant",
+            "title": "InfluxDB database name",
+            "description": "The name of the InfluxDB database containing your Home Assistant data. Defaults to 'homeassistant'."
+          },
+          "influxdb_measurement": {
+            "type": "string",
+            "default": "W",
+            "title": "InfluxDB measurement name",
+            "description": "The measurement name where your sensor data is stored. Defaults to 'W' for the Home Assistant integration."
+          },
+          "influxdb_retention_policy": {
+            "type": "string",
+            "default": "autogen",
+            "title": "InfluxDB retention policy",
+            "description": "The retention policy to use for InfluxDB queries. Defaults to 'autogen'."
+          },
+          "influxdb_use_ssl": {
+            "type": "boolean",
+            "default": false,
+            "title": "Use HTTPS on InfluxDB connection",
+            "description": "Enables HTTPS on InfluxDB connections. Defaults to 'false'."
+          },
+          "influxdb_verify_ssl": {
+            "type": "boolean",
+            "default": false,
+            "title": "Verify HTTPS on InfluxDB connection",
+            "description": "Enables SSL verification of the certificate (e.g. Let's Encrypt) on InfluxDB connections. Defaults to 'false'."
+          },
+          "continual_publish": {
+            "type": "boolean",
+            "default": false,
+            "title": "Continually publish optimization results",
+            "description": "set to True to save entities to .json after an optimization run. Then automatically republish the saved entities (with updated current state value) every freq minutes. entity data saved to data_path/entities."
+          },
+          "logging_level": {
+            "type": "string",
+            "enum": [
+              "INFO",
+              "DEBUG",
+              "WARNING",
+              "ERROR"
+            ],
+            "default": "INFO",
+            "title": "Logging level",
+            "description": "DEBUG provides detailed diagnostic information, INFO gives general operational messages, WARNING highlights potential issues, and ERROR indicates critical problems that may disrupt functionality."
+          },
+          "optimization_time_step": {
+            "type": "integer",
+            "default": 30,
+            "title": "Optimization steps per minute (timesteps)",
+            "x-unit": "min",
+            "description": "The time step to resample retrieved data from hass. This parameter is given in minutes. It should not be defined too low or you will run into memory problems when defining the Linear Programming optimization. Defaults to 30 (unit: min)"
+          },
+          "historic_days_to_retrieve": {
+            "type": "integer",
+            "default": 2,
+            "title": "Historic days to retrieve",
+            "x-unit": "days",
+            "description": "We will retrieve data from now to days_to_retrieve days. Defaults to 2 (unit: days)"
+          },
+          "load_negative": {
+            "type": "boolean",
+            "default": false,
+            "title": "Load negative values",
+            "description": "Set this parameter to True if the retrieved load variable is negative by convention. Defaults to False"
+          },
+          "set_zero_min": {
+            "type": "boolean",
+            "default": true,
+            "title": "Remove Negatives",
+            "description": "Set this parameter to True to give a special treatment for a minimum value saturation to zero for power consumption data. Values below zero are replaced by nans. Defaults to True."
+          },
+          "method_ts_round": {
+            "type": "string",
+            "enum": [
+              "nearest",
+              "first",
+              "last"
+            ],
+            "default": "nearest",
+            "title": "Timestamp rounding method",
+            "description": "Set the method for timestamp rounding, options are: first, last and nearest."
+          },
+          "delta_forecast_daily": {
+            "type": "integer",
+            "default": 1,
+            "title": "Number of forecasted days",
+            "x-unit": "days",
+            "description": "The number of days for forecasted data. Defaults to 1. (unit: days)"
+          },
+          "load_forecast_method": {
+            "type": "string",
+            "enum": [
+              "typical",
+              "naive",
+              "mlforecaster",
+              "csv"
+            ],
+            "default": "typical",
+            "title": "Load forecast method",
+            "description": "The load forecast method that will be used. The options are ‘csv’ to load a CSV file or ‘naive’ for a simple 1-day persistence model."
+          },
+          "set_total_pv_sell": {
+            "type": "boolean",
+            "default": false,
+            "title": "PV straight to grid",
+            "description": "Set this parameter to true to consider that all the PV power produced is injected to the grid. No direct self-consumption. The default is false, for a system with direct self-consumption."
+          },
+          "num_threads": {
+            "type": "integer",
+            "default": 0,
+            "title": "Number of threads to use for the LP solver",
+            "x-unit": "count",
+            "description": "Set the number of threads for the LP solver to use, when supported by the solver. Defaults to 0 (autodetect) (unit: count)"
+          },
+          "lp_solver_timeout": {
+            "type": "integer",
+            "default": 45,
+            "title": "Linear programming solver timeout",
+            "x-unit": "s",
+            "description": "Set the maximum time (in seconds) for the LP solver. Defaults to 45. (unit: s)"
+          },
+          "lp_solver_mip_rel_gap": {
+            "type": "number",
+            "default": 0.0,
+            "title": "MIP relative gap tolerance",
+            "x-unit": "fraction",
+            "description": "For mixed-integer problems (with binary variables), the solver stops when the solution is within this percentage of optimal. Valid range: 0 to 1 (0% to 100%). Higher values (e.g., 0.05 = 5%) solve faster with minimal quality loss. Recommended: 0.05 for ~2x speedup. Defaults to 0 (exact optimal). (unit: fraction)"
+          },
+          "weather_forecast_method": {
+            "type": "string",
+            "enum": [
+              "open-meteo",
+              "solcast",
+              "solar.forecast",
+              "csv"
+            ],
+            "default": "open-meteo",
+            "title": "Weather forecast method",
+            "description": "This will define the weather forecast method that will be used. options are 'open-meteo', 'Solcast', 'solar.forecast' (forecast.solar) and 'csv' to load a CSV file. When loading a CSV file this will be directly considered as the PV power forecast in Watts."
+          },
+          "open_meteo_cache_max_age": {
+            "type": "integer",
+            "default": 30,
+            "title": "Open-Meteo Cache Max Age",
+            "x-unit": "min",
+            "description": "The maximum age, in minutes, of the cached open-meteo json response, after which a new version will be fetched from Open-Meteo. Defaults to 30. (unit: min)"
+          },
+          "maximum_power_from_grid": {
+            "type": "integer",
+            "default": 9000,
+            "title": "Max power from grid",
+            "x-unit": "W",
+            "description": "The maximum power that can be supplied by the utility grid in Watts (consumption). Defaults to 9000. (unit: W)"
+          },
+          "maximum_power_to_grid": {
+            "type": "integer",
+            "default": 9000,
+            "title": "Max export power to grid",
+            "x-unit": "W",
+            "description": "The maximum power that can be supplied to the utility grid in Watts (injection). Defaults to 9000. (unit: W)"
+          },
+          "inverter_is_hybrid": {
+            "type": "boolean",
+            "default": false,
+            "title": "Inverter is a hybrid",
+            "description": "Set to True to consider that the installation inverter is hybrid for PV and batteries (Default False)"
+          },
+          "inverter_ac_output_max": {
+            "type": "integer",
+            "default": 0,
+            "title": "Max hybrid inverter AC output power",
+            "x-unit": "W",
+            "description": "Maximum hybrid inverter output power from combined PV and battery discharge. (unit: W)"
+          },
+          "inverter_ac_input_max": {
+            "type": "integer",
+            "default": 0,
+            "title": "Max hybrid inverter AC input power",
+            "x-unit": "W",
+            "description": "Maximum hybrid inverter input power from grid to charge battery. (unit: W)"
+          },
+          "inverter_efficiency_dc_ac": {
+            "type": "number",
+            "default": 1.0,
+            "title": "Hybrid inverter efficency DC to AC",
+            "x-unit": "fraction",
+            "description": "Hybrid inverter efficiency from the DC bus to AC output. (percentage/100) (unit: fraction)"
+          },
+          "inverter_efficiency_ac_dc": {
+            "type": "number",
+            "default": 1.0,
+            "title": "Hybrid inverter efficency AC to DC",
+            "x-unit": "fraction",
+            "description": "Hybrid inverter efficiency when charging from the AC input to DC bus. (percentage/100) (unit: fraction)"
+          },
+          "inverter_stress_cost": {
+            "type": "number",
+            "default": 0.0,
+            "title": "Hybrid Inverter Stress Cost",
+            "x-unit": "¤/kWh",
+            "description": "A virtual cost (Currency/kWh) applied at the inverter's nominal power to penalise high loads. Currently implemented as a quadratic curve (Cost ∝ Power²), incentivising 'low and slow' operation to reduce thermal stress and smooth power flows. (unit: ¤/kWh)"
+          },
+          "inverter_stress_segments": {
+            "type": "integer",
+            "default": 10,
+            "title": "Hybrid Inverter Stress Segments",
+            "x-unit": "count",
+            "description": "The number of linear segments used to approximate the stress cost curve. Higher values increase accuracy but may slightly increase computation time. (unit: count)"
+          },
+          "compute_curtailment": {
+            "type": "boolean",
+            "default": false,
+            "title": "Set compute curtailment (grid export limit)",
+            "description": "Set to True to compute a special PV curtailment variable (Default False)"
+          },
+          "load_cost_forecast_method": {
+            "type": "string",
+            "enum": [
+              "hp_hc_periods",
+              "csv"
+            ],
+            "default": "hp_hc_periods",
+            "title": "Load cost method",
+            "description": "Define the method that will be used for load cost forecast. The options are ‘hp_hc_periods’ for peak and non-peak hours contracts, and ‘csv’ to load custom cost from CSV file."
+          },
+          "load_peak_hour_periods": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": {
+                "period_hp_template": [
+                  {
+                    "start": "02:54"
+                  },
+                  {
+                    "end": "15:24"
+                  }
+                ]
+              }
+            },
+            "title": "List peak hour periods",
+            "description": "A list of peak hour periods for load consumption from the grid. This is useful if you have a contract with peak and non-peak hours."
+          },
+          "load_peak_hours_cost": {
+            "type": "number",
+            "default": 0.1907,
+            "title": "Peak hours electrical energy cost",
+            "x-unit": "¤/kWh",
+            "description": "The cost of the electrical energy during peak hours (unit: ¤/kWh)"
+          },
+          "load_offpeak_hours_cost": {
+            "type": "number",
+            "default": 0.1419,
+            "title": "Off-peak hours electrical energy cost",
+            "x-unit": "¤/kWh",
+            "description": "The cost of the electrical energy during off-peak hours (unit: ¤/kWh)"
+          },
+          "production_price_forecast_method": {
+            "type": "string",
+            "enum": [
+              "constant",
+              "csv"
+            ],
+            "default": "constant",
+            "title": "PV power production price forecast method",
+            "description": "Define the method that will be used for PV power production price forecast. This is the price that is paid by the utility for energy injected into the grid. The options are ‘constant’ for a constant fixed value or ‘csv’ to load custom price forecasts from a CSV file."
+          },
+          "photovoltaic_production_sell_price": {
+            "type": "number",
+            "default": 0.1419,
+            "title": "Constant PV power production price",
+            "x-unit": "¤/kWh",
+            "description": "The paid price for energy injected to the grid from excess PV production in currency/kWh. (unit: ¤/kWh)"
+          },
+          "set_use_pv": {
+            "type": "boolean",
+            "default": false,
+            "title": "Enable PV system",
+            "description": "Set to True if we should consider an solar PV system. Defaults to False"
+          },
+          "set_use_adjusted_pv": {
+            "type": "boolean",
+            "default": false,
+            "title": "Enable adjusted PV system",
+            "description": "Set to True if we should consider an adjusted solar PV system. Defaults to False"
+          },
+          "adjusted_pv_regression_model": {
+            "type": "string",
+            "enum": [
+              "LinearRegression",
+              "RidgeRegression",
+              "LassoRegression",
+              "ElasticNet",
+              "KNeighborsRegressor",
+              "DecisionTreeRegressor",
+              "SVR",
+              "RandomForestRegressor",
+              "ExtraTreesRegressor",
+              "GradientBoostingRegressor",
+              "AdaBoostRegressor",
+              "MLPRegressor"
+            ],
+            "default": "LassoRegression",
+            "title": "Regression model for adjusted PV",
+            "description": "Set the type of regression model that will be used to adjust the solar PV production to local conditions. Available models are defined in REGRESSION_METHODS (machine_learning_regressor.py). Defaults to LassoRegression"
+          },
+          "adjusted_pv_solar_elevation_threshold": {
+            "type": "integer",
+            "default": 10,
+            "title": "Solar elevation threshold",
+            "x-unit": "°",
+            "description": "This is the solar elevation threshold parameter used to identify the early morning or late evening periods. Defaults to 10. (unit: °)"
+          },
+          "adjusted_pv_model_max_age": {
+            "type": "integer",
+            "default": 24,
+            "title": "Adjusted PV model maximum age",
+            "x-unit": "h",
+            "description": "Maximum age in hours before the adjusted PV regression model is re-fitted. If the saved model is older than this value, a new model will be trained using fresh historical data. Set to 0 to force re-fitting on every call. Defaults to 24 hours (1 day). (unit: h)"
+          },
+          "pv_module_model": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "CSUN_Eurasia_Energy_Systems_Industry_and_Trade_CSUN295_60M"
+            },
+            "title": "PV module model",
+            "description": "The PV module model. Enter the exact CEC database name, or enter the nominal power in Watts (e.g., 300) to automatically use the closest matching panel. Can be a list for mixed orientation systems."
+          },
+          "pv_inverter_model": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "Fronius_International_GmbH__Fronius_Primo_5_0_1_208_240__240V_"
+            },
+            "title": "PV inverter model",
+            "description": "The PV inverter model. Enter the exact CEC database name, or enter the nominal AC power in Watts (e.g., 5000) to automatically use the closest matching inverter. Can be a list for mixed orientation systems."
+          },
+          "surface_tilt": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "default": 30
+            },
+            "title": "The PV panel tilt",
+            "x-unit": "°",
+            "description": "The tilt angle of your solar panels. Defaults to 30. This parameter can be a list of items to enable the simulation of mixed orientation systems. (unit: °)"
+          },
+          "surface_azimuth": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "default": 205
+            },
+            "title": "The PV azimuth (direction)",
+            "x-unit": "°",
+            "description": "The azimuth of your PV installation. Defaults to 205. This parameter can be a list of items to enable the simulation of mixed orientation systems. (unit: °)"
+          },
+          "modules_per_string": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "default": 16
+            },
+            "title": "Number of modules per string",
+            "x-unit": "count",
+            "description": "The number of modules per string. Defaults to 16. This parameter can be a list of items to enable the simulation of mixed orientation systems. (unit: count)"
+          },
+          "strings_per_inverter": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "default": 1
+            },
+            "title": "Number of strings per inverter",
+            "x-unit": "count",
+            "description": "The number of used strings per inverter. Defaults to 1. This parameter can be a list of items to enable the simulation of mixed orientation systems. (unit: count)"
+          },
+          "number_of_deferrable_loads": {
+            "type": "integer",
+            "default": 2,
+            "title": "Number of deferrable loads",
+            "x-unit": "count",
+            "description": "Define the number of deferrable loads (appliances to shift) to consider. Defaults to 2. (unit: count)"
+          },
+          "nominal_power_of_deferrable_loads": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "default": 3000.0
+            },
+            "title": "Deferrable load nominal power",
+            "x-unit": "W",
+            "description": "The nominal (calculated max) power for each deferrable load in Watts. (unit: W)"
+          },
+          "minimum_power_of_deferrable_loads": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "default": 0.0
+            },
+            "title": "Deferrable load minimum power",
+            "x-unit": "W",
+            "description": "The minimum power for each deferrable load in Watts. (unit: W)"
+          },
+          "cost_forecast_per_deferrable_load": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "title": "Per-load cost forecast",
+            "description": "Optional per-deferrable-load cost forecast track (Currency/kWh) that overrides the shared load_cost_forecast for that load. Useful for hybrid heating setups where one load (gas boiler) is priced against a gas tariff while another (heat pump) is priced against electricity. Pass null/None for any load that should keep the shared tariff. Runtime parameter - not cached."
+          },
+          "heat_topology": {
+            "type": "object",
+            "title": "Heat topology (graph model)",
+            "description": "Declarative directed graph of heat sources, thermal storage, consumers, and flows. When set, EMHASS compiles this into the flat optim_conf primitives (def_load_config, shared_thermal_tanks, deferrable_load_groups, cost_forecast_per_deferrable_load) automatically. Lets you express hybrid heating setups (gas + heat pump feeding the same DHW + buffer) without hand-rolling the deferrable-load indices. See docs/heat_topology.md for the schema."
+          },
+          "is_electric_load": {
+            "type": "array",
+            "items": {
+              "type": "boolean",
+              "default": true
+            },
+            "title": "Per-load electric-bus membership",
+            "description": "Per-deferrable-load boolean. True (default) means the load draws from the electric balance (heat pumps, electric heaters). False means the load consumes a non-electric commodity (gas, oil, district heating) and contributes only to its thermal target, not to the electric power balance. Auto-populated by the heat_topology compiler based on source type but can be overridden directly."
+          },
+          "operating_hours_of_each_deferrable_load": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "default": 0
+            },
+            "title": "Deferrable load operating hours",
+            "x-unit": "h",
+            "description": "The total number of hours that each deferrable load should operate (unit: h)"
+          },
+          "treat_deferrable_load_as_semi_cont": {
+            "type": "array",
+            "items": {
+              "type": "boolean",
+              "default": true
+            },
+            "title": "Deferrable load as semi-continuous (on/off) variable",
+            "description": "When configuring a deferrable load, set treat_deferrable_load_as_semi_cont = True if the device should only switch fully on or off (for example, a basic hot water heater), or set treat_deferrable_load_as_semi_cont = False if the device supports variable power control within its range (for example, an EV charger with adjustable charging rate)."
+          },
+          "set_deferrable_load_single_constant": {
+            "type": "array",
+            "items": {
+              "type": "boolean",
+              "default": false
+            },
+            "title": "Deferrable load run single constant per optimization",
+            "description": "Define if we should set each deferrable load as a constant fixed value variable with just one startup for each optimization task"
+          },
+          "set_deferrable_startup_penalty": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "default": 0.0
+            },
+            "title": "Set deferrable startup penalty",
+            "description": "For penalty P, each time the deferrable load turns on will incur an additional cost of nominal_power (kW) * cost_of_electricity * time step at that time"
+          },
+          "deferrable_load_max_cost": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "default": 0.0
+            },
+            "title": "Deferrable load max cost",
+            "x-unit": "¤",
+            "description": "Maximum acceptable cost for scheduling each deferrable load. If the cost to schedule the load (including startup penalty) exceeds this threshold, the load will not be scheduled. Set to 0 to disable and make load scheduling mandatory. (unit: ¤)"
+          },
+          "set_deferrable_max_startups": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "default": 0
+            },
+            "title": "Maximum startups for deferrable loads",
+            "x-unit": "count",
+            "description": "Set the maximum number of times each deferrable load can be turned on during the optimization horizon. Set to 0 to disable this limit. (unit: count)"
+          },
+          "start_timesteps_of_each_deferrable_load": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "default": 0
+            },
+            "title": "Deferrable start timestamp",
+            "x-unit": "timesteps",
+            "description": "The timestep as from which each deferrable load is allowed to operate (if you don’t want the deferrable load to use the whole optimization time window). If you specify a value of 0 (or negative), the deferrable load will be optimized as from the beginning of the complete prediction horizon window. (unit: timesteps)"
+          },
+          "end_timesteps_of_each_deferrable_load": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "default": 0
+            },
+            "title": "Deferrable end timestamp",
+            "x-unit": "timesteps",
+            "description": "The timestep before which each deferrable load should operate. The deferrable load is not allowed to operate after the specified time step. If a value of 0 (or negative) is provided, the deferrable load is allowed to operate in the complete optimization window) (unit: timesteps)"
+          },
+          "set_use_battery": {
+            "type": "boolean",
+            "default": false,
+            "title": "Enable Battery",
+            "description": "Set to True if we should consider an energy storage device such as a Li-Ion battery. Defaults to False"
+          },
+          "set_nocharge_from_grid": {
+            "type": "boolean",
+            "default": false,
+            "title": "Forbid charging battery from grid",
+            "description": "Set this to true if you want to forbid charging the battery from the grid. The battery will only be charged from excess PV"
+          },
+          "set_nodischarge_to_grid": {
+            "type": "boolean",
+            "default": true,
+            "title": "Forbid battery discharge to the grid",
+            "description": "Set this to true if you want to forbid discharging battery power to the grid."
+          },
+          "set_battery_dynamic": {
+            "type": "boolean",
+            "default": false,
+            "title": "Set Battery dynamic (dis)charge power limiting",
+            "description": "Set a power dynamic limiting condition to the battery power. This is an additional constraint on the battery dynamic in power per unit of time (timestep), which allows you to set a percentage of the battery’s nominal full power as the maximum power allowed for (dis)charge."
+          },
+          "battery_dynamic_max": {
+            "type": "number",
+            "default": 0.9,
+            "title": "Maximum percentage of battery discharge per hour",
+            "x-unit": "fraction",
+            "description": "The maximum positive (for discharge) allowed power variation (in percentage of battery maximum power) per hour. The solver will automatically scale this limit down based on your chosen timestep duration. (unit: fraction)"
+          },
+          "battery_dynamic_min": {
+            "type": "number",
+            "default": -0.9,
+            "title": "Maximum percentage of battery charge per hour",
+            "x-unit": "fraction",
+            "description": "The maximum negative (for charge) allowed power variation (in percentage of battery maximum power) per hour. The solver will automatically scale this limit down based on your chosen timestep duration. (unit: fraction)"
+          },
+          "weight_battery_discharge": {
+            "type": "number",
+            "default": 0.0,
+            "title": "Add cost weight for battery discharge",
+            "x-unit": "¤/kWh",
+            "description": "An additional weight (currency/ kWh) applied in the cost function to battery usage for discharging (unit: ¤/kWh)"
+          },
+          "weight_battery_charge": {
+            "type": "number",
+            "default": 0.0,
+            "title": "Add cost weight for battery charge",
+            "x-unit": "¤/kWh",
+            "description": "An additional weight (currency/ kWh) applied in the cost function to battery usage for charging (unit: ¤/kWh)"
+          },
+          "battery_discharge_power_max": {
+            "type": "integer",
+            "default": 1000,
+            "title": "Max battery discharge power",
+            "x-unit": "W",
+            "description": "The maximum discharge power in Watts (unit: W)"
+          },
+          "battery_charge_power_max": {
+            "type": "integer",
+            "default": 1000,
+            "title": "Max battery charge power",
+            "x-unit": "W",
+            "description": "The maximum charge power in Watts (unit: W)"
+          },
+          "battery_discharge_efficiency": {
+            "type": "number",
+            "default": 0.95,
+            "title": "Battery discharge efficiency",
+            "x-unit": "fraction",
+            "description": "The discharge efficiency. (percentage/100) (unit: fraction)"
+          },
+          "battery_charge_efficiency": {
+            "type": "number",
+            "default": 0.95,
+            "title": "Battery charge efficiency",
+            "x-unit": "fraction",
+            "description": "The charge efficiency. (percentage/100) (unit: fraction)"
+          },
+          "battery_nominal_energy_capacity": {
+            "type": "integer",
+            "default": 5000,
+            "title": "Battery total capacity",
+            "x-unit": "Wh",
+            "description": "The total capacity of the battery stack in Wh (unit: Wh)"
+          },
+          "battery_minimum_state_of_charge": {
+            "type": "number",
+            "default": 0.3,
+            "title": "Minimum Battery charge percentage",
+            "x-unit": "fraction",
+            "description": "The minimum allowable battery state of charge. (percentage/100) (unit: fraction)"
+          },
+          "battery_maximum_state_of_charge": {
+            "type": "number",
+            "default": 0.9,
+            "title": "Maximum Battery charge percentage",
+            "x-unit": "fraction",
+            "description": "The maximum allowable battery state of charge. (percentage/100) (unit: fraction)"
+          },
+          "battery_target_state_of_charge": {
+            "type": "number",
+            "default": 0.6,
+            "title": "Battery desired percentage after optimization",
+            "x-unit": "fraction",
+            "description": "The desired battery state of charge at the end of each optimization cycle. (percentage/100) (unit: fraction)"
+          },
+          "battery_stress_cost": {
+            "type": "number",
+            "default": 0.0,
+            "title": "Battery Stress Cost",
+            "x-unit": "¤/kWh",
+            "description": "A virtual cost (Currency/kWh) applied at the battery's nominal power to penalise high loads. Currently implemented as a quadratic curve (Cost ∝ Power²), incentivising 'low and slow' operation to reduce thermal stress and smooth power flows. (unit: ¤/kWh)"
+          },
+          "battery_stress_segments": {
+            "type": "integer",
+            "default": 10,
+            "title": "Battery Stress Segments",
+            "x-unit": "count",
+            "description": "The number of linear segments used to approximate the stress cost curve. Higher values increase accuracy but may slightly increase computation time. (unit: count)"
+          },
+          "battery_soc_deficit_threshold": {
+            "type": "number",
+            "default": 0.4,
+            "title": "Battery SOC deficit threshold",
+            "description": "The SOC threshold below which deficit penalties apply. For example, 0.20 for 20% SOC. Penalties are applied for every hour and every kWh the SOC is below this value."
+          },
+          "battery_soc_deficit_cost": {
+            "type": "number",
+            "default": 0.0,
+            "title": "Battery SOC deficit cost",
+            "description": "A virtual cost (Currency/kWh/h) applied for each kWh of SOC deficit per hour. This penalizes periods when the battery SOC falls below the deficit threshold."
+          },
+          "ignore_pv_feedback_during_curtailment": {
+            "type": "boolean",
+            "default": false,
+            "title": "Ignore PV feedback during curtailment",
+            "description": "When set to true, prevents PV forecast from being updated with real PV data, avoiding flip-flop behavior during curtailment operations"
+          }
+        }
+      },
+      "LastRun": {
+        "title": "EMHASS /api/v1/last-run response",
+        "description": "Response shape for GET /api/v1/last-run. AM-1's openapi generator (board item AM-1) ingests this sidecar alongside other per-endpoint schemas and emits the unified openapi.json. Authored manually until AM-1 lands.",
+        "type": "object",
+        "required": [
+          "status",
+          "timestamp",
+          "action",
+          "stage_times",
+          "duration_total_seconds",
+          "emhass_version",
+          "schema_version",
+          "infeasible",
+          "error_message"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "no-run",
+              "ok",
+              "infeasible",
+              "error"
+            ],
+            "description": "Discriminator: which-state-is-this-response."
+          },
+          "timestamp": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO 8601 UTC instant when the run completed. Null when status='no-run'."
+          },
+          "action": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "perfect-optim",
+              "dayahead-optim",
+              "naive-mpc-optim",
+              null
+            ],
+            "description": "URL-form action name (matches /action/<name>). Null when status='no-run'."
+          },
+          "stage_times": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "number"
+            },
+            "description": "Per-stage elapsed seconds, e.g. {pv_forecast: 1.2, load_forecast: 0.5}. Null when status='no-run'."
+          },
+          "duration_total_seconds": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Wall-clock seconds from optim-wrapper entry to record() call. Null when status='no-run'."
+          },
+          "emhass_version": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Installed emhass package version (importlib.metadata). Null when status='no-run'."
+          },
+          "schema_version": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "EMHASS_SCHEMA_VERSION from command_line.py (per AC-1). Null when status='no-run'."
+          },
+          "infeasible": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "True when the solver returned Infeasible. Null when status='no-run'."
+          },
+          "error_message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Populated when status='error'. Null otherwise."
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "status": {
+                  "const": "no-run"
+                }
+              },
+              "required": [
+                "status"
+              ]
+            },
+            "then": {
+              "properties": {
+                "timestamp": {
+                  "const": null
+                },
+                "action": {
+                  "const": null
+                },
+                "stage_times": {
+                  "const": null
+                },
+                "duration_total_seconds": {
+                  "const": null
+                },
+                "infeasible": {
+                  "const": null
+                },
+                "error_message": {
+                  "const": null
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Healthz": {
+        "title": "EMHASS /healthz response",
+        "description": "Liveness/readiness probe response. HTTP 200 => status 'ok'; HTTP 503 => status 'degraded'. Health is recency-only; last-run correctness is reported in last_run_status but does not affect status.",
+        "type": "object",
+        "required": [
+          "status",
+          "boot_ts",
+          "last_run_ts",
+          "last_run_status",
+          "versions"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "degraded"
+            ]
+          },
+          "boot_ts": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO-8601 UTC (Z) server boot timestamp"
+          },
+          "last_run_ts": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO-8601 UTC (Z) timestamp of the most recent optimization run, or null if none"
+          },
+          "last_run_status": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "ok",
+              "infeasible",
+              "error",
+              null
+            ],
+            "description": "Raw correctness of the last run (diagnostic only; does not affect status)"
+          },
+          "versions": {
+            "type": "object",
+            "required": [
+              "emhass",
+              "python",
+              "schema_version"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "emhass": {
+                "type": "string"
+              },
+              "python": {
+                "type": "string"
+              },
+              "schema_version": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -140,8 +140,20 @@ class TestRouteGuard(unittest.TestCase):
         # the live route set must be fully partitioned by CURATED ∪ SKIP
         gen.assert_no_undocumented(gen.discovered_routes(), gen.CURATED, gen.SKIP)
 
+    def test_normalise_path_converts_converters_and_args(self):
+        self.assertEqual(gen._normalise_path("/action/<action_name>"), "/action/{action_name}")
+        self.assertEqual(gen._normalise_path("/action/<int:action_id>"), "/action/{action_id}")
+        self.assertEqual(gen._normalise_path("/static/<path:filename>"), "/static/{filename}")
+        self.assertEqual(gen._normalise_path("/healthz"), "/healthz")  # no params untouched
+
 
 class TestBuildSpec(unittest.TestCase):
+    def test_build_spec_filters_paths_to_live_routes(self):
+        # only routes present in the passed-in live set survive; other curated paths drop
+        spec = gen.build_spec(routes={("/get-config", "GET"), ("/healthz", "GET")})
+        self.assertEqual(set(spec["paths"]), {"/get-config", "/healthz"})
+        self.assertNotIn("/get-json", spec["paths"])
+
     def test_spec_has_core_shape_and_curated_paths(self):
         spec = gen.build_spec()
         self.assertEqual(spec["openapi"], "3.1.0")
@@ -182,6 +194,20 @@ class TestBuildSpec(unittest.TestCase):
 
 class TestOpenapiArtifact(unittest.TestCase):
     OUT = REPO_ROOT / "src" / "emhass" / "static" / "openapi.json"
+
+    def test_load_json_strips_schema_and_id(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "x.schema.json"
+            p.write_text(
+                json.dumps({"$schema": "h", "$id": "i", "type": "object", "foo": 1}),
+                encoding="utf-8",
+            )
+            loaded = gen._load_json(p)
+        self.assertNotIn("$schema", loaded)
+        self.assertNotIn("$id", loaded)
+        self.assertEqual(loaded["foo"], 1)  # real content preserved
 
     def test_committed_file_is_valid(self):
         self.assertTrue(self.OUT.exists(), f"missing {self.OUT} — run scripts/generate_openapi.py")

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -128,5 +128,27 @@ class TestBuildSpec(unittest.TestCase):
         self.assertTrue(schema["additionalProperties"])
 
 
+class TestOpenapiArtifact(unittest.TestCase):
+    OUT = REPO_ROOT / "src" / "emhass" / "static" / "openapi.json"
+
+    def test_committed_file_is_valid(self):
+        self.assertTrue(self.OUT.exists(), f"missing {self.OUT} — run scripts/generate_openapi.py")
+        spec = json.loads(self.OUT.read_text(encoding="utf-8"))
+        for key in ("openapi", "info", "paths", "components"):
+            self.assertIn(key, spec)
+        # every internal $ref resolves to a declared component
+        names = set(spec["components"]["schemas"])
+        text = json.dumps(spec)
+        for ref in ("Config", "LastRun", "Healthz"):
+            if f"#/components/schemas/{ref}" in text:
+                self.assertIn(ref, names)
+
+    def test_committed_matches_generated(self):
+        committed = json.loads(self.OUT.read_text(encoding="utf-8"))
+        fresh = gen.generate()
+        self.assertEqual(committed, fresh,
+                         "openapi.json is stale — run `python scripts/generate_openapi.py` and commit")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -51,5 +51,26 @@ class TestInputToSchema(unittest.TestCase):
         self.assertNotIn("default", s)
 
 
+class TestConfigComponent(unittest.TestCase):
+    def _defs(self):
+        return {
+            "SectionA": {"costfun": {"input": "select", "select_options": ["profit", "cost"],
+                                     "default_value": "profit", "friendly_name": "Cost", "Description": "d", "unit": "none"}},
+            "SectionB": {"battery_power": {"input": "int", "default_value": 5, "friendly_name": "BP", "Description": "d", "unit": "W"}},
+        }
+
+    def test_flattens_all_sections_into_properties(self):
+        comp = gen.build_config_component(self._defs())
+        self.assertEqual(comp["type"], "object")
+        self.assertIn("costfun", comp["properties"])
+        self.assertIn("battery_power", comp["properties"])
+
+    def test_duplicate_key_across_sections_raises(self):
+        defs = self._defs()
+        defs["SectionB"]["costfun"] = {"input": "int", "default_value": 1}
+        with self.assertRaises(SystemExit):
+            gen.build_config_component(defs)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -170,7 +170,7 @@ class TestBuildSpec(unittest.TestCase):
         spec = gen.build_spec()
         action = spec["paths"]["/action/{action_name}"]["post"]
         self.assertIn("plan_output_schema.md", action["externalDocs"]["url"])
-        self.assertNotIn("externalDocs", action["responses"]["201"])
+        self.assertNotIn("externalDocs", action["responses"]["200"])
 
     def test_action_request_is_open_object(self):
         spec = gen.build_spec()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -72,5 +72,31 @@ class TestConfigComponent(unittest.TestCase):
             gen.build_config_component(defs)
 
 
+class TestRouteGuard(unittest.TestCase):
+    def test_undocumented_route_raises(self):
+        routes = {("/healthz", "GET"), ("/brand-new", "GET")}
+        curated = {"/healthz": {"GET"}}
+        skip = {"/"}
+        with self.assertRaises(SystemExit):
+            gen.assert_no_undocumented(routes, curated, skip)
+
+    def test_skiplisted_and_curated_ok(self):
+        routes = {("/healthz", "GET"), ("/", "GET")}
+        curated = {"/healthz": {"GET"}}
+        skip = {"/"}
+        gen.assert_no_undocumented(routes, curated, skip)  # no raise
+
+    def test_discovered_routes_returns_pairs(self):
+        routes = gen.discovered_routes()
+        self.assertTrue(all(isinstance(p, tuple) and len(p) == 2 for p in routes))
+        # the curated API routes must be discoverable (proves url_map import works)
+        paths = {p for p, _ in routes}
+        self.assertIn("/api/v1/last-run", paths)
+
+    def test_curated_union_skip_covers_live_routes(self):
+        # the live route set must be fully partitioned by CURATED ∪ SKIP
+        gen.assert_no_undocumented(gen.discovered_routes(), gen.CURATED, gen.SKIP)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -98,5 +98,35 @@ class TestRouteGuard(unittest.TestCase):
         gen.assert_no_undocumented(gen.discovered_routes(), gen.CURATED, gen.SKIP)
 
 
+class TestBuildSpec(unittest.TestCase):
+    def test_spec_has_core_shape_and_curated_paths(self):
+        spec = gen.build_spec()
+        self.assertEqual(spec["openapi"], "3.1.0")
+        self.assertEqual(spec["info"]["title"], "EMHASS API")
+        self.assertTrue(spec["info"]["version"])  # EMHASS_SCHEMA_VERSION
+        for p in ("/get-config", "/set-config", "/get-json", "/action/{action_name}",
+                  "/api/v1/last-run", "/healthz"):
+            self.assertIn(p, spec["paths"], f"missing {p}")
+        # HTML/UI routes absent
+        for p in ("/", "/index", "/template", "/configuration", "/static/{filename}"):
+            self.assertNotIn(p, spec["paths"])
+        # config + inlined response components present
+        self.assertIn("Config", spec["components"]["schemas"])
+        self.assertIn("LastRun", spec["components"]["schemas"])
+        self.assertIn("Healthz", spec["components"]["schemas"])
+
+    def test_action_response_links_plan_output_doc(self):
+        spec = gen.build_spec()
+        action_201 = spec["paths"]["/action/{action_name}"]["post"]["responses"]["201"]
+        self.assertIn("plan_output_schema.md", json.dumps(action_201))
+
+    def test_action_request_is_open_object(self):
+        spec = gen.build_spec()
+        body = spec["paths"]["/action/{action_name}"]["post"]["requestBody"]
+        schema = body["content"]["application/json"]["schema"]
+        self.assertEqual(schema["type"], "object")
+        self.assertTrue(schema["additionalProperties"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,55 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+
+# scripts/ is not a package — add it to path
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import generate_openapi as gen  # noqa: E402
+
+
+class TestInputToSchema(unittest.TestCase):
+    def test_select_becomes_string_enum(self):
+        p = {"input": "select", "select_options": ["a", "b"], "default_value": "a",
+             "friendly_name": "F", "Description": "D", "unit": "none"}
+        s = gen._input_to_schema("select", p)
+        self.assertEqual(s["type"], "string")
+        self.assertEqual(s["enum"], ["a", "b"])
+        self.assertEqual(s["default"], "a")
+
+    def test_int_and_float(self):
+        self.assertEqual(gen._input_to_schema("int", {"input": "int", "default_value": 5})["type"], "integer")
+        self.assertEqual(gen._input_to_schema("float", {"input": "float", "default_value": 1.0})["type"], "number")
+
+    def test_array_float_wraps_items_with_scalar_default(self):
+        p = {"input": "array.float", "default_value": 3000, "unit": "W", "friendly_name": "N", "Description": "D"}
+        s = gen._input_to_schema("array.float", p)
+        self.assertEqual(s["type"], "array")
+        self.assertEqual(s["items"]["type"], "number")
+        self.assertEqual(s["items"]["default"], 3000)   # per-element template default
+        self.assertNotIn("default", s)                  # not on the array itself
+        self.assertEqual(s["x-unit"], "W")              # unit annotation on the property
+
+    def test_nested_array_array_float(self):
+        s = gen._input_to_schema("array.array.float", {"input": "array.array.float", "default_value": None})
+        self.assertEqual(s["type"], "array")
+        self.assertEqual(s["items"]["type"], "array")
+        self.assertEqual(s["items"]["items"]["type"], "number")
+
+    def test_object_and_time(self):
+        self.assertEqual(gen._input_to_schema("object", {"input": "object", "default_value": None})["type"], "object")
+        self.assertEqual(gen._input_to_schema("array.time", {"input": "array.time", "default_value": None})["items"]["type"], "string")
+
+    def test_unknown_input_raises(self):
+        with self.assertRaises(SystemExit):
+            gen._input_to_schema("widget", {"input": "widget"})
+
+    def test_null_default_omitted(self):
+        s = gen._input_to_schema("float", {"input": "float", "default_value": None})
+        self.assertNotIn("default", s)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -164,10 +164,13 @@ class TestBuildSpec(unittest.TestCase):
         self.assertIn("LastRun", spec["components"]["schemas"])
         self.assertIn("Healthz", spec["components"]["schemas"])
 
-    def test_action_response_links_plan_output_doc(self):
+    def test_action_operation_links_plan_output_doc(self):
+        # externalDocs must sit on the Operation Object (valid in OpenAPI 3.1),
+        # not on a Response Object (invalid — strict validators reject it).
         spec = gen.build_spec()
-        action_201 = spec["paths"]["/action/{action_name}"]["post"]["responses"]["201"]
-        self.assertIn("plan_output_schema.md", json.dumps(action_201))
+        action = spec["paths"]["/action/{action_name}"]["post"]
+        self.assertIn("plan_output_schema.md", action["externalDocs"]["url"])
+        self.assertNotIn("externalDocs", action["responses"]["201"])
 
     def test_action_request_is_open_object(self):
         spec = gen.build_spec()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -12,35 +12,62 @@ import generate_openapi as gen  # noqa: E402
 
 class TestInputToSchema(unittest.TestCase):
     def test_select_becomes_string_enum(self):
-        p = {"input": "select", "select_options": ["a", "b"], "default_value": "a",
-             "friendly_name": "F", "Description": "D", "unit": "none"}
+        p = {
+            "input": "select",
+            "select_options": ["a", "b"],
+            "default_value": "a",
+            "friendly_name": "F",
+            "Description": "D",
+            "unit": "none",
+        }
         s = gen._input_to_schema("select", p)
         self.assertEqual(s["type"], "string")
         self.assertEqual(s["enum"], ["a", "b"])
         self.assertEqual(s["default"], "a")
 
     def test_int_and_float(self):
-        self.assertEqual(gen._input_to_schema("int", {"input": "int", "default_value": 5})["type"], "integer")
-        self.assertEqual(gen._input_to_schema("float", {"input": "float", "default_value": 1.0})["type"], "number")
+        self.assertEqual(
+            gen._input_to_schema("int", {"input": "int", "default_value": 5})["type"], "integer"
+        )
+        self.assertEqual(
+            gen._input_to_schema("float", {"input": "float", "default_value": 1.0})["type"],
+            "number",
+        )
 
     def test_array_float_wraps_items_with_scalar_default(self):
-        p = {"input": "array.float", "default_value": 3000, "unit": "W", "friendly_name": "N", "Description": "D"}
+        p = {
+            "input": "array.float",
+            "default_value": 3000,
+            "unit": "W",
+            "friendly_name": "N",
+            "Description": "D",
+        }
         s = gen._input_to_schema("array.float", p)
         self.assertEqual(s["type"], "array")
         self.assertEqual(s["items"]["type"], "number")
-        self.assertEqual(s["items"]["default"], 3000)   # per-element template default
-        self.assertNotIn("default", s)                  # not on the array itself
-        self.assertEqual(s["x-unit"], "W")              # unit annotation on the property
+        self.assertEqual(s["items"]["default"], 3000)  # per-element template default
+        self.assertNotIn("default", s)  # not on the array itself
+        self.assertEqual(s["x-unit"], "W")  # unit annotation on the property
 
     def test_nested_array_array_float(self):
-        s = gen._input_to_schema("array.array.float", {"input": "array.array.float", "default_value": None})
+        s = gen._input_to_schema(
+            "array.array.float", {"input": "array.array.float", "default_value": None}
+        )
         self.assertEqual(s["type"], "array")
         self.assertEqual(s["items"]["type"], "array")
         self.assertEqual(s["items"]["items"]["type"], "number")
 
     def test_object_and_time(self):
-        self.assertEqual(gen._input_to_schema("object", {"input": "object", "default_value": None})["type"], "object")
-        self.assertEqual(gen._input_to_schema("array.time", {"input": "array.time", "default_value": None})["items"]["type"], "string")
+        self.assertEqual(
+            gen._input_to_schema("object", {"input": "object", "default_value": None})["type"],
+            "object",
+        )
+        self.assertEqual(
+            gen._input_to_schema("array.time", {"input": "array.time", "default_value": None})[
+                "items"
+            ]["type"],
+            "string",
+        )
 
     def test_unknown_input_raises(self):
         with self.assertRaises(SystemExit):
@@ -54,9 +81,25 @@ class TestInputToSchema(unittest.TestCase):
 class TestConfigComponent(unittest.TestCase):
     def _defs(self):
         return {
-            "SectionA": {"costfun": {"input": "select", "select_options": ["profit", "cost"],
-                                     "default_value": "profit", "friendly_name": "Cost", "Description": "d", "unit": "none"}},
-            "SectionB": {"battery_power": {"input": "int", "default_value": 5, "friendly_name": "BP", "Description": "d", "unit": "W"}},
+            "SectionA": {
+                "costfun": {
+                    "input": "select",
+                    "select_options": ["profit", "cost"],
+                    "default_value": "profit",
+                    "friendly_name": "Cost",
+                    "Description": "d",
+                    "unit": "none",
+                }
+            },
+            "SectionB": {
+                "battery_power": {
+                    "input": "int",
+                    "default_value": 5,
+                    "friendly_name": "BP",
+                    "Description": "d",
+                    "unit": "W",
+                }
+            },
         }
 
     def test_flattens_all_sections_into_properties(self):
@@ -104,8 +147,14 @@ class TestBuildSpec(unittest.TestCase):
         self.assertEqual(spec["openapi"], "3.1.0")
         self.assertEqual(spec["info"]["title"], "EMHASS API")
         self.assertTrue(spec["info"]["version"])  # EMHASS_SCHEMA_VERSION
-        for p in ("/get-config", "/set-config", "/get-json", "/action/{action_name}",
-                  "/api/v1/last-run", "/healthz"):
+        for p in (
+            "/get-config",
+            "/set-config",
+            "/get-json",
+            "/action/{action_name}",
+            "/api/v1/last-run",
+            "/healthz",
+        ):
             self.assertIn(p, spec["paths"], f"missing {p}")
         # HTML/UI routes absent
         for p in ("/", "/index", "/template", "/configuration", "/static/{filename}"):
@@ -146,8 +195,11 @@ class TestOpenapiArtifact(unittest.TestCase):
     def test_committed_matches_generated(self):
         committed = json.loads(self.OUT.read_text(encoding="utf-8"))
         fresh = gen.generate()
-        self.assertEqual(committed, fresh,
-                         "openapi.json is stale — run `python scripts/generate_openapi.py` and commit")
+        self.assertEqual(
+            committed,
+            fresh,
+            "openapi.json is stale — run `python scripts/generate_openapi.py` and commit",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds a generated OpenAPI 3.1 contract for the EMHASS JSON API:

- `scripts/generate_openapi.py` — stdlib generator. Reads the live `app.url_map`
  (authoritative route set), pairs each API route with a curated schema, skip-lists
  HTML/UI routes, and **fails on any undocumented route** so the contract can't silently rot.
- `src/emhass/static/openapi.json` — committed, generated contract.
- `tests/test_openapi.py` — unit (input→schema mapping, route guard), validity, and a
  **drift test** that fails if the committed file is stale vs a fresh generation (runs in
  the existing `python-test.yml`; no new workflow).

Covered: `/get-config`, `/get-config/defaults`, `/set-config`, `/get-json`,
`/action/{action_name}`, `/api/v1/last-run`, `/healthz`. The config request/response schema
is generated from `param_definitions.json` (incl. units from #850). `/api/v1/last-run` and
`/healthz` response schemas are inlined from their existing JSON Schema files. `/action/*`
links the plan-output reference (`docs/plan_output_schema.md`) via externalDocs; its request
payload is an `additionalProperties: true` stub (structured per-action payloads are a follow-up).

## Why

EMHASS exposes a JSON API but ships no machine-readable contract — tool consumers (Node-RED,
EVCC, HA cards, IDE/LLM tooling) must read source or boot EMHASS. This commits the contract
and keeps it honest via the drift guard.

## Design notes

- Stdlib only — no new dependency.
- HTML/UI routes (`/`, `/index`, `/template`, `/configuration`) are excluded; `/configuration`
  is the browser config/secrets form, not a JSON API.
- `default` values come from `param_definitions.json` (maintainer-declared SoT, #830/#845);
  runtime currently loads `config_defaults.json` (aligned, not code-enforced) — noted in
  `info.description`.
- Self-policing: unknown route, unknown `input` type, or duplicate param key fail the generator.

## Out of scope

Structured `/action/*` request payloads; a served `/openapi.json` route; generating
`config_defaults.json`; any new dependency.

## Summary by Sourcery

Add a generated, versioned OpenAPI 3.1 specification for the EMHASS JSON API and enforce its alignment with the live routes and schemas.

New Features:
- Introduce a stdlib-only script to generate an OpenAPI 3.1 contract from the live EMHASS route map and schema sources.
- Commit the generated openapi.json artifact describing the public JSON API endpoints and their schemas.

Tests:
- Add unit tests for the OpenAPI generator’s schema mapping, route coverage guard, and spec shape.
- Add a drift test that compares the committed openapi.json against a freshly generated version to prevent the contract from becoming stale.