### PR TITLE
fix: cap aiohttp<3.13 in test extra for aioresponses compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,12 @@ test = [
     "ruff",
     "tabulate",
     "hatchling",
-    "aioresponses"
+    "aioresponses",
+    # aioresponses 0.7.8 (latest) builds an aiohttp ClientResponse without the
+    # stream_writer argument that aiohttp>=3.13 made required, so the mock-based
+    # tests fail under aiohttp 3.13+. Cap aiohttp here (test extra only) until
+    # aioresponses ships 3.13 support; production installs stay unpinned.
+    "aiohttp<3.13",
 ]
 dev = ["ruff"]
 


### PR DESCRIPTION
## What

Caps `aiohttp<3.13` in the **`test`** optional-dependencies group so the aioresponses-mocked
tests stop failing on CI. Production dependencies are untouched — end users still get the
latest aiohttp.

## Why

`master`'s CI is red on all platforms (and so is every open PR). aiohttp **3.13** made
`stream_writer` a required argument of `ClientResponse.__init__`; `aioresponses` (latest
**0.7.8**) doesn't pass it, so every aioresponses-mocked test fails with:

```
TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'
```

Both deps were unpinned, so a fresh CI install resolves aiohttp 3.13/3.14 against the
incompatible aioresponses. aioresponses has no fixed release to upgrade to yet (0.7.8 is
latest), so the cap is the available lever. Scoping it to the `test` extra keeps it out of
production resolution.

## Verification

Locally with `aiohttp 3.12.15`: `tests/test_retrieve_hass.py` and the Solcast/solar-forecast
mock tests pass (29 passed) — the same tests that error under aiohttp 3.13.

## Notes

Temporary — revert the cap once `aioresponses` ships aiohttp 3.13 support. Closes #926.
