### PR TITLE
fix: recover from schema-incompatible weather forecast cache (issue #932)

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -463,7 +463,11 @@ class Forecast:
     async def _get_weather_solcast(self, w_forecast_cache_path: str) -> pd.DataFrame:
         """Helper to retrieve weather data from Solcast or cache."""
         if os.path.isfile(w_forecast_cache_path):
-            return await self.get_cached_forecast_data(w_forecast_cache_path)
+            cached_data = await self.get_cached_forecast_data(w_forecast_cache_path)
+            if cached_data is not None:
+                return cached_data
+            # Incompatible/stale cache was discarded (issue #932); fall through
+            # to fetch fresh data from the Solcast API (quota-guarded below).
         if self.params["passed_data"].get("weather_forecast_cache_only", False):
             self.logger.warning("Solcast cache file missing or deleted due to being out of date.")
             self.logger.warning(
@@ -545,7 +549,11 @@ class Forecast:
     async def _get_weather_solar_forecast(self, w_forecast_cache_path: str) -> pd.DataFrame:
         """Helper to retrieve weather data from solar.forecast or cache."""
         if os.path.isfile(w_forecast_cache_path):
-            return await self.get_cached_forecast_data(w_forecast_cache_path)
+            cached_data = await self.get_cached_forecast_data(w_forecast_cache_path)
+            if cached_data is not None:
+                return cached_data
+            # Incompatible/stale cache was discarded (issue #932); fall through
+            # to fetch fresh data from the forecast.solar API.
         # Validation and Default Setup
         if "solar_forecast_kwp" not in self.retrieve_hass_conf:
             self.logger.warning(
@@ -1898,6 +1906,31 @@ class Forecast:
                     data[irradiance_cols] = data[irradiance_cols].fillna(0.0)
 
                 data = data.fillna(0.0)
+
+        # The weather cache file is shared across every weather_forecast_method,
+        # so a cache written by a different method can lack the column the active
+        # method needs. Serving it would crash later in get_power_from_weather
+        # with an opaque KeyError: 'yhat' (issue #932). Treat a schema-incompatible
+        # cache as a recoverable miss: drop it and return None so the rate-limited
+        # fetchers fall through to a fresh fetch (the open-meteo path already does
+        # this for its own stale cache).
+        if (
+            self.weather_forecast_method in ("solcast", "solar.forecast")
+            and self.retrieve_hass_conf.get("solar_forecast_kwp") != 0
+            and "yhat" not in data.columns
+        ):
+            self.logger.warning(
+                "Cached forecast is missing the 'yhat' column required by "
+                "weather_forecast_method='%s' (cache likely written by a "
+                "different method). Discarding the incompatible cache and "
+                "fetching fresh data.",
+                self.weather_forecast_method,
+            )
+            try:
+                os.remove(w_forecast_cache_path)
+            except FileNotFoundError:
+                pass
+            return None
         return data
 
     async def set_cached_forecast_data(self, w_forecast_cache_path, data) -> pd.DataFrame:

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -460,14 +460,25 @@ class Forecast:
             self.logger.error(f"Failed to check or increment Solcast rate limit: {e}")
             return False
 
+    async def _get_cached_forecast_or_none(self, w_forecast_cache_path: str) -> pd.DataFrame | None:
+        """Return a usable cached forecast, or None when there is no cache file
+        or it was discarded as stale/schema-incompatible (issue #932).
+
+        Lets the rate-limited fetchers (solcast, solar.forecast) share one
+        cache-recovery path: a non-None result is served directly, None means
+        fall through to a fresh API fetch.
+        """
+        if not os.path.isfile(w_forecast_cache_path):
+            return None
+        return await self.get_cached_forecast_data(w_forecast_cache_path)
+
     async def _get_weather_solcast(self, w_forecast_cache_path: str) -> pd.DataFrame:
         """Helper to retrieve weather data from Solcast or cache."""
-        if os.path.isfile(w_forecast_cache_path):
-            cached_data = await self.get_cached_forecast_data(w_forecast_cache_path)
-            if cached_data is not None:
-                return cached_data
-            # Incompatible/stale cache was discarded (issue #932); fall through
-            # to fetch fresh data from the Solcast API (quota-guarded below).
+        cached_data = await self._get_cached_forecast_or_none(w_forecast_cache_path)
+        if cached_data is not None:
+            return cached_data
+        # Incompatible/stale cache was discarded (issue #932); fall through
+        # to fetch fresh data from the Solcast API (quota-guarded below).
         if self.params["passed_data"].get("weather_forecast_cache_only", False):
             self.logger.warning("Solcast cache file missing or deleted due to being out of date.")
             self.logger.warning(
@@ -548,12 +559,11 @@ class Forecast:
 
     async def _get_weather_solar_forecast(self, w_forecast_cache_path: str) -> pd.DataFrame:
         """Helper to retrieve weather data from solar.forecast or cache."""
-        if os.path.isfile(w_forecast_cache_path):
-            cached_data = await self.get_cached_forecast_data(w_forecast_cache_path)
-            if cached_data is not None:
-                return cached_data
-            # Incompatible/stale cache was discarded (issue #932); fall through
-            # to fetch fresh data from the forecast.solar API.
+        cached_data = await self._get_cached_forecast_or_none(w_forecast_cache_path)
+        if cached_data is not None:
+            return cached_data
+        # Incompatible/stale cache was discarded (issue #932); fall through
+        # to fetch fresh data from the forecast.solar API.
         # Validation and Default Setup
         if "solar_forecast_kwp" not in self.retrieve_hass_conf:
             self.logger.warning(
@@ -1913,10 +1923,11 @@ class Forecast:
         # with an opaque KeyError: 'yhat' (issue #932). Treat a schema-incompatible
         # cache as a recoverable miss: drop it and return None so the rate-limited
         # fetchers fall through to a fresh fetch (the open-meteo path already does
-        # this for its own stale cache).
+        # this for its own stale cache). 'yhat' (PV power) is required by both
+        # solcast and solar.forecast regardless of solar_forecast_kwp, so the
+        # check does not depend on that key.
         if (
             self.weather_forecast_method in ("solcast", "solar.forecast")
-            and self.retrieve_hass_conf.get("solar_forecast_kwp") != 0
             and "yhat" not in data.columns
         ):
             self.logger.warning(

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -661,6 +661,71 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
                 emhass_conf["data_path"] / "weather_forecast_data.pkl",
             )
 
+    # Test #932: a weather cache lacking 'yhat' (e.g. left over after switching
+    # weather_forecast_method, since the cache file is shared across methods)
+    # must not crash get_power_from_weather. The rate-limited fetchers should
+    # self-heal by refetching, the same way open-meteo already does.
+    async def test_get_weather_forecast_solcast_incompatible_cache_recovers(self):
+        from unittest.mock import patch
+
+        cache_path = emhass_conf["data_path"] / "weather_forecast_data.pkl"
+        temp_path = emhass_conf["data_path"] / "temp_weather_forecast_data.pkl"
+        if os.path.isfile(cache_path):
+            os.rename(cache_path, temp_path)
+
+        # Schema-incompatible cache: open-meteo columns, NO 'yhat', over a stale
+        # window that does not cover forecast_dates (forces the stale-cache path).
+        stale_index = pd.date_range(
+            start=self.fcst.forecast_dates[0] - pd.Timedelta(days=2),
+            periods=len(self.fcst.forecast_dates) + 4,
+            freq=self.fcst.freq,
+        )
+        incompatible = pd.DataFrame(
+            {"ghi": 500.0, "dni": 400.0, "dhi": 100.0, "temp_air": 20.0},
+            index=stale_index,
+        )
+        with open(cache_path, "wb") as f:
+            pickle.dump(incompatible, f)
+
+        self.fcst.params = {
+            "passed_data": {
+                "weather_forecast_cache": False,
+                "weather_forecast_cache_only": False,
+            }
+        }
+        self.fcst.retrieve_hass_conf["solcast_api_key"] = "123456"
+        self.fcst.retrieve_hass_conf["solcast_rooftop_id"] = "123456"
+
+        # Solcast fixture for the (mocked) fresh fetch the fix should trigger.
+        test_data_path = str(emhass_conf["data_path"] / "test_response_solcast_get_method.pbz2")
+        async with aiofiles.open(test_data_path, "rb") as f:
+            compressed = await f.read()
+        payload = orjson.loads(cPickle.loads(bz2.decompress(compressed)).content)
+
+        try:
+            with (
+                patch.object(self.fcst, "_solcast_rate_limit_ok", return_value=True),
+                aioresponses() as mocked,
+            ):
+                mocked.get(
+                    re.compile(r"https://api\.solcast\.com\.au/.*"),
+                    payload=payload,
+                )
+                df_weather = await self.fcst.get_weather_forecast(method="solcast")
+
+            # The incompatible cache must NOT be served verbatim: the refetched
+            # frame has 'yhat' and get_power_from_weather must not raise.
+            self.assertIsInstance(df_weather, pd.DataFrame)
+            self.assertIn("yhat", df_weather.columns)
+            p_pv = self.fcst.get_power_from_weather(df_weather)
+            self.assertEqual(len(p_pv), len(self.fcst.forecast_dates))
+            self.assertFalse(p_pv.isna().any())
+        finally:
+            if os.path.isfile(cache_path):
+                os.remove(cache_path)
+            if os.path.isfile(temp_path):
+                os.rename(temp_path, cache_path)
+
     # Test output weather forecast using Forecast.Solar with mock get request data
     async def test_get_weather_forecast_solarforecast_method_mock(self):
         test_data_path = str(

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -695,6 +695,11 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
         }
         self.fcst.retrieve_hass_conf["solcast_api_key"] = "123456"
         self.fcst.retrieve_hass_conf["solcast_rooftop_id"] = "123456"
+        # solar_forecast_kwp == 0 is the case the schema check must NOT depend on:
+        # solcast does not use that key, yet a real solcast user can leave it at 0.
+        # The old `solar_forecast_kwp != 0` guard would skip the check and serve the
+        # yhat-less cache, crashing get_power_from_weather. Pin it to 0 here.
+        self.fcst.retrieve_hass_conf["solar_forecast_kwp"] = 0
 
         # Solcast fixture for the (mocked) fresh fetch the fix should trigger.
         test_data_path = str(emhass_conf["data_path"] / "test_response_solcast_get_method.pbz2")


### PR DESCRIPTION
Fixes #932.

## What's going on

The weather forecast cache lives in one file, `data/weather_forecast_data.pkl`, and the name is the same for every `weather_forecast_method`. So when the method in use changes (open-meteo and solcast running at different times, say), the cache on disk can belong to a different method than the one running now.

The stale-cache fallback in `get_cached_forecast_data` then serves that old frame as-is, and solcast/solar.forecast hit an unconditional `df_weather["yhat"]` in `get_power_from_weather`. An open-meteo cache has ghi/dni/dhi, not yhat, so it throws `KeyError: 'yhat'` and the optim returns a 500. A valid solcast cache is fine here (it does carry a yhat column), so the crash specifically needs a schema-mismatched cache, which the shared file produces once methods differ.

## The fix

Make the rate-limited methods self-heal like open-meteo already does (it deletes a stale cache and refetches):

1. `get_cached_forecast_data`: before returning a served cache, if the active method needs `yhat` and it isn't there, warn, drop the incompatible cache, and return `None` (already the documented recoverable-miss signal).
2. `_get_weather_solcast` and `_get_weather_solar_forecast`: on `None`, fall through to a fresh fetch instead of returning `None`, mirroring `_get_weather_open_meteo`.

Quota stays protected by the existing `_solcast_rate_limit_ok` cap, so worst case is one refetch of a genuinely unusable cache. The guard skips `solar_forecast_kwp == 0` (where yhat is never read) and leaves valid caches alone, so #918's rate-limit-preserving behaviour holds for the normal stale-but-valid case. The mirror case (a yhat-only cache read as open-meteo over a covered window) is pre-existing and method-gated out of this change; happy to do a follow-up if you want it.

## Tests

Added `test_get_weather_forecast_solcast_incompatible_cache_recovers`: writes an open-meteo-schema cache (no yhat) over a stale window, runs solcast against a mocked API, and asserts the result has `yhat` and `get_power_from_weather` doesn't raise. Fails on master, passes with the fix; full suite stays green (539 passed).