### PR TITLE
Add optional intermediate battery SoC target (soc_target / soc_target_timestep) — addresses #553

### DIFF
--- a/docs/passing_data.md
+++ b/docs/passing_data.md
@@ -99,6 +99,49 @@ Here is the list of the other additional dictionary keys that can be passed at r
 
 - `publish_prefix` use this key to pass a common prefix to all published data. This will add a prefix to the sensor name but also the forecast attribute keys within the sensor.
 
+### Requiring an intermediate battery SOC target (naive-mpc-optim)
+
+By default the battery SOC is only pinned at the start (`soc_init`) and end (`soc_final`) of the horizon, leaving the optimizer free to choose the trajectory in between. Sometimes you want to *guarantee* the battery reaches a given charge level **partway through** the horizon — for example, "make sure the battery is full by the time the cheap window ends, even though it's fine to discharge it afterwards". This is the request in [issue #553](https://github.com/davidusb-geek/emhass/issues/553).
+
+Two optional runtime keys (only used by `naive-mpc-optim`) make this possible:
+
+- `soc_target`: the desired *minimum* SOC as a fraction in `[0, 1]` (NOT percent). It is clamped to `[battery_minimum_state_of_charge, battery_maximum_state_of_charge]`.
+- `soc_target_timestep`: the 0-based horizon timestep by which `soc_target` must be reached. After this step the battery is free to discharge again. Defaults to the last timestep if `soc_target` is given without it.
+
+Both default to *unset* (`None`), in which case nothing changes — the constraint is a no-op and existing behaviour is preserved. The target is a one-sided constraint (`SOC >= soc_target` at that step), so it never forces the battery to discharge.
+
+For example, the following runtime payload tells EMHASS that the battery must reach 100% SOC by horizon step index 14 (the SoC after that step, ~7.5 h into a 30-min-step horizon), while still letting it discharge in the steps after that:
+
+```json
+{
+  "prediction_horizon": 48,
+  "soc_init": 0.30,
+  "soc_target": 1.0,
+  "soc_target_timestep": 14
+}
+```
+
+As an HA `rest_command`:
+
+```yaml
+rest_command:
+  naive_mpc_optim:
+    url: http://localhost:5000/action/naive-mpc-optim
+    method: post
+    content_type: application/json
+    payload: >
+      {
+        "prediction_horizon": 48,
+        "soc_init": {{ states('sensor.battery_soc') | float / 100 }},
+        "soc_target": 1.0,
+        "soc_target_timestep": 14
+      }
+```
+
+```{warning}
+The target must be *reachable* by its timestep. If the requested SOC cannot be achieved in time given `soc_init`, `battery_charge_power_max` and the optimization time step, EMHASS logs a warning and the LP is likely to be **infeasible** (the target is a hard constraint, so it is not silently relaxed). Size `soc_target` / `soc_target_timestep` to what your charge power actually allows (e.g. don't ask for +0.7 SOC in 3 steps if a full charge takes 10). Note too that with the default `set_nodischarge_to_grid: true` a high target can be infeasible if local load is too low to shed the stored energy back down to `soc_final`. `soc_target_timestep` is clamped to `[0, prediction_horizon - 1]`.
+```
+
 ### Passing forecast data
 
 There is a complete dedicated section in the [Forecast](forecasts) section.

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -1657,6 +1657,8 @@ async def naive_mpc_optim(
     )
     soc_init = input_data_dict["params"]["passed_data"]["soc_init"]
     soc_final = input_data_dict["params"]["passed_data"]["soc_final"]
+    soc_target = input_data_dict["params"]["passed_data"].get("soc_target", None)
+    soc_target_timestep = input_data_dict["params"]["passed_data"].get("soc_target_timestep", None)
     def_total_hours = input_data_dict["params"]["optim_conf"].get(
         "operating_hours_of_each_deferrable_load", None
     )
@@ -1677,10 +1679,12 @@ async def naive_mpc_optim(
             prediction_horizon,
             soc_init,
             soc_final,
-            def_total_hours,
-            def_total_timestep,
-            def_start_timestep,
-            def_end_timestep,
+            soc_target=soc_target,
+            soc_target_timestep=soc_target_timestep,
+            def_total_hours=def_total_hours,
+            def_total_timestep=def_total_timestep,
+            def_start_timestep=def_start_timestep,
+            def_end_timestep=def_end_timestep,
             stage_times=input_data_dict["stage_times"],
         )
     # Save CSV file for publish_data

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -177,6 +177,9 @@ class Optimization:
         # SOC recovery parameters
         self._init_soc_recovery_params()
 
+        # Optional intermediate SOC target parameters (issue #553)
+        self._init_soc_target_params()
+
         # Initialize deferrable load parameters (window masks and energy constraints)
         self._init_deferrable_load_params()
 
@@ -196,6 +199,25 @@ class Optimization:
         self.param_soc_high_gap.value = 0.0
         self.param_soc_low_required.value = 0.0
         self.param_soc_high_required.value = 0.0
+
+    def _init_soc_target_params(self) -> None:
+        """Initialize CVXPY parameters for the optional intermediate SOC target (#553).
+
+        ``param_soc_target_floor`` is a single per-horizon vector giving the
+        minimum stored energy (Wh) required at each timestep: the target energy
+        at the requested timestep and 0.0 everywhere else. Using one precomputed
+        floor vector (rather than a mask * value product of two parameters) keeps
+        the problem DPP / warm-start safe — the numeric multiply happens at
+        set-time, so no recanonicalisation is forced on each solve. The default
+        (all zeros) makes the constraint a no-op, so behaviour is unchanged
+        unless a target is explicitly requested. It is a vector param so it must
+        be (re)created whenever the horizon length changes. Called from __init__
+        and when resizing the optimization problem.
+        """
+        self.param_soc_target_floor = cp.Parameter(
+            self.num_timesteps, nonneg=True, name="soc_target_floor"
+        )
+        self.param_soc_target_floor.value = np.zeros(self.num_timesteps)
 
     def _init_deferrable_load_params(self) -> None:
         """
@@ -1394,6 +1416,12 @@ class Optimization:
         # Total Sum of power flow * dt == (Init - Final) * Capacity
         total_energy_change = cp.sum(energy_change)
         constraints.append(total_energy_change == (soc_init - soc_final) * cap)
+
+        # Intermediate SOC target (issue #553): require SoC >= target at the
+        # requested timestep, leaving the battery free to discharge afterward.
+        # Single precomputed floor vector; zero = no-op, so behaviour is
+        # unchanged unless a target is explicitly requested.
+        constraints.append(current_stored_energy >= self.param_soc_target_floor)
 
         # Stress Cost
         if batt_stress_conf and batt_stress_conf["active"]:
@@ -2862,6 +2890,8 @@ class Optimization:
         unit_prod_price: np.array,
         soc_init: float | None = None,
         soc_final: float | None = None,
+        soc_target: float | None = None,
+        soc_target_timestep: int | None = None,
         def_total_hours: list | None = None,
         def_total_timestep: list | None = None,
         def_start_timestep: list | None = None,
@@ -2904,6 +2934,9 @@ class Optimization:
             # Re-initialize SOC recovery parameters with the new horizon
             self._init_soc_recovery_params()
 
+            # Re-initialize the intermediate SOC target mask with the new horizon (#553)
+            self._init_soc_target_params()
+
             # Re-initialize deferrable load parameters (window masks and energy constraints)
             self._init_deferrable_load_params()
 
@@ -2928,6 +2961,58 @@ class Optimization:
             self.logger.debug(
                 f"Battery usage enabled. Initial SOC: {soc_init}, Final SOC: {soc_final}"
             )
+
+        # Optional intermediate SOC target (issue #553).
+        # Reset the floor on EVERY call so a target from a previous run is
+        # cleared (the constraint is then a no-op). When a target is requested,
+        # clamp it to the configured SOC bounds and build the floor vector
+        # numerically (target energy at the requested horizon timestep, 0.0
+        # elsewhere). The np multiply happens here at set-time, so the problem
+        # stays DPP / warm-start safe.
+        if self.optim_conf["set_use_battery"] and soc_target is not None:
+            soc_min = self.plant_conf["battery_minimum_state_of_charge"]
+            soc_max = self.plant_conf["battery_maximum_state_of_charge"]
+            soc_target_raw = float(soc_target)
+            soc_target_clamped = min(max(soc_target_raw, soc_min), soc_max)
+            if soc_target_timestep is None:
+                k_target = self.num_timesteps - 1
+            else:
+                k_target = min(max(int(float(soc_target_timestep)), 0), self.num_timesteps - 1)
+            # Observability: warn (do not change the constraint) when the request
+            # was out of range or appears unreachable in time given charge power.
+            if soc_target_raw < soc_min or soc_target_raw > soc_max:
+                self.logger.warning(
+                    f"Passed soc_target={soc_target_raw} is outside "
+                    f"[{soc_min}, {soc_max}], clamping to soc_target={soc_target_clamped}"
+                )
+            cap = self.plant_conf["battery_nominal_energy_capacity"]
+            # Max stored-energy gain per step is battery_charge_power_max * time_step:
+            # the charge constraint caps grid-side power at max_chg / eff so the
+            # battery-side energy added (grid * eff) is max_chg * time_step, i.e. the
+            # charge efficiency cancels. (Do not multiply by efficiency again here, or
+            # the bound under-estimates reach and warns spuriously when eff < 1.)
+            reach = (
+                soc_init
+                + (self.plant_conf["battery_charge_power_max"] * self.time_step * (k_target + 1))
+                / cap
+            )
+            if soc_target_clamped > reach + 1e-6:
+                self.logger.warning(
+                    f"Intermediate soc_target={soc_target_clamped} may be unreachable "
+                    f"by timestep {k_target}: from soc_init={soc_init} the maximum "
+                    f"reachable SoC is ~{reach:.3f} given battery_charge_power_max; "
+                    "the optimization may be infeasible."
+                )
+            floor = np.zeros(self.num_timesteps)
+            floor[k_target] = soc_target_clamped * cap
+            self.param_soc_target_floor.value = floor
+            self.logger.debug(
+                f"Intermediate SOC target enabled: SoC >= {soc_target_clamped} "
+                f"by timestep {k_target} (requested soc_target={soc_target}, "
+                f"soc_target_timestep={soc_target_timestep})."
+            )
+        else:
+            self.param_soc_target_floor.value = np.zeros(self.num_timesteps)
 
         # Pad deferrable load lists
         if def_total_timestep is not None:
@@ -3697,6 +3782,8 @@ class Optimization:
         prediction_horizon: int,
         soc_init: float | None = None,
         soc_final: float | None = None,
+        soc_target: float | None = None,
+        soc_target_timestep: int | None = None,
         def_total_hours: list | None = None,
         def_total_timestep: list | None = None,
         def_start_timestep: list | None = None,
@@ -3726,6 +3813,16 @@ class Optimization:
         :param soc_final: The final battery SOC for the optimization. This parameter \
             is optional, if not given soc_init = soc_final = soc_target from the configuration file.
         :type soc_final:
+        :param soc_target: An optional intermediate minimum battery SOC (fraction in [0, 1]) that \
+            must be reached by ``soc_target_timestep``, after which the battery is free to \
+            discharge again. When ``None`` (the default) no intermediate target is imposed and \
+            behaviour is unchanged. See issue #553.
+        :type soc_target: float
+        :param soc_target_timestep: The 0-based horizon timestep by which ``soc_target`` must be \
+            met. The index refers to the SoC *after* that timestep's flow. Defaults to the last \
+            timestep when ``soc_target`` is given but this is ``None``. Ignored when \
+            ``soc_target`` is ``None``.
+        :type soc_target_timestep: int
         :param def_total_timestep: The functioning timesteps for this iteration for each deferrable load. \
             (For continuous deferrable loads: functioning timesteps at nominal power)
         :type def_total_timestep: list
@@ -3775,6 +3872,8 @@ class Optimization:
             unit_prod_price,
             soc_init=soc_init,
             soc_final=soc_final,
+            soc_target=soc_target,
+            soc_target_timestep=soc_target_timestep,
             def_total_hours=def_total_hours,
             def_total_timestep=def_total_timestep,
             def_start_timestep=def_start_timestep,

--- a/src/emhass/static/data/runtime_params.json
+++ b/src/emhass/static/data/runtime_params.json
@@ -21,6 +21,20 @@
       "default_value": null,
       "unit": "fraction"
     },
+    "soc_target": {
+      "friendly_name": "Intermediate battery state of charge target",
+      "Description": "Optional minimum battery state of charge, as a fraction in [0,1] (NOT percent), that must be reached by soc_target_timestep, after which the battery is free to discharge again. Defaults to no intermediate target (None) so behaviour is unchanged when omitted. Clamped to [battery_minimum_state_of_charge, battery_maximum_state_of_charge] if out of range. An unreachable target by its timestep makes the problem infeasible. Only used by naive-mpc-optim. See issue #553 and passing_data.md.",
+      "input": "float",
+      "default_value": null,
+      "unit": "fraction"
+    },
+    "soc_target_timestep": {
+      "friendly_name": "Intermediate SOC target timestep",
+      "Description": "The 0-based horizon timestep by which soc_target must be met. Defaults to the last timestep when soc_target is given but this is omitted; clamped to [0, prediction_horizon-1]. Ignored when soc_target is not set. Only used by naive-mpc-optim. See issue #553 and passing_data.md.",
+      "input": "int",
+      "default_value": null,
+      "unit": "timesteps"
+    },
     "operating_timesteps_of_each_deferrable_load": {
       "friendly_name": "Operating timesteps of each deferrable load",
       "Description": "Per-deferrable-load total number of operating timesteps over the horizon (the timestep-based alternative to operating_hours_of_each_deferrable_load, preferred for sub-hour steps). One int per deferrable load. Only used by naive-mpc-optim. See passing_data.md.",

--- a/src/emhass/static/openapi.json
+++ b/src/emhass/static/openapi.json
@@ -359,7 +359,7 @@
             "default": 1,
             "title": "Number of forecasted days",
             "x-unit": "days",
-            "description": "The number of days for forecasted data. Defaults to 1. (unit: days)"
+            "description": "The number of days for forecasted data; can be overridden at runtime via runtimeparams. Defaults to 1. For naive-mpc, the forecast window is now extended automatically to cover a longer prediction_horizon, so this parameter usually need not be set manually for multi-day MPC runs. (unit: days)"
           },
           "load_forecast_method": {
             "type": "string",
@@ -441,14 +441,14 @@
           },
           "inverter_ac_output_max": {
             "type": "integer",
-            "default": 0,
+            "default": 5000,
             "title": "Max hybrid inverter AC output power",
             "x-unit": "W",
             "description": "Maximum hybrid inverter output power from combined PV and battery discharge. (unit: W)"
           },
           "inverter_ac_input_max": {
             "type": "integer",
-            "default": 0,
+            "default": 5000,
             "title": "Max hybrid inverter AC input power",
             "x-unit": "W",
             "description": "Maximum hybrid inverter input power from grid to charge battery. (unit: W)"
@@ -705,12 +705,12 @@
           "operating_hours_of_each_deferrable_load": {
             "type": "array",
             "items": {
-              "type": "integer",
+              "type": "number",
               "default": 0
             },
             "title": "Deferrable load operating hours",
             "x-unit": "h",
-            "description": "The total number of hours that each deferrable load should operate (unit: h)"
+            "description": "The total number of hours that each deferrable load should operate. Fractional values are accepted (e.g. 4.5) and scheduled as the exact nominal_power * hours of energy; for control finer than the optimization timestep use operating_timesteps_of_each_deferrable_load. (unit: h)"
           },
           "treat_deferrable_load_as_semi_cont": {
             "type": "array",

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1567,6 +1567,13 @@ async def treat_runtimeparams(
                 )
                 soc_final = params["plant_conf"]["battery_maximum_state_of_charge"]
             params["passed_data"]["soc_final"] = soc_final
+            # Optional intermediate SOC target (issue #553). Both are runtime-only
+            # and default to None (no intermediate target); clamping/validation of
+            # the value and the timestep is handled in Optimization.perform_optimization.
+            params["passed_data"]["soc_target"] = runtimeparams.get("soc_target", None)
+            params["passed_data"]["soc_target_timestep"] = runtimeparams.get(
+                "soc_target_timestep", None
+            )
             if "operating_timesteps_of_each_deferrable_load" in runtimeparams.keys():
                 params["passed_data"]["operating_timesteps_of_each_deferrable_load"] = (
                     runtimeparams["operating_timesteps_of_each_deferrable_load"]
@@ -1590,6 +1597,8 @@ async def treat_runtimeparams(
             params["passed_data"]["prediction_horizon"] = None
             params["passed_data"]["soc_init"] = None
             params["passed_data"]["soc_final"] = None
+            params["passed_data"]["soc_target"] = None
+            params["passed_data"]["soc_target_timestep"] = None
 
         # Parsing the thermal model parameters
         # Load the default config
@@ -3019,6 +3028,8 @@ async def build_params(
         "prediction_horizon": None,
         "soc_init": None,
         "soc_final": None,
+        "soc_target": None,
+        "soc_target_timestep": None,
         "operating_hours_of_each_deferrable_load": None,
         "start_timesteps_of_each_deferrable_load": None,
         "end_timesteps_of_each_deferrable_load": None,

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -576,6 +576,201 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             soc_final,
         )
 
+    def test_perform_naive_mpc_optim_intermediate_soc_target(self):
+        """Issue #553: an intermediate ``soc_target`` must be met by
+        ``soc_target_timestep`` while the battery is still free to discharge
+        afterward, and passing no target must leave behaviour unchanged.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        # Flat, equal buy/sell prices -> zero time-arbitrage incentive. With a
+        # lossless battery any charge/discharge round-trip is exactly cost-neutral,
+        # so the unconstrained baseline has no economic reason to move the battery.
+        self.df_input_data_dayahead["unit_load_cost"] = 0.2
+        self.df_input_data_dayahead["unit_prod_price"] = 0.2
+        self.optim_conf.update({"set_use_battery": True})
+        self.optim_conf.update({"number_of_deferrable_loads": 0})
+        self.optim_conf.update({"set_battery_dynamic": False})
+        # A small positive cycle cost makes leaving the battery untouched the
+        # unique baseline optimum (any cycling is then strictly worse), so the
+        # charge seen in the targeted run is unambiguously caused by the floor.
+        self.optim_conf.update({"weight_battery_discharge": 1.0})
+        self.optim_conf.update({"weight_battery_charge": 1.0})
+        # Allow export so the battery can discharge down to soc_final (otherwise
+        # the no-discharge-to-grid default makes shedding 0.8->0.5 infeasible when
+        # local load is low). This keeps the test focused on the intermediate target.
+        self.optim_conf.update({"set_nodischarge_to_grid": False})
+        # Clean, ample battery so a mid-horizon target is reachable and the
+        # SOC trajectory is deterministic (no efficiency losses).
+        self.plant_conf.update(
+            {
+                "battery_nominal_energy_capacity": 10000,
+                "battery_discharge_power_max": 20000,
+                "battery_charge_power_max": 20000,
+                "battery_minimum_state_of_charge": 0.0,
+                "battery_maximum_state_of_charge": 1.0,
+                "battery_discharge_efficiency": 1.0,
+                "battery_charge_efficiency": 1.0,
+            }
+        )
+        prediction_horizon = 10
+        # Deterministic charge-up scenario: start and end low so the
+        # unconstrained baseline has no reason to charge (it stays ~soc_init),
+        # but a mid-horizon target forces a clear charge 0.3->0.9 by step 5 and
+        # back to 0.3 — feasible at 20 kW / 10 kWh / eff 1.0.
+        soc_init = 0.3
+        soc_final = 0.3
+        target_step = 5
+        soc_target = 0.9
+
+        # Baseline (no intermediate target) — establishes the unconstrained SOC.
+        self.opt = self.create_optimization()
+        opt_res_baseline = self.opt.perform_naive_mpc_optim(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast,
+            self.p_load_forecast,
+            prediction_horizon,
+            soc_init=soc_init,
+            soc_final=soc_final,
+        )
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+        self.assertIn("SOC_opt", opt_res_baseline.columns)
+        soc_baseline_at_step = opt_res_baseline["SOC_opt"].iloc[target_step]
+        # No-op-by-default coverage: with no target and no arbitrage incentive the
+        # baseline leaves the battery on soc_init, well below the target. This is
+        # what proves the floor param (not arbitrage / tie-breaking) drives the
+        # change in the targeted run below.
+        self.assertAlmostEqual(soc_baseline_at_step, soc_init, delta=1e-2)
+        self.assertLess(soc_baseline_at_step, soc_target - 0.2)
+
+        # With intermediate target — SOC at target_step must meet/exceed soc_target.
+        self.opt = self.create_optimization()
+        opt_res_target = self.opt.perform_naive_mpc_optim(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast,
+            self.p_load_forecast,
+            prediction_horizon,
+            soc_init=soc_init,
+            soc_final=soc_final,
+            soc_target=soc_target,
+            soc_target_timestep=target_step,
+        )
+        self.assertEqual(self.opt.optim_status, "Optimal")
+        self.assertIn("SOC_opt", opt_res_target.columns)
+        # Lock in the DPP fix: a non-DPP product of two parameters would force
+        # recanonicalisation and flip this to False (this is what catches Fix 1
+        # regressing).
+        self.assertTrue(self.opt.prob.is_dpp())
+        soc_target_at_step = opt_res_target["SOC_opt"].iloc[target_step]
+
+        # 1) The target is enforced at the requested timestep.
+        self.assertGreaterEqual(soc_target_at_step, soc_target - 1e-3)
+        # 2) The constraint actually bit: the targeted run holds clearly more
+        #    charge at the target step than the unconstrained baseline did.
+        self.assertGreaterEqual(soc_target_at_step, soc_baseline_at_step + 0.2)
+        # 3) The battery is still free to discharge afterward: the end-of-horizon
+        #    SOC still lands on soc_final (target does not pin the tail).
+        self.assertLess(
+            np.abs(opt_res_target.loc[opt_res_target.index[-1], "SOC_opt"] - soc_final),
+            1e-2,
+        )
+
+    def test_intermediate_soc_target_clamped_above_max(self):
+        """Issue #553: a soc_target above battery_maximum_state_of_charge is
+        clamped to the ceiling (with a warning) instead of forcing infeasibility.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        self.df_input_data_dayahead["unit_load_cost"] = 0.2
+        self.df_input_data_dayahead["unit_prod_price"] = 0.2
+        self.optim_conf.update({"set_use_battery": True})
+        self.optim_conf.update({"number_of_deferrable_loads": 0})
+        self.optim_conf.update({"set_battery_dynamic": False})
+        self.optim_conf.update({"set_nodischarge_to_grid": False})
+        soc_max = 0.8
+        self.plant_conf.update(
+            {
+                "battery_nominal_energy_capacity": 10000,
+                "battery_discharge_power_max": 20000,
+                "battery_charge_power_max": 20000,
+                "battery_minimum_state_of_charge": 0.0,
+                "battery_maximum_state_of_charge": soc_max,
+                "battery_discharge_efficiency": 1.0,
+                "battery_charge_efficiency": 1.0,
+            }
+        )
+        self.opt = self.create_optimization()
+        with self.assertLogs(level="WARNING") as logs:
+            opt_res = self.opt.perform_naive_mpc_optim(
+                self.df_input_data_dayahead,
+                self.p_pv_forecast,
+                self.p_load_forecast,
+                10,
+                soc_init=0.3,
+                soc_final=0.3,
+                soc_target=1.5,  # absurd: above the 0.8 ceiling
+                soc_target_timestep=5,
+            )
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+        # Clamped: the target step reaches the ceiling and SOC never exceeds it.
+        self.assertGreaterEqual(opt_res["SOC_opt"].iloc[5], soc_max - 1e-3)
+        self.assertLessEqual(opt_res["SOC_opt"].max(), soc_max + 1e-3)
+        # And the out-of-range request is surfaced to the user.
+        self.assertTrue(
+            any("outside" in line for line in logs.output),
+            msg=f"expected an out-of-range clamp warning, got: {logs.output}",
+        )
+
+    def test_intermediate_soc_target_below_soc_init_is_noop(self):
+        """Issue #553: a soc_target at or below the SoC the battery already holds
+        builds a non-biting floor, so the optimized plan is unchanged vs no target.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        self.df_input_data_dayahead["unit_load_cost"] = 0.2
+        self.df_input_data_dayahead["unit_prod_price"] = 0.2
+        self.optim_conf.update({"set_use_battery": True})
+        self.optim_conf.update({"number_of_deferrable_loads": 0})
+        self.optim_conf.update({"set_battery_dynamic": False})
+        self.optim_conf.update({"set_nodischarge_to_grid": False})
+        self.optim_conf.update({"weight_battery_discharge": 1.0})
+        self.optim_conf.update({"weight_battery_charge": 1.0})
+        self.plant_conf.update(
+            {
+                "battery_nominal_energy_capacity": 10000,
+                "battery_discharge_power_max": 20000,
+                "battery_charge_power_max": 20000,
+                "battery_minimum_state_of_charge": 0.0,
+                "battery_maximum_state_of_charge": 1.0,
+                "battery_discharge_efficiency": 1.0,
+                "battery_charge_efficiency": 1.0,
+            }
+        )
+        self.opt = self.create_optimization()
+        opt_res_baseline = self.opt.perform_naive_mpc_optim(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast,
+            self.p_load_forecast,
+            10,
+            soc_init=0.3,
+            soc_final=0.3,
+        )
+        self.opt = self.create_optimization()
+        opt_res_low_target = self.opt.perform_naive_mpc_optim(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast,
+            self.p_load_forecast,
+            10,
+            soc_init=0.3,
+            soc_final=0.3,
+            soc_target=0.2,  # below soc_init -> floor never binds
+            soc_target_timestep=5,
+        )
+        # Identical optimized SoC trajectory: the floor imposed nothing.
+        assert_series_equal(
+            opt_res_baseline["SOC_opt"],
+            opt_res_low_target["SOC_opt"],
+            atol=1e-3,
+            check_names=False,
+        )
+
     def test_perform_naive_mpc_optim_weight_scaling(self):
         """
         Regression test: Ensure weights are applied element-wise, not as matrix multiplication.

--- a/tests/test_runtime_params.py
+++ b/tests/test_runtime_params.py
@@ -49,6 +49,8 @@ EXPECTED_KEYS = {
     "prediction_horizon",
     "soc_init",
     "soc_final",
+    "soc_target",
+    "soc_target_timestep",
     "operating_timesteps_of_each_deferrable_load",
     "alpha",
     "beta",


### PR DESCRIPTION
## What

Two optional `naive-mpc-optim` runtime parameters to require a minimum battery SoC **inside** the horizon, not just at the end:

- **`soc_target`** — desired minimum SoC (fraction in `[0, 1]`); clamped to `[battery_minimum_state_of_charge, battery_maximum_state_of_charge]`.
- **`soc_target_timestep`** — 0-based horizon step by which it must be met (defaults to the last step).

This implements the request in #553 — e.g. "reach 100% by mid-afternoon, then be free to discharge into the evening peak." Today the only SoC target is `soc_final`, which applies only at the horizon end.

## Design

- A one-sided floor `SOC[k] >= soc_target` implemented as a **single precomputed `cp.Parameter` floor vector** (zeros = no-op), set numerically in `perform_optimization`.
- **DPP / warm-start safe** — the floor is computed in NumPy at parameter-set time, so the cached problem stays DPP and re-solves warm-start. A `self.prob.is_dpp()` assertion in the test locks this in.
- **Opt-in, zero behaviour change when unset** — the floor defaults to all-zeros (constraint becomes `SOC >= 0`, a no-op), and is reset on every call so a target can't leak between runs.
- `>=` only, so it never forces a discharge; `soc_final` still governs the tail (the battery is free to discharge after the target step).
- Out-of-range targets are clamped (with a warning); a best-effort reachability check warns when a target likely can't be met in time (which would otherwise surface as LP infeasibility).

## Usage

```json
{ "prediction_horizon": 48, "soc_init": 0.30, "soc_target": 1.0, "soc_target_timestep": 14 }
```

"Be at 100% by horizon step 14, then discharge after." Documented in `passing_data.md` with a Home Assistant `rest_command` example and a reachability note.

## Included

- Constraint + single floor parameter in `optimization.py` (`perform_optimization` and `perform_naive_mpc_optim` signatures + docstrings), with string/float-tolerant timestep parsing and clamp/reachability warnings.
- Runtime plumbing through `utils.py` (`treat_runtimeparams`) and `command_line.py`.
- `runtime_params.json` schema entries.
- Docs: worked example + reachability warning.
- A test asserting the target is met at the requested step, the plan changes vs an unconstrained baseline, the end-of-horizon SoC still lands on `soc_final`, and `prob.is_dpp()` (warm-start caching preserved). The battery / MPC / schema test sweep passes locally.

## Open to feedback

I kept this a **hard** constraint to match #553. Happy to add a **soft-penalty** variant (to degrade gracefully instead of going infeasible when a target is unreachable), or to generalise to **multiple / per-step** targets, if you'd prefer either direction.
