### PR TITLE
test: raise node subprocess timeout to 120s for Windows CI flake

### DIFF
--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -9,6 +9,9 @@ from pathlib import Path
 import pytest
 
 _NODE = shutil.which("node")
+# Node cold-start can be slow on loaded Windows CI runners; 30 s still flaked
+# (test_minus_elements_does_not_crash_on_zero_inputs timed out). Give it headroom.
+_NODE_TIMEOUT_S = 120
 
 # Keys in config_defaults.json with no param_definitions.json entry.
 # These are ML-subsystem parameters not represented in the UI schema.
@@ -210,7 +213,9 @@ def _run_node(script: str) -> subprocess.CompletedProcess:
         f.write(script)
         tmp = f.name
     try:
-        return subprocess.run([_NODE, tmp], capture_output=True, text=True, timeout=30)
+        return subprocess.run(
+            [_NODE, tmp], capture_output=True, text=True, timeout=_NODE_TIMEOUT_S
+        )
     finally:
         os.unlink(tmp)
 

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -213,9 +213,7 @@ def _run_node(script: str) -> subprocess.CompletedProcess:
         f.write(script)
         tmp = f.name
     try:
-        return subprocess.run(
-            [_NODE, tmp], capture_output=True, text=True, timeout=_NODE_TIMEOUT_S
-        )
+        return subprocess.run([_NODE, tmp], capture_output=True, text=True, timeout=_NODE_TIMEOUT_S)
     finally:
         os.unlink(tmp)
 


### PR DESCRIPTION
## What

`test_schema_contract.py::test_minus_elements_does_not_crash_on_zero_inputs` flakes on the `windows-latest` runner with:

```
subprocess.TimeoutExpired: Command '[node ... tmp.js]' timed out after 30 seconds
```

It passes on ubuntu, macos and the debian arm/amd builds, and passes locally. Node cold-start under load on the Windows runner just occasionally runs past the 30s cap. The timeout was already bumped to 30s once for Windows (ae4a675), so this raises the shared `_run_node` helper to 120s.

## Change

One constant in `tests/test_schema_contract.py`: `_run_node` timeout 30s -> 120s. Test-only, no production code touched. It's a real wall-clock cap, so a genuine hang would still fail, just with more headroom against runner contention.

This is the lone red check showing up on recent PRs' Windows builds (e.g. #934), unrelated to those changes.

## Summary by Sourcery

Tests:
- Raise the shared Node subprocess timeout in the schema contract tests from 30s to 120s to accommodate slow cold-starts on Windows CI runners.