### PR TITLE
docs: correct stale "integer hours only" claim for operating_hours_of_each_deferrable_load + add regression test (#373)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -61,7 +61,7 @@ These are the parameters needed to properly define the optimization problem.
 - `nominal_power_of_deferrable_loads`: The nominal power for each deferrable load in Watts. This is a list with a number of elements consistent with the number of deferrable loads defined before. For example:
 	- 3000
 	- 750
-- `operating_hours_of_each_deferrable_load`: The total number of hours that each deferrable load should operate. For example:
+- `operating_hours_of_each_deferrable_load`: The total number of hours that each deferrable load should operate. Fractional values are accepted (e.g. `4.5`); the optimizer schedules the exact `nominal_power × hours` of energy. For control finer than the optimization timestep you can also pass `operating_timesteps_of_each_deferrable_load`. For example:
 	- 5
 	- 8
 - `start_timesteps_of_each_deferrable_load`: A list of integers defining the **earliest time step index** from which each deferrable load is allowed to start consuming power.

--- a/docs/cookbook/transport_nodered_mpc_orchestration.md
+++ b/docs/cookbook/transport_nodered_mpc_orchestration.md
@@ -32,7 +32,7 @@ Reference table of the runtime params accepted by `treat_runtimeparams` that thi
 
 | Field | Type | Purpose |
 |---|---|---|
-| `operating_hours_of_each_deferrable_load` | `list[int]` | hours each deferrable should run |
+| `operating_hours_of_each_deferrable_load` | `list[float]` | hours each deferrable should run (fractional allowed) |
 | `start_timesteps_of_each_deferrable_load` | `list[int]` | earliest allowed step per deferrable |
 | `end_timesteps_of_each_deferrable_load` | `list[int]` | latest allowed step per deferrable |
 | `load_cost_forecast` | `list[float]` | per-timestep tariff for load |

--- a/docs/study_cases/ev.md
+++ b/docs/study_cases/ev.md
@@ -55,7 +55,7 @@ Two values you compute fresh per MPC call:
 
 | Variable | Source | Calculation |
 |----------|--------|-------------|
-| `def_total_hours[2]` | a sensor that reports remaining kWh to deliver | `kWh_remaining / charger_kW`, rounded to whole hours (see *Known limits*) |
+| `def_total_hours[2]` | a sensor that reports remaining kWh to deliver | `kWh_remaining / charger_kW` (fractional hours are fine) |
 | `end_timesteps_of_each_deferrable_load[2]` | departure deadline | `(deadline - now) / optimization_time_step_minutes`, integer |
 
 A Home Assistant `rest_command` template, source-agnostic:
@@ -73,7 +73,7 @@ rest_command:
       {%- set timestep_min = 30 -%}
       {%- set horizon = 48 -%}
       {%- set ev_remaining_kwh = states('sensor.YOUR_EV_REMAINING_KWH') | float -%}
-      {%- set ev_hours = (ev_remaining_kwh / charger_kw) | round(0, 'ceil') | int -%}
+      {%- set ev_hours = (ev_remaining_kwh / charger_kw) | round(2) -%}
       {%- set deadline = today_at("07:00") if now() < today_at("07:00") else today_at("07:00") + timedelta(days=1) -%}
       {%- set departure_minutes = (deadline - now()).total_seconds() / 60 -%}
       {%- set end_step = (departure_minutes / timestep_min) | int -%}
@@ -123,7 +123,7 @@ Replace `switch.YOUR_EV_CHARGER` with the actual control entity for your charger
 
 Read these before designing around the pattern above.
 
-- **Integer hours only.** `operating_hours_of_each_deferrable_load` accepts whole hours, not fractions ([issue #373](https://github.com/davidusb-geek/emhass/issues/373)). With a 30-minute timestep and an 11 kW charger, that means kWh-required is rounded up to the next 11 kWh increment. Reduce the rounding error by using a smaller `optimization_time_step` (e.g. 15 minutes) — but then 48 timesteps becomes 96.
+- **Fractional hours are honoured.** `operating_hours_of_each_deferrable_load` accepts fractional values (e.g. `1.25`); EMHASS targets exactly `nominal_power × hours` of energy ([issue #373](https://github.com/davidusb-geek/emhass/issues/373)), so a smaller `optimization_time_step` is no longer required just for charge-amount precision. A value that isn't a whole number of timesteps is still met exactly on an energy basis; for a single fixed on-block (`set_deferrable_load_single_constant`) prefer a timestep-aligned value or `operating_timesteps_of_each_deferrable_load`.
 - **Power modulation is not supported.** EMHASS schedules the deferrable as either-on-at-nominal-power-or-off per timestep. Modulating chargers (e.g. Tesla 3.6–11 kW continuous) cannot be cleanly expressed as a single deferrable; you would need multiple parallel deferrable slots at different powers, or model only the upper bound.
 - **Mid-session state is not forced.** `def_current_state` flags the load as currently-on for startup-penalty purposes but does not force the optimizer to plan a non-zero power for the first timestep ([issue #605](https://github.com/davidusb-geek/emhass/issues/605)). If you start charging manually mid-window, the optimizer may plan to stop and re-start.
 - **No native vehicle-API integration.** EMHASS does not query the vehicle SOC directly; you provide kWh-remaining via a sensor. The community has seen this gap and discussed approaches in [#789](https://github.com/davidusb-geek/emhass/discussions/789), including a fork by @tomvanacker85 with calendar-driven SOC targets. None of those have been upstreamed.

--- a/docs/study_cases/reference_configs.md
+++ b/docs/study_cases/reference_configs.md
@@ -5,7 +5,7 @@
 These are anonymized, abstract templates. They are not real users' systems. Each block is a starting point — the parameter values reflect typical hardware in the archetype, but you must verify against your own equipment. See [Configuration](../config.md) for the full parameter reference.
 
 ```{note}
-**Integer hours only.** `operating_hours_of_each_deferrable_load` accepts whole integers (see [issue #373](https://github.com/davidusb-geek/emhass/issues/373)). The blueprints below round all hour values up to the nearest integer. If your loads need finer control, reduce `optimization_time_step` (e.g. to 15 minutes) so the same wall-clock duration spans more timesteps.
+**Fractional hours are supported.** `operating_hours_of_each_deferrable_load` accepts fractional values; the optimizer targets exactly `nominal_power × hours` of energy (see [issue #373](https://github.com/davidusb-geek/emhass/issues/373)). The blueprints below use whole-hour values for readability, but you can specify e.g. `3.5`. For control finer than the optimization timestep you can also reduce `optimization_time_step` or pass `operating_timesteps_of_each_deferrable_load`.
 ```
 
 ## 1. Single-family home — PV + battery + heat pump + EV + dynamic tariff

--- a/src/emhass/static/data/param_definitions.json
+++ b/src/emhass/static/data/param_definitions.json
@@ -492,8 +492,8 @@
     },
     "operating_hours_of_each_deferrable_load": {
       "friendly_name": "Deferrable load operating hours",
-      "Description": "The total number of hours that each deferrable load should operate",
-      "input": "array.int",
+      "Description": "The total number of hours that each deferrable load should operate. Fractional values are accepted (e.g. 4.5) and scheduled as the exact nominal_power * hours of energy; for control finer than the optimization timestep use operating_timesteps_of_each_deferrable_load.",
+      "input": "array.float",
       "default_value": 0,
       "unit": "h"
     },

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -4775,6 +4775,45 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             "Load 1 with 0 hours should be deactivated",
         )
 
+    def test_fractional_operating_hours(self):
+        """Fractional ``operating_hours_of_each_deferrable_load`` are honoured and
+        schedule the exact corresponding energy (regression for issue #373).
+
+        ``assert_energy_constraint`` checks scheduled energy == ``nominal_power *
+        fractional_hours`` to 1e-3 Wh. An integer-only implementation would
+        truncate/round e.g. 2.5 h to 2 or 3 h and produce ``nominal_power * {2, 3}``
+        Wh, so the assertion (plus the explicit integer-counterfactual below)
+        cannot false-green.
+        """
+        nominal = self.optim_conf["nominal_power_of_deferrable_loads"][0]
+        timestep_h = self.retrieve_hass_conf["optimization_time_step"].seconds / 3600
+        # 2.5 h: non-integer, timestep-aligned. 1.25 h: sub-timestep fraction.
+        for fractional_hours in (2.5, 1.25):
+            self.optim_conf.update(
+                {"operating_hours_of_each_deferrable_load": [fractional_hours, 0]}
+            )
+            self.opt = self.create_optimization()
+            self.df_input_data_dayahead = self.prepare_forecast_data()
+            opt_res = self.opt.perform_dayahead_forecast_optim(
+                self.df_input_data_dayahead, self.p_pv_forecast, self.p_load_forecast
+            )
+            # A sub-timestep fraction (1.25 h at a 30-min step) makes the strict MILP
+            # infeasible, so EMHASS falls back to the relaxed LP ("Optimal (Relaxed)").
+            # The target-energy equality is enforced on both solve paths, so the energy
+            # assertion below still holds; VALID_OPTIMAL_STATUSES accepts both statuses.
+            self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+            # Exact fractional energy = nominal_power * fractional_hours.
+            self.assert_energy_constraint(opt_res["P_deferrable0"], fractional_hours)
+            # Discriminating counterfactual: energy must not match integer-rounded hours.
+            actual_energy = opt_res["P_deferrable0"].sum() * timestep_h
+            for integer_hours in (int(fractional_hours), int(fractional_hours) + 1):
+                self.assertGreater(
+                    abs(actual_energy - nominal * integer_hours),
+                    1.0,
+                    f"Energy {actual_energy:.1f} Wh matches integer {integer_hours} h "
+                    "-> fractional hours not honoured",
+                )
+
     def test_deferrable_load_group_shared_power(self):
         """Test that shared power budget constraint limits combined power of grouped loads."""
         self.optim_conf.update(
@@ -5369,11 +5408,11 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
 
         logger.debug("Pdef0\n{}".format(opt_res["P_deferrable0"]))
         logger.debug("Pdef1\n{}".format(opt_res["P_deferrable1"]))
-        
+
         # Verify load 0 was not scheduled, load 1 was
         self.assertTrue(np.allclose(opt_res["P_deferrable0"], 0.0))
         self.assertTrue(np.allclose(opt_res["P_deferrable1"], [0, 1000, 1000, 0]))
-        
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -4787,32 +4787,39 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         """
         nominal = self.optim_conf["nominal_power_of_deferrable_loads"][0]
         timestep_h = self.retrieve_hass_conf["optimization_time_step"].seconds / 3600
-        # 2.5 h: non-integer, timestep-aligned. 1.25 h: sub-timestep fraction.
+        # Counterfactual margin tied to the problem scale rather than a magic number:
+        # 10% of one timestep's energy. Far above solver noise (~1e-3 Wh) yet far below
+        # the >=750 Wh gap from either test value to its nearest integer-hour schedule,
+        # so it stays valid if the timestep or nominal power are changed.
+        integer_margin = 0.1 * nominal * timestep_h
+        # 2.5 h: non-integer, timestep-aligned. 1.25 h: sub-timestep fraction. subTest
+        # reports each regime independently so a failure pinpoints which one broke.
         for fractional_hours in (2.5, 1.25):
-            self.optim_conf.update(
-                {"operating_hours_of_each_deferrable_load": [fractional_hours, 0]}
-            )
-            self.opt = self.create_optimization()
-            self.df_input_data_dayahead = self.prepare_forecast_data()
-            opt_res = self.opt.perform_dayahead_forecast_optim(
-                self.df_input_data_dayahead, self.p_pv_forecast, self.p_load_forecast
-            )
-            # A sub-timestep fraction (1.25 h at a 30-min step) makes the strict MILP
-            # infeasible, so EMHASS falls back to the relaxed LP ("Optimal (Relaxed)").
-            # The target-energy equality is enforced on both solve paths, so the energy
-            # assertion below still holds; VALID_OPTIMAL_STATUSES accepts both statuses.
-            self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
-            # Exact fractional energy = nominal_power * fractional_hours.
-            self.assert_energy_constraint(opt_res["P_deferrable0"], fractional_hours)
-            # Discriminating counterfactual: energy must not match integer-rounded hours.
-            actual_energy = opt_res["P_deferrable0"].sum() * timestep_h
-            for integer_hours in (int(fractional_hours), int(fractional_hours) + 1):
-                self.assertGreater(
-                    abs(actual_energy - nominal * integer_hours),
-                    1.0,
-                    f"Energy {actual_energy:.1f} Wh matches integer {integer_hours} h "
-                    "-> fractional hours not honoured",
+            with self.subTest(fractional_hours=fractional_hours):
+                self.optim_conf.update(
+                    {"operating_hours_of_each_deferrable_load": [fractional_hours, 0]}
                 )
+                self.opt = self.create_optimization()
+                self.df_input_data_dayahead = self.prepare_forecast_data()
+                opt_res = self.opt.perform_dayahead_forecast_optim(
+                    self.df_input_data_dayahead, self.p_pv_forecast, self.p_load_forecast
+                )
+                # A sub-timestep fraction (1.25 h at a 30-min step) makes the strict MILP
+                # infeasible, so EMHASS falls back to the relaxed LP ("Optimal (Relaxed)").
+                # The target-energy equality is enforced on both solve paths, so the energy
+                # assertion below still holds; VALID_OPTIMAL_STATUSES accepts both statuses.
+                self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+                # Exact fractional energy = nominal_power * fractional_hours.
+                self.assert_energy_constraint(opt_res["P_deferrable0"], fractional_hours)
+                # Discriminating counterfactual: energy must not match integer-rounded hours.
+                actual_energy = opt_res["P_deferrable0"].sum() * timestep_h
+                for integer_hours in (int(fractional_hours), int(fractional_hours) + 1):
+                    self.assertGreater(
+                        abs(actual_energy - nominal * integer_hours),
+                        integer_margin,
+                        f"Energy {actual_energy:.1f} Wh matches integer {integer_hours} h "
+                        "-> fractional hours not honoured",
+                    )
 
     def test_deferrable_load_group_shared_power(self):
         """Test that shared power budget constraint limits combined power of grouped loads."""


### PR DESCRIPTION
## Summary

`operating_hours_of_each_deferrable_load` **already accepts fractional values** in the current code (and in the v0.17.6 release): the optimizer computes `target_energy = nominal_power * operating_hours` and `required_timesteps = ceil(operating_hours / time_step)`, so a fractional value schedules the exact `nominal_power × hours` of energy. This PR does **not** add that — it has been the behaviour since the CVXPY optimizer landed.

What this PR fixes is the **documentation**: several study-case docs (added April 2026) describe the parameter as *integer-only* and cite this issue as an open limitation, which isn't accurate. This corrects the docs, locks the behaviour with a regression test, and aligns the parameter's UI schema hint.

## Evidence (it already works)

Day-ahead optim with a fractional value (default 30-min timestep, nominal 3000 W) schedules the exact energy:

| `operating_hours` | scheduled energy | (integer rounding would give) |
|---|---|---|
| 2.5 | 7500 Wh | 6000 / 9000 |
| 1.25 | 3750 Wh | 3000 / 6000 |
| 0.1 (sub-timestep) | 300 Wh | 0 / 3000 |

## Changes

- **Test** — `tests/test_optimization.py::test_fractional_operating_hours`: asserts a fractional `operating_hours` schedules `nominal_power × hours` of energy (to 1e-3 Wh) for 2.5 h and 1.25 h, with an explicit integer-rounding counterfactual so it cannot false-green.
- **Docs** — correct the "integer hours only" claims in `docs/study_cases/ev.md` and `docs/study_cases/reference_configs.md`, the `list[int]` type hint in `docs/cookbook/transport_nodered_mpc_orchestration.md`, and clarify `docs/config.md`. Each now states fractional values are accepted and points to `operating_timesteps_of_each_deferrable_load` for control finer than the timestep.
- **Schema** — `src/emhass/static/data/param_definitions.json`: change `operating_hours_of_each_deferrable_load` `input` from `array.int` to `array.float`, consistent with the sibling deferrable-load float params (`nominal_power_of_deferrable_loads`, `minimum_power_of_deferrable_loads`, …). This field is UI metadata only — not read by the Python runtime, and the config-page JS already parses the input with `parseFloat` — so it has no runtime effect; it simply lets the config UI accept decimals.

## Behaviour notes (full disclosure)

- No optimizer/source logic is changed — this is docs + a test + a UI schema hint.
- A fraction that isn't a whole number of timesteps (e.g. 1.25 h at a 30-min step, or a `set_deferrable_load_single_constant` load at 2.4 h) makes the strict MILP infeasible, so EMHASS falls back to the relaxed LP (`Optimal (Relaxed)`). **The target energy is still met exactly**; only the strict single-constant/binary structure relaxes. For exact on-block structure, use a timestep-aligned value or the runtime parameter `operating_timesteps_of_each_deferrable_load`.
- Incidental: `ruff` stripped trailing whitespace on 2 pre-existing blank lines in `tests/test_optimization.py` (same file).
- Happy to split the `param_definitions.json` change into its own PR if you'd prefer the schema hint to have a separate review thread.

## Tests

`uv run pytest tests/test_optimization.py` passes locally (108 passed, incl. the new test). `ruff check` / `ruff format --check` clean on the changed file.

Closes #373.

## Summary by Sourcery

Clarify that deferrable load operating hours support fractional values, aligning documentation, tests, and UI metadata with existing optimizer behavior.

Enhancements:
- Add a regression test to verify that fractional operating hours schedule the exact target energy for deferrable loads.
- Update configuration UI parameter metadata so `operating_hours_of_each_deferrable_load` accepts floating-point values instead of integers.

Documentation:
- Correct study case and configuration documentation to state that `operating_hours_of_each_deferrable_load` supports fractional hours, and reference `operating_timesteps_of_each_deferrable_load` for finer control.

Tests:
- Add a fractional operating hours regression test for deferrable-load optimization, including a counterfactual check against integer rounding.