### PR TITLE
fix: surface infeasible optimization on publish instead of KeyError (#875)

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -2555,6 +2555,20 @@ async def publish_data(
         opt_res_latest = _load_opt_res_latest(input_data_dict, logger, save_data_to_file)
         if opt_res_latest is None:
             return None
+    # A failed/infeasible optimization yields a results frame with only the
+    # optim_status column (see Optimization.perform_optimization); the forecast
+    # and battery columns are absent. Publishing it would crash on the first
+    # lookup (e.g. opt_res_latest["P_Load"]). Surface the failure instead.
+    if "P_Load" not in opt_res_latest.columns:
+        status = "unknown"
+        if "optim_status" in opt_res_latest.columns and not opt_res_latest.empty:
+            status = opt_res_latest["optim_status"].iloc[0]
+        logger.error(
+            "Optimization result is incomplete (status: %s); nothing to publish. "
+            "Run a successful optimization before publishing.",
+            status,
+        )
+        return None
     # Determine Closest Index
     idx_closest = _get_closest_index(input_data_dict["retrieve_hass_conf"], opt_res_latest.index)
     # Create Context

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -2075,6 +2075,26 @@ class TestSchemaVersion(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.attrs["emhass_schema_version"], EMHASS_SCHEMA_VERSION)
 
 
+class TestPublishInfeasibleGuard(unittest.IsolatedAsyncioTestCase):
+    """Regression test for #875.
+
+    When the optimization comes back infeasible, perform_optimization returns a
+    frame containing only the optim_status column. publish_data used to crash with
+    KeyError: 'P_Load' (reported by g1za and ztega). It should now log and return
+    None instead.
+    """
+
+    async def test_publish_data_infeasible_returns_none(self):
+        idx = pd.date_range("2024-01-01", periods=3, freq="30min", tz="UTC")
+        infeasible_res = pd.DataFrame({"optim_status": ["Infeasible"] * 3}, index=idx)
+        with patch(
+            "emhass.command_line._get_params",
+            return_value={"passed_data": {"publish_prefix": ""}},
+        ):
+            result = await publish_data({}, logger, opt_res_latest=infeasible_res)
+        self.assertIsNone(result)
+
+
 class TestOptimizationCache(unittest.TestCase):
     """Unit tests for the OptimizationCache warm-starting functionality."""
 


### PR DESCRIPTION
## What

`publish_data` crashes with `KeyError: 'P_Load'` when the optimization came back infeasible.

When a solve fails (MILP infeasible and the relaxed LP also infeasible), `perform_optimization` returns a results frame that only has the `optim_status` column. `publish_data` never checks for that, so the first forecast lookup in `_publish_standard_forecasts` (`opt_res_latest["P_Load"]`) throws.

Reported in #875 by @g1za and @ztega, both hitting it on the first run after a restart:

```
ERROR in optimization: Relaxed optimization also failed with status: infeasible
ERROR in app: Exception on request POST /action/publish-data
KeyError: 'P_Load'
```

## Change

One guard in `publish_data`: if the loaded result has no `P_Load` column, log the optim status and return `None` instead of crashing.

I check for the `P_Load` column rather than the status string on purpose. A successful relaxed solve reports `optim_status` as `Optimal (Relaxed)` (there is also `Optimal_Inaccurate`), and those results are complete and should still publish. Column presence is really "is there anything to publish", which is what matters here.

## Scope

This only stops the crash. It does not make an infeasible problem solve. The underlying infeasibility some users in #875 report is a separate thread, and at least one case there is a different non-hybrid regression still being narrowed down.

## Test

`tests/test_command_line_utils.py::TestPublishInfeasibleGuard` feeds `publish_data` an infeasible-shaped frame (only `optim_status`) and asserts it returns `None` without raising.

refs #875

## Summary by Sourcery

Guard publish_data against incomplete optimization results that lack forecast columns and add a regression test for infeasible optimization outputs.

Bug Fixes:
- Prevent publish_data from raising KeyError when optimization results only contain optim_status for infeasible solves.

Tests:
- Add regression test ensuring publish_data returns None without error when given an infeasible-shaped optimization result.