### PR TITLE
chore: add prek hook to auto-regenerate openapi.json

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -14,3 +14,20 @@ args = ["--fix"]
 
 [[repos.hooks]]
 id = "ruff-format"
+
+# Local hook: keep the committed OpenAPI spec in sync with its sources.
+# Regenerates src/emhass/static/openapi.json whenever param_definitions.json,
+# the generator, or one of the schema inputs it reads changes. Like ruff-format,
+# this is a fixer: it rewrites the file, and prek's "files were modified by this
+# hook" then fails the commit so the regenerated spec gets staged. Mirrors the CI
+# drift-check (tests/test_openapi.py::test_committed_matches_generated) proactively.
+[[repos]]
+repo = "local"
+
+[[repos.hooks]]
+id = "generate-openapi"
+name = "regenerate openapi.json from param_definitions"
+entry = "python scripts/generate_openapi.py"
+language = "system"
+pass_filenames = false
+files = '^(src/emhass/static/data/param_definitions\.json|scripts/generate_openapi\.py|docs/api/v1/last-run\.schema\.json|docs/api/healthz\.schema\.json)$'


### PR DESCRIPTION
## What

Adds a **local prek hook** (`generate-openapi`) to `prek.toml` that regenerates the committed `src/emhass/static/openapi.json` whenever one of its sources changes:

- `src/emhass/static/data/param_definitions.json`
- `scripts/generate_openapi.py`
- `docs/api/v1/last-run.schema.json`, `docs/api/healthz.schema.json` (the schema inputs the generator reads)

Like the existing `ruff-format` hook it is a **fixer**: it rewrites `openapi.json`, and prek's "files were modified by this hook" then fails the commit so the regenerated spec gets staged before the commit lands.

## Why

#921 added the generator (`scripts/generate_openapi.py`) and a CI **drift-check** (`tests/test_openapi.py::test_committed_matches_generated`). That backstop kept firing on master when `param_definitions.json` edits landed without a regen, forcing manual catch-up regens (e.g. #945 and the cherry-pick discussed there). This is the missing **proactive** half: contributors regenerate locally before pushing instead of discovering the drift in CI. LesIT1 explicitly asked for auto-regen in the #945 thread ("would've saved me the cherry-pick").

## Scope

Config-only — one block added to `prek.toml`. No production code, no CI auto-commit, and the existing drift-check test is untouched (it stays as the CI backstop).

## Verification

- `prek run generate-openapi --all-files` → **Passed** on current master (spec already in sync; no diff).
- Throwaway edit to a `param_definitions.json` default + `git commit` → hook regenerated `openapi.json` and **failed** the commit (`files were modified by this hook`); reverting the edit → clean again.
- Committing the `prek.toml` change itself → generate-openapi **Skipped** (no matching files) — no false-positive on unrelated commits.
- `pytest tests/test_openapi.py` → 21 passed.

> Note: the repo uses [`prek`](https://prek.j178.dev/) (per `CONTRIBUTING.md` + `prek.toml`), so the hook is authored in prek's native TOML and verified with `prek run` rather than `pre-commit run`.

## Summary by Sourcery

Enhancements:
- Configure a local prek hook to run the OpenAPI generator script and keep src/emhass/static/openapi.json in sync with param definitions and schema inputs.