### PR TITLE
fix(utils): stop spurious deferrable_load_max_cost warning on startup (#929)

### DIFF
--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -2907,13 +2907,6 @@ async def build_params(
             "nominal_power_of_deferrable_loads",
             logger,
         )
-        params["optim_conf"]["deferrable_load_max_cost"] = check_def_loads(
-            num_def_loads,
-            params["optim_conf"],
-            0,
-            "deferrable_load_max_cost",
-            logger,
-        )
         # Validate deferrable_load_groups
         groups = params["optim_conf"].get("deferrable_load_groups", [])
         if groups:
@@ -3073,19 +3066,26 @@ def check_def_loads(
     :return: parameter list
     :rtype: list[dict]
     """
-    if (
-        parameter.get(parameter_name, None) is not None
-        and type(parameter[parameter_name]) is list
-        and num_def_loads > len(parameter[parameter_name])
-    ):
-        logger.warning(
+    current = parameter.get(parameter_name, None)
+    # Missing key or explicit JSON null: apply the default for every load. This is
+    # expected when a per-load array is absent from the user config (e.g. a parameter
+    # added in a later release), so do it silently rather than raising KeyError.
+    if current is None:
+        parameter[parameter_name] = [default] * num_def_loads
+        return parameter[parameter_name]
+    if type(current) is list and num_def_loads > len(current):
+        # Enlarging a short list to match number_of_deferrable_loads is this function's
+        # documented job, not an error: the shipped defaults are sized for the default
+        # load count, so any user that raises the count without restating every per-load
+        # array lands here. Log at debug to avoid spurious startup warnings (#929).
+        logger.debug(
             parameter_name
-            + " does not match number in num_def_loads, adding default values ("
+            + " has fewer entries than number_of_deferrable_loads, padding with default ("
             + str(default)
-            + ") to parameter"
+            + ")"
         )
-        for _x in range(len(parameter[parameter_name]), num_def_loads):
-            parameter[parameter_name].append(default)
+        for _x in range(len(current), num_def_loads):
+            current.append(default)
     result = parameter[parameter_name]
     # Replace any None elements with the default (can occur when set-config
     # receives a partial config, e.g. [null, 0] instead of [0, 0]).

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -3053,6 +3053,10 @@ def check_def_loads(
     """
     Check parameter lists with deferrable loads number, if they do not match, enlarge to fit.
 
+    A missing key or ``None`` value is filled with ``default`` for every load. ``parameter``
+    is updated in place (and the same list returned), matching how every call site reassigns
+    ``params["optim_conf"][name] = check_def_loads(...)``.
+
     :param num_def_loads: Total number deferrable loads
     :type num_def_loads: int
     :param parameter: parameter config dict containing paramater
@@ -3073,7 +3077,7 @@ def check_def_loads(
     if current is None:
         parameter[parameter_name] = [default] * num_def_loads
         return parameter[parameter_name]
-    if type(current) is list and num_def_loads > len(current):
+    if isinstance(current, list) and num_def_loads > len(current):
         # Enlarging a short list to match number_of_deferrable_loads is this function's
         # documented job, not an error: the shipped defaults are sized for the default
         # load count, so any user that raises the count without restating every per-load

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1452,9 +1452,9 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
 
     def test_check_def_loads(self):
         """Test padding of deferrable load parameter lists."""
-        parameter = {"operating_hours": [3, 4]}
         default_val = 5
         # Case 1: Needs padding (num_def_loads > list length)
+        parameter = {"operating_hours": [3, 4]}
         result1 = utils.check_def_loads(4, parameter, default_val, "operating_hours", logger)
         self.assertEqual(len(result1), 4)
         self.assertEqual(result1, [3, 4, 5, 5])
@@ -1463,11 +1463,25 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
         result2 = utils.check_def_loads(2, parameter, default_val, "operating_hours", logger)
         self.assertEqual(len(result2), 2)
         self.assertEqual(result2, [3, 4])
-        # Case 3: Parameter doesn't exist or isn't a list (should just return as-is, though the logic might fail if not checked)
+        # Case 3: Missing key -> fill with defaults instead of raising KeyError (#929)
         parameter = {"other_param": "test"}
-        with self.assertRaises(KeyError):
-            # The function blindly returns parameter[parameter_name], so a missing key will KeyError
-            utils.check_def_loads(2, parameter, default_val, "missing_key", logger)
+        result3 = utils.check_def_loads(2, parameter, default_val, "missing_key", logger)
+        self.assertEqual(result3, [5, 5])
+        self.assertEqual(parameter["missing_key"], [5, 5])
+        # Case 4: Explicit JSON null (None) -> fill with defaults, no crash
+        parameter = {"deferrable_load_max_cost": None}
+        result4 = utils.check_def_loads(3, parameter, 0.0, "deferrable_load_max_cost", logger)
+        self.assertEqual(result4, [0.0, 0.0, 0.0])
+        # Case 5 (#929 regression): a per-load list shorter than the load count
+        # (e.g. the length-2 shipped default vs number_of_deferrable_loads=3) must pad
+        # SILENTLY. Enlarging-to-fit is the function's documented job, not a warning, so
+        # it is logged at DEBUG and never at WARNING.
+        parameter = {"deferrable_load_max_cost": [0.0, 0.0]}
+        with self.assertLogs(logger, level="DEBUG") as cm:
+            result5 = utils.check_def_loads(3, parameter, 0.0, "deferrable_load_max_cost", logger)
+        self.assertEqual(result5, [0.0, 0.0, 0.0])
+        self.assertTrue(any(r.levelno == logging.DEBUG for r in cm.records))
+        self.assertFalse(any(r.levelno >= logging.WARNING for r in cm.records))
 
     def test_parse_export_time_range(self):
         """Test timestamp parsing and validation for data exports."""


### PR DESCRIPTION
Fixes #929.

## What's happening

`check_def_loads` logs a WARNING whenever it pads a per-load array up to `number_of_deferrable_loads`. The defaults in `config_defaults.json` are all sized for the default count of 2, so as soon as someone sets `number_of_deferrable_loads: 3` without also restating every per-load array, the padding kicks in and the warning fires on every startup. `deferrable_load_max_cost` is the one people actually report because it was added recently (#886) and isn't always written back into existing configs, so it falls back to the length-2 default while the other arrays don't.

Padding short lists up to the load count is exactly what the function is documented to do ("if they do not match, enlarge to fit"), and the optimisation runs fine afterwards, so the WARNING is a false alarm. This drops it to debug.

## Changes

- `check_def_loads`: log the padding at debug instead of warning.
- `check_def_loads`: a missing key or an explicit `null` now returns a full default-filled list instead of raising `KeyError`. That's the other half of the same report, the original `KeyError: 'deferrable_load_max_cost'` people saw before adding the key by hand.
- Removed a duplicate `check_def_loads` call for `deferrable_load_max_cost` in `build_params`. It ran right after the canonical one and passed an int `0` default instead of the float `0.0` the canonical call uses. It was a no-op (the first call already padded the list), so dropping it doesn't change the result.

The stringly-typed path from the #900 resilience work is untouched: a present-but-non-list value is still returned as-is.

## Behaviour changes worth calling out

- `check_def_loads` with a missing key was a `KeyError`, now returns `[default] * num_def_loads`. The existing unit test that asserted the `KeyError` is updated to the new contract.
- The padding message moves from WARNING to DEBUG, so it no longer shows at the add-on's default INFO level.

## Tests

Expanded `test_check_def_loads` in `tests/test_utils.py`:
- missing key returns the default-filled list (was asserting `KeyError`)
- explicit `None` returns the default-filled list
- a length-2 list with count 3 pads to length 3, logs at DEBUG and never at WARNING (the #929 regression)
- the existing pad / no-pad cases still pass

Full `uv run pytest` is green locally apart from the three `test_forecast.py` solcast mock tests, which fail the same way on a clean `master` (a Solcast API safety cap in my environment), so they're unrelated to this change.

Happy to add a CHANGELOG line if you'd like one, I just didn't see an unreleased section to slot it into.

## Summary by Sourcery

Relax deferrable load configuration handling by treating missing or shorter per-load arrays as defaults rather than errors and silencing noisy startup warnings.

Bug Fixes:
- Prevent KeyError when deferrable load per-load arrays such as deferrable_load_max_cost are missing or set to null in the configuration.
- Stop spurious startup warnings by downgrading padding messages for undersized deferrable load lists from warning to debug and removing a redundant deferrable_load_max_cost check.

Tests:
- Extend check_def_loads unit tests to cover missing keys, explicit null values, and debug-only logging when padding shorter per-load arrays.