### PR TITLE
ci(codecov): skip Codecov upload on fork PRs so the run check can pass

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -36,6 +36,7 @@ jobs:
           uv run coverage xml -o coverage.xml
 
       - name: Upload coverage reports to Codecov
+        if: github.event.pull_request.head.repo.fork == false
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The CodeCov `run` check goes red on every PR from a fork, even when all the tests pass. GitHub doesn't pass repository secrets to fork PRs, so `secrets.CODECOV_TOKEN` is empty there, and with `fail_ci_if_error: true` the `codecov/codecov-action` step fails and takes the whole job down with it.

This gates the upload step on the same `github.event.pull_request.head.repo.fork == false` check the SonarQube step in this same workflow already uses. So the upload still runs on pushes to master and on internal-branch PRs, and is skipped on fork PRs where it can't work anyway. The test and coverage steps are untouched, so coverage is still generated and still uploaded everywhere the token is available.

If you'd rather keep the step running and just not let it fail the job, `fail_ci_if_error: false` would also do it. I went with the fork gate to match the existing Sonar step.

One thing this doesn't cover: the check is also red on the current master HEAD, where secrets are available. That points at the token itself (`CODECOV_TOKEN`, or the SonarQube step's `SONAR_TOKEN`) rather than the fork case, which I can't see or fix from outside. Worth a look if you want master green too.

## Summary by Sourcery

CI:
- Update the Codecov GitHub Actions workflow to skip coverage upload on forked pull requests that lack repository secrets.