### PR TITLE
fix: regenerate committed openapi.json (stale vs param_definitions)

### DIFF
--- a/src/emhass/static/openapi.json
+++ b/src/emhass/static/openapi.json
@@ -359,7 +359,7 @@
             "default": 1,
             "title": "Number of forecasted days",
             "x-unit": "days",
-            "description": "The number of days for forecasted data. Defaults to 1. (unit: days)"
+            "description": "The number of days for forecasted data; can be overridden at runtime via runtimeparams. Defaults to 1. For naive-mpc, the forecast window is now extended automatically to cover a longer prediction_horizon, so this parameter usually need not be set manually for multi-day MPC runs. (unit: days)"
           },
           "load_forecast_method": {
             "type": "string",
@@ -441,14 +441,14 @@
           },
           "inverter_ac_output_max": {
             "type": "integer",
-            "default": 0,
+            "default": 5000,
             "title": "Max hybrid inverter AC output power",
             "x-unit": "W",
             "description": "Maximum hybrid inverter output power from combined PV and battery discharge. (unit: W)"
           },
           "inverter_ac_input_max": {
             "type": "integer",
-            "default": 0,
+            "default": 5000,
             "title": "Max hybrid inverter AC input power",
             "x-unit": "W",
             "description": "Maximum hybrid inverter input power from grid to charge battery. (unit: W)"
@@ -705,12 +705,12 @@
           "operating_hours_of_each_deferrable_load": {
             "type": "array",
             "items": {
-              "type": "integer",
+              "type": "number",
               "default": 0
             },
             "title": "Deferrable load operating hours",
             "x-unit": "h",
-            "description": "The total number of hours that each deferrable load should operate (unit: h)"
+            "description": "The total number of hours that each deferrable load should operate. Fractional values are accepted (e.g. 4.5) and scheduled as the exact nominal_power * hours of energy; for control finer than the optimization timestep use operating_timesteps_of_each_deferrable_load. (unit: h)"
           },
           "treat_deferrable_load_as_semi_cont": {
             "type": "array",


### PR DESCRIPTION
## Problem

`tests/test_openapi.py::TestOpenapiArtifact::test_committed_matches_generated` is currently **failing on `master`** — the committed `src/emhass/static/openapi.json` has drifted from what `scripts/generate_openapi.py` produces.

## Cause

A few recent changes edited `src/emhass/static/data/param_definitions.json` (titles/defaults/descriptions) without re-running the generator, so the committed spec went stale:

- hybrid-inverter `inverter_ac_output_max` / `inverter_ac_input_max` defaults `0 → 5000` (#875 / #934),
- the `delta_forecast_daily` description update from the naive-mpc auto-extend forecast-window work,
- the `operating_hours_of_each_deferrable_load` fractional-value description (#373 / #939).

## Fix

Just re-ran `python scripts/generate_openapi.py` and committed the result. **No schema or code-logic change** — only the committed artifact is brought back in sync (5 lines). `test_committed_matches_generated` passes locally afterward.

```
1 passed in 4.76s
```

Happy to close this if you'd rather fold the regen into another change.

## Summary by Sourcery

Bug Fixes:
- Resolve the mismatch between the committed openapi.json and the version produced by scripts/generate_openapi.py, restoring the passing openapi artifact consistency test.