### PR TITLE
fix: close weather cache file before unlink (Windows WinError 32)

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -1844,59 +1844,61 @@ class Forecast:
         :rtype: pd.DataFrame | None
 
         """
+        # Read then close the file BEFORE any os.remove below: on Windows a file
+        # cannot be unlinked while a handle is still open (PermissionError WinError 32).
         async with aiofiles.open(w_forecast_cache_path, "rb") as file:
             content = await file.read()
-            data = pickle.loads(content)
-            if not isinstance(data, pd.DataFrame) or data.empty:
-                self.logger.error("Cache file is corrupt or empty.")
-                self.logger.error(
-                    "Try running action `weather-forecast-cache` to pull new data from forecast API."
+        data = pickle.loads(content)
+        if not isinstance(data, pd.DataFrame) or data.empty:
+            self.logger.error("Cache file is corrupt or empty.")
+            self.logger.error(
+                "Try running action `weather-forecast-cache` to pull new data from forecast API."
+            )
+            try:
+                os.remove(w_forecast_cache_path)
+            except FileNotFoundError:
+                pass
+            return None
+        # Filter cached forecast data to match current forecast_dates start-end range
+        if self.forecast_dates[0] in data.index and self.forecast_dates[-1] in data.index:
+            data = data.loc[self.forecast_dates[0] : self.forecast_dates[-1]]
+            self.logger.info("Retrieved forecast data from the previously saved cache.")
+        else:
+            if self.weather_forecast_method == "open-meteo":
+                # Open-Meteo has no rate limits: delete the stale cache so
+                # the next call fetches fresh data directly from the API.
+                self.logger.warning(
+                    "Cache does not fully cover the requested timeframe. "
+                    "Removing stale Open-Meteo cache; fresh data will be fetched from the API."
                 )
                 try:
                     os.remove(w_forecast_cache_path)
                 except FileNotFoundError:
                     pass
                 return None
-            # Filter cached forecast data to match current forecast_dates start-end range
-            if self.forecast_dates[0] in data.index and self.forecast_dates[-1] in data.index:
-                data = data.loc[self.forecast_dates[0] : self.forecast_dates[-1]]
-                self.logger.info("Retrieved forecast data from the previously saved cache.")
             else:
-                if self.weather_forecast_method == "open-meteo":
-                    # Open-Meteo has no rate limits: delete the stale cache so
-                    # the next call fetches fresh data directly from the API.
-                    self.logger.warning(
-                        "Cache does not fully cover the requested timeframe. "
-                        "Removing stale Open-Meteo cache; fresh data will be fetched from the API."
-                    )
-                    try:
-                        os.remove(w_forecast_cache_path)
-                    except FileNotFoundError:
-                        pass
-                    return None
-                else:
-                    # Solcast and other rate-limited APIs: serve best-effort
-                    # stale data to avoid burning daily API quota.
-                    self.logger.warning(
-                        "Cache does not fully cover the requested timeframe. "
-                        "Serving best-effort stale data (reindexed + zero-filled). "
-                        "Cache preserved to protect API rate limits."
-                    )
-                    combined_index = data.index.union(self.forecast_dates).sort_values()
-                    data = data.reindex(combined_index)
-                    data.interpolate(method="time", inplace=True)
-                    data = data.reindex(self.forecast_dates)
+                # Solcast and other rate-limited APIs: serve best-effort
+                # stale data to avoid burning daily API quota.
+                self.logger.warning(
+                    "Cache does not fully cover the requested timeframe. "
+                    "Serving best-effort stale data (reindexed + zero-filled). "
+                    "Cache preserved to protect API rate limits."
+                )
+                combined_index = data.index.union(self.forecast_dates).sort_values()
+                data = data.reindex(combined_index)
+                data.interpolate(method="time", inplace=True)
+                data = data.reindex(self.forecast_dates)
 
-                    irradiance_cols = [c for c in ["ghi", "dni", "dhi"] if c in data.columns]
-                    other_cols = [c for c in data.columns if c not in irradiance_cols]
+                irradiance_cols = [c for c in ["ghi", "dni", "dhi"] if c in data.columns]
+                other_cols = [c for c in data.columns if c not in irradiance_cols]
 
-                    if other_cols:
-                        data[other_cols] = data[other_cols].ffill().bfill()
-                    if irradiance_cols:
-                        data[irradiance_cols] = data[irradiance_cols].fillna(0.0)
+                if other_cols:
+                    data[other_cols] = data[other_cols].ffill().bfill()
+                if irradiance_cols:
+                    data[irradiance_cols] = data[irradiance_cols].fillna(0.0)
 
-                    data = data.fillna(0.0)
-            return data
+                data = data.fillna(0.0)
+        return data
 
     async def set_cached_forecast_data(self, w_forecast_cache_path, data) -> pd.DataFrame:
         r"""

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1548,6 +1548,23 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(result)
         self.assertFalse(w_forecast_cache_path.exists(), "Stale Open-Meteo cache should be deleted")
 
+    async def test_get_cached_forecast_data_corrupt_cache_deletes_and_returns_none(self):
+        """A corrupt (non-DataFrame) cache pickle must be deleted and return None.
+
+        Also exercises the os.remove-after-close path on Windows (the file handle
+        must be released before unlink, else PermissionError [WinError 32]).
+        """
+        w_forecast_cache_path = emhass_conf["data_path"] / "weather_forecast_data_corrupt_test.pkl"
+        # Write a non-DataFrame payload directly (bypasses set_cached_forecast_data)
+        with open(w_forecast_cache_path, "wb") as f:
+            pickle.dump({"not": "a dataframe"}, f)
+        self.assertTrue(w_forecast_cache_path.exists())
+
+        result = await self.fcst.get_cached_forecast_data(w_forecast_cache_path)
+
+        self.assertIsNone(result)
+        self.assertFalse(w_forecast_cache_path.exists(), "Corrupt cache should be deleted")
+
     async def test_get_cached_forecast_data_stale_solcast_zero_fills(self):
         """Stale Solcast cache must be served as reindexed/zero-filled data.
 


### PR DESCRIPTION
## What

`Forecast.get_cached_forecast_data()` called `os.remove(w_forecast_cache_path)` from inside
the `async with aiofiles.open(w_forecast_cache_path, "rb") as file:` block — i.e. while the
file handle was still open — in both the corrupt-cache branch and the stale-Open-Meteo branch.

On POSIX, unlinking an open file is fine. On **Windows** it raises:

```
PermissionError: [WinError 32] The process cannot access the file because it is being
used by another process: '...\weather_forecast_data_stale_test.pkl'
```

which fails `tests/test_forecast.py::TestForecast::test_get_cached_forecast_data_stale_open_meteo_deletes_cache`
on the `windows-latest` (and contributes to the `macos-latest`) CI legs.

## Fix

Narrow the context manager to the **read only**, so the handle is closed before any
`os.remove`. All subsequent work (`pickle.loads`, the staleness checks, the deletions, the
reindex/zero-fill path) operates on in-memory data after the file is closed. No behavioural
change on POSIX; the deletions, log lines and return values are identical.

## Verification

- `test_get_cached_forecast_data_stale_open_meteo_deletes_cache` and the Solcast sibling pass.
- Full `tests/test_forecast.py` green locally (31 passed) on Windows.

## Notes

Closes #922. That issue also flagged a `ruff format` drift in `forecast.py` / `test_forecast.py`;
that half was already resolved in v0.17.6 (both files are format-clean on current `master`), so
this PR only carries the Windows file-handle fix.

## Summary by Sourcery

Fix weather forecast cache deletion to close the file before unlinking, ensuring compatibility with Windows file handling, and extend coverage for corrupt cache scenarios.

Bug Fixes:
- Prevent PermissionError on Windows by ensuring cached forecast files are closed before attempting deletion in corrupt and stale Open-Meteo cases.

Tests:
- Add a test verifying that a corrupt cached forecast pickle is deleted and get_cached_forecast_data returns None.