### PR TITLE
fix: return HTTP 200 (not 201) from JSON API endpoints

### DIFF
--- a/docs/usage_guide.md
+++ b/docs/usage_guide.md
@@ -16,6 +16,12 @@ With this web server, you can perform RESTful POST commands on multiple ENDPOINT
 
 A `curl` command can then be used to launch an optimization task like this: `curl -i -H 'Content-Type:application/json' -X POST -d '{}' http://localhost:5000/action/dayahead-optim`.
 
+> **⚠️ Breaking change — HTTP status codes.** On success, the JSON API endpoints
+> (`action/*`, `get-config`, `get-config/defaults`, `set-config`, `get-json`) now return
+> **`200 OK`**. Earlier releases incorrectly returned **`201 Created`** for *every* response,
+> including read-only reads. If you have automations or integrations (Node-RED, Home Assistant
+> REST commands, custom scripts) that check for HTTP `201`, update them to accept `200`.
+
 ## Method 2) Legacy method using a Python virtual environment
 
 To run a command simply use the `emhass` CLI command followed by the needed arguments.

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -351,7 +351,7 @@ async def parameter_get():
     # Covert formatted parameters from params back into config.json format
     return_config = param_to_config(params, app.logger)
     # Send config
-    return await make_response(return_config, 201)
+    return await make_response(return_config, 200)
 
 
 # Get default Config
@@ -373,7 +373,7 @@ async def config_get():
     # Covert formatted parameters from params back into config.json format
     return_config = param_to_config(params, app.logger)
     # Send params
-    return await make_response(return_config, 201)
+    return await make_response(return_config, 200)
 
 
 # Get YAML-to-JSON config
@@ -404,7 +404,7 @@ async def json_convert():
     config = orjson.dumps(config).decode()
 
     # Send params
-    return await make_response(config, 201)
+    return await make_response(config, 200)
 
 
 @app.route("/set-config", methods=["POST"])
@@ -469,7 +469,7 @@ async def parameter_set():
         return await make_response(["Unable to save params file, missing data_path"], 500)
 
     app.logger.info("Saved parameters from webserver")
-    return await make_response({}, 201)
+    return await make_response({}, 200)
 
 
 async def _load_params_and_runtime(request, emhass_conf, logger):
@@ -532,14 +532,14 @@ async def _handle_action_dispatch(
         action_str = " >> Performing weather forecast, try to caching result"
         logger.info(action_str)
         await weather_forecast_cache(emhass_conf, params, runtimeparams, logger)
-        return "EMHASS >> Weather Forecast has run and results possibly cached... \n", 201
+        return "EMHASS >> Weather Forecast has run and results possibly cached... \n", 200
 
     if action_name == "export-influxdb-to-csv":
         action_str = " >> Exporting InfluxDB data to CSV..."
         logger.info(action_str)
         success = await export_influxdb_to_csv(None, logger, emhass_conf, params, runtimeparams)
         if success:
-            return "EMHASS >> Action export-influxdb-to-csv executed successfully... \n", 201
+            return "EMHASS >> Action export-influxdb-to-csv executed successfully... \n", 200
         return await grab_log(action_str), 400
 
     # Actions requiring input_data_dict
@@ -547,7 +547,7 @@ async def _handle_action_dispatch(
         action_str = " >> Publishing data..."
         logger.info(action_str)
         _ = await publish_data(input_data_dict, logger)
-        return "EMHASS >> Action publish-data executed... \n", 201
+        return "EMHASS >> Action publish-data executed... \n", 200
 
     # Mapping for optimization actions to their functions
     optim_actions = {
@@ -562,7 +562,7 @@ async def _handle_action_dispatch(
         opt_res = await optim_actions[action_name](input_data_dict, logger)
         injection_dict = get_injection_dict(opt_res)
         await _save_injection_dict(injection_dict, emhass_conf["data_path"])
-        return f"EMHASS >> Action {action_name} executed... \n", 201
+        return f"EMHASS >> Action {action_name} executed... \n", 200
 
     # Delegate Machine Learning actions to helper
     ml_response = await _handle_ml_actions(action_name, input_data_dict, emhass_conf, logger)
@@ -586,7 +586,7 @@ async def _handle_ml_actions(action_name, input_data_dict, emhass_conf, logger):
         df_fit_pred, _, mlf = await forecast_model_fit(input_data_dict, logger)
         injection_dict = get_injection_dict_forecast_model_fit(df_fit_pred, mlf)
         await _save_injection_dict(injection_dict, emhass_conf["data_path"])
-        return "EMHASS >> Action forecast-model-fit executed... \n", 201
+        return "EMHASS >> Action forecast-model-fit executed... \n", 200
 
     # forecast-model-predict
     if action_name == "forecast-model-predict":
@@ -603,7 +603,7 @@ async def _handle_ml_actions(action_name, input_data_dict, emhass_conf, logger):
             "table1": table1,
         }
         await _save_injection_dict(injection_dict, emhass_conf["data_path"])
-        return "EMHASS >> Action forecast-model-predict executed... \n", 201
+        return "EMHASS >> Action forecast-model-predict executed... \n", 200
 
     # forecast-model-tune
     if action_name == "forecast-model-tune":
@@ -615,21 +615,21 @@ async def _handle_ml_actions(action_name, input_data_dict, emhass_conf, logger):
 
         injection_dict = get_injection_dict_forecast_model_tune(df_pred_optim, mlf)
         await _save_injection_dict(injection_dict, emhass_conf["data_path"])
-        return "EMHASS >> Action forecast-model-tune executed... \n", 201
+        return "EMHASS >> Action forecast-model-tune executed... \n", 200
 
     # regressor-model-fit
     if action_name == "regressor-model-fit":
         action_str = " >> Performing a machine learning regressor fit..."
         logger.info(action_str)
         await regressor_model_fit(input_data_dict, logger)
-        return "EMHASS >> Action regressor-model-fit executed... \n", 201
+        return "EMHASS >> Action regressor-model-fit executed... \n", 200
 
     # regressor-model-predict
     if action_name == "regressor-model-predict":
         action_str = " >> Performing a machine learning regressor predict..."
         logger.info(action_str)
         await regressor_model_predict(input_data_dict, logger)
-        return "EMHASS >> Action regressor-model-predict executed... \n", 201
+        return "EMHASS >> Action regressor-model-predict executed... \n", 200
 
     return None
 
@@ -781,9 +781,9 @@ async def action_call(action_name: str):
             await input_data_dict["rh"].close()
 
     # Final Log Check & Response
-    if status == 201:
+    if status == 200:
         if not await check_file_log(" >> "):
-            return await make_response(msg, 201)
+            return await make_response(msg, 200)
         return await make_response(await grab_log(" >> "), 400)
 
     return await make_response(msg, status)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -89,7 +89,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         mock_build_params.return_value = {"some": "params"}
         mock_p2c.return_value = {"final": "config"}
         response = await self.client.get("/get-config")
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         data = await response.get_json()
         self.assertEqual(data, {"final": "config"})
 
@@ -101,7 +101,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         mock_build_params.return_value = {"default": "params"}
         mock_p2c.return_value = {"final": "default"}
         response = await self.client.get("/get-config/defaults")
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         data = await response.get_json()
         self.assertEqual(data, {"final": "default"})
 
@@ -115,7 +115,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         # Test successful conversion
         yaml_data = b"foo: bar"
         response = await self.client.post("/get-json", data=yaml_data)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         data = await response.get_data()
         self.assertEqual(orjson.loads(data), {"converted": "config"})
         # Test invalid YAML
@@ -136,7 +136,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         mock_build_params.return_value = {"new": "params"}
         mock_p2c.return_value = {"new": "config"}
         response = await self.client.post("/set-config", json={"some": "data"})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         self.assertTrue(f_write.write.called)
 
     @patch("emhass.web_server.set_input_data_dict")
@@ -152,7 +152,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         mock_optim.return_value = pd.DataFrame()
         mock_get_inject.return_value = {}
         response = await self.client.post("/action/perfect-optim", json={})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         mock_optim.assert_called_once()
 
     @patch("emhass.web_server.export_influxdb_to_csv")
@@ -161,7 +161,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         mock_load.return_value = ({}, "profit", "{}")
         mock_export.return_value = True
         response = await self.client.post("/action/export-influxdb-to-csv", json={})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
 
     @patch("emhass.web_server.grab_log")
     @patch("emhass.web_server.export_influxdb_to_csv")
@@ -187,7 +187,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         mock_fit.return_value = (pd.DataFrame(), None, MagicMock())
         mock_get_inject.return_value = {}
         response = await self.client.post("/action/forecast-model-fit", json={})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         mock_fit.assert_called_once()
 
     @patch("emhass.web_server.set_input_data_dict")
@@ -202,7 +202,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         # Success
         mock_predict.return_value = pd.DataFrame({"col": [1, 2]})
         response = await self.client.post("/action/forecast-model-predict", json={})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         # Fail
         mock_predict.return_value = None
         # Mock check_file_log to return False, simulating no error in log, but code returns 400
@@ -224,7 +224,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         # Success case
         mock_tune.return_value = (pd.DataFrame(), MagicMock())
         response = await self.client.post("/action/forecast-model-tune", json={})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         # Fail case
         mock_tune.return_value = (None, None)
         with patch("emhass.web_server.check_file_log", new=AsyncMock(return_value=False)):
@@ -239,7 +239,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         mock_set_input.return_value = {"retrieve_hass_conf": {"continual_publish": False}}
         mock_fit.return_value = True
         response = await self.client.post("/action/regressor-model-fit", json={})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
 
     @patch("emhass.web_server.set_input_data_dict")
     @patch("emhass.web_server.regressor_model_predict")
@@ -249,7 +249,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
         mock_set_input.return_value = {"retrieve_hass_conf": {"continual_publish": False}}
         mock_predict.return_value = True
         response = await self.client.post("/action/regressor-model-predict", json={})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
 
     @patch("emhass.web_server.aiofiles.open")
     async def test_check_file_log(self, mock_file):
@@ -382,7 +382,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
             headers={"Content-Type": "application/json"},
         )
         # Assertions
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         log_found = False
         for call in mock_logger.error.call_args_list:
             args, _ = call
@@ -439,7 +439,7 @@ class TestWebServer(unittest.IsolatedAsyncioTestCase):
             data=valid_json_str,
             headers={"Content-Type": "application/json"},
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         # Verify no error was logged
         self.assertFalse(mock_logger.error.called)
         # Verify runtime params were passed correctly


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE

The JSON API endpoints now return **`200 OK`** on success instead of **`201 Created`**.
**Any client that checks for HTTP `201` must be updated to accept `200`** — this includes
Node-RED flows, Home Assistant REST commands/sensors, and custom scripts that call the
EMHASS API.

## What

Per the decision in #923, the `201`-everywhere behaviour is corrected. Every JSON handler
previously returned `201 Created` on success, including read-only reads. `201` means *a new
resource was created*; none of these endpoints create a resource addressed by the response,
so they now return `200 OK`:

| Endpoint | Before | After |
|---|---|---|
| `GET /get-config` | 201 | **200** |
| `GET /get-config/defaults` | 201 | **200** |
| `POST /get-json` (YAML→JSON convert) | 201 | **200** |
| `POST /set-config` (save config) | 201 | **200** |
| `POST /action/<name>` (all actions: optim, publish, weather-cache, *-model-fit/predict/tune, regressor-*, export-influxdb) | 201 | **200** |

Error responses (`400`/`500`) are unchanged. The internal success sentinel in `action_call`
(`status == 201`) and its final emit are updated in lockstep so success detection still works.

### Why not keep `201` for the "create-like" actions?

`set-config` persists the config file, and `weather-forecast-cache` / `forecast-model-fit` /
`forecast-model-tune` / `regressor-model-fit` write a cache or model artifact. These have a
write side-effect, but none return a representation (or `Location`) of a newly created,
client-addressable resource — they return a status string. Per #923 ("default to 200 unless
a handler truly creates a resource") they return `200`. Happy to bump any specific one back to
`201` if you'd prefer.

## Docs

Added a prominent breaking-change admonition to `docs/usage_guide.md` next to the API examples.
(The `CHANGELOG.md` is auto-generated from PR titles by `scripts/generate_changelog.py`, so the
`fix:` title carries the changelog entry rather than a manual edit.)

## Tests

`tests/test_web_server.py` assertions updated `201` → `200` (13 sites); full `test_web_server.py`
suite passes (48). `test_command_line_utils.py` + `test_last_run.py` green.

Closes #923.

## Summary by Sourcery

Normalize JSON API success responses to return HTTP 200 instead of 201 across web server endpoints and actions.

Bug Fixes:
- Correct JSON API endpoints that incorrectly returned HTTP 201 on successful reads and actions to now return HTTP 200.

Enhancements:
- Align internal action dispatch and success detection logic with the new HTTP 200 success status semantics.

Documentation:
- Document the breaking change in JSON API HTTP status codes in the usage guide so clients update to expect 200 responses.

Tests:
- Update web server tests to assert HTTP 200 success responses from JSON endpoints and actions.