### PR TITLE
feat: warn on unrecognized thermal_config keys (issue #943)

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -12,6 +12,36 @@ import pandas as pd
 
 from emhass import utils
 
+# Keys the thermal model actually reads from a load's thermal_config (issue #943).
+# Any other key is silently ignored, so a typo such as the singular
+# `min_temperature` (the model reads the list key `min_temperatures`) yields a
+# load that never schedules, with no feedback; we warn on unrecognized keys.
+THERMAL_CONFIG_KNOWN_KEYS = frozenset(
+    {
+        "heating_rate",
+        "cooling_constant",
+        "start_temperature",
+        "min_temperatures",
+        "max_temperatures",
+        "desired_temperatures",
+        "overshoot_temperature",
+        "penalty_factor",
+        "sense",
+    }
+)
+# Common singular typo -> (correct list key, what that key controls). The role
+# tailors the guidance so the hint for `desired_temperature` talks about the soft
+# target rather than the hard min/max comfort band.
+THERMAL_CONFIG_KEY_HINTS = {
+    "min_temperature": ("min_temperatures", "the hard comfort band"),
+    "max_temperature": ("max_temperatures", "the hard comfort band"),
+    "target_temperature": ("min_temperatures/max_temperatures", "the hard comfort band"),
+    "desired_temperature": (
+        "desired_temperatures",
+        "the soft target used with overshoot_temperature",
+    ),
+}
+
 
 class Optimization:
     r"""
@@ -309,44 +339,23 @@ class Optimization:
         # This allows updating runtime values (forecasts, temperatures) without rebuilding constraints
         self.param_thermal = {}
         def_load_config = self.optim_conf.get("def_load_config", []) or []
-        # Keys the thermal model actually reads from a load's thermal_config.
-        # Anything else is silently ignored, so we warn on it (issue #943): a
-        # typo such as the singular `min_temperature` (the model reads the list
-        # key `min_temperatures`) otherwise produces a load that never schedules,
-        # with no feedback.
-        known_thermal_config_keys = {
-            "heating_rate",
-            "cooling_constant",
-            "start_temperature",
-            "min_temperatures",
-            "max_temperatures",
-            "desired_temperatures",
-            "overshoot_temperature",
-            "penalty_factor",
-            "sense",
-        }
-        thermal_config_key_hints = {
-            "min_temperature": "min_temperatures",
-            "max_temperature": "max_temperatures",
-            "target_temperature": "min_temperatures/max_temperatures",
-            "desired_temperature": "desired_temperatures",
-        }
         for k in range(num_def_loads):
             if k < len(def_load_config) and def_load_config[k]:
                 cfg = def_load_config[k]
                 if "thermal_config" in cfg:
                     hc = cfg["thermal_config"]
                     if isinstance(hc, dict):
-                        for bad_key in (key for key in hc if key not in known_thermal_config_keys):
-                            hint = thermal_config_key_hints.get(bad_key)
+                        for bad_key in (key for key in hc if key not in THERMAL_CONFIG_KNOWN_KEYS):
+                            hint = THERMAL_CONFIG_KEY_HINTS.get(bad_key)
                             if hint:
+                                correct_key, role = hint
                                 self.logger.warning(
                                     "Deferrable load %d thermal_config: unknown key '%s' is "
-                                    "ignored; did you mean '%s'? Temperature bounds use the list "
-                                    "keys min_temperatures/max_temperatures.",
+                                    "ignored; did you mean '%s' (%s)?",
                                     k,
                                     bad_key,
-                                    hint,
+                                    correct_key,
+                                    role,
                                 )
                             else:
                                 self.logger.warning(
@@ -354,7 +363,7 @@ class Optimization:
                                     "ignored. Recognized keys: %s.",
                                     k,
                                     bad_key,
-                                    ", ".join(sorted(known_thermal_config_keys)),
+                                    ", ".join(sorted(THERMAL_CONFIG_KNOWN_KEYS)),
                                 )
                     init_temp = float(hc.get("start_temperature", 20.0) or 20.0)
                     min_temps = hc.get("min_temperatures", [])

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -309,11 +309,53 @@ class Optimization:
         # This allows updating runtime values (forecasts, temperatures) without rebuilding constraints
         self.param_thermal = {}
         def_load_config = self.optim_conf.get("def_load_config", []) or []
+        # Keys the thermal model actually reads from a load's thermal_config.
+        # Anything else is silently ignored, so we warn on it (issue #943): a
+        # typo such as the singular `min_temperature` (the model reads the list
+        # key `min_temperatures`) otherwise produces a load that never schedules,
+        # with no feedback.
+        known_thermal_config_keys = {
+            "heating_rate",
+            "cooling_constant",
+            "start_temperature",
+            "min_temperatures",
+            "max_temperatures",
+            "desired_temperatures",
+            "overshoot_temperature",
+            "penalty_factor",
+            "sense",
+        }
+        thermal_config_key_hints = {
+            "min_temperature": "min_temperatures",
+            "max_temperature": "max_temperatures",
+            "target_temperature": "min_temperatures/max_temperatures",
+            "desired_temperature": "desired_temperatures",
+        }
         for k in range(num_def_loads):
             if k < len(def_load_config) and def_load_config[k]:
                 cfg = def_load_config[k]
                 if "thermal_config" in cfg:
                     hc = cfg["thermal_config"]
+                    if isinstance(hc, dict):
+                        for bad_key in (key for key in hc if key not in known_thermal_config_keys):
+                            hint = thermal_config_key_hints.get(bad_key)
+                            if hint:
+                                self.logger.warning(
+                                    "Deferrable load %d thermal_config: unknown key '%s' is "
+                                    "ignored; did you mean '%s'? Temperature bounds use the list "
+                                    "keys min_temperatures/max_temperatures.",
+                                    k,
+                                    bad_key,
+                                    hint,
+                                )
+                            else:
+                                self.logger.warning(
+                                    "Deferrable load %d thermal_config: unknown key '%s' is "
+                                    "ignored. Recognized keys: %s.",
+                                    k,
+                                    bad_key,
+                                    ", ".join(sorted(known_thermal_config_keys)),
+                                )
                     init_temp = float(hc.get("start_temperature", 20.0) or 20.0)
                     min_temps = hc.get("min_temperatures", [])
                     max_temps = hc.get("max_temperatures", [])

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -876,6 +876,32 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         # The 2-step, 1000 W sequence ran exactly once: total power 2000 W.
         self.assertAlmostEqual(res["P_deferrable0"].sum(), 2000.0, delta=1.0)
 
+    def test_thermal_config_unknown_key_warns(self):
+        """Issue #943: a thermal_config with an unrecognized key (e.g. the
+        singular min_temperature instead of the list min_temperatures, or a
+        stray target_temperature) is silently ignored, which yields a load that
+        never schedules. Warn so the typo is visible to the user.
+        """
+        self.optim_conf["number_of_deferrable_loads"] = 1
+        self.optim_conf["def_load_config"] = [
+            {
+                "thermal_config": {
+                    "heating_rate": 0.25,
+                    "cooling_constant": 0.01,
+                    "start_temperature": 22.0,
+                    "min_temperature": 22.0,  # singular typo: never read
+                    "target_temperature": 23.0,  # not a recognized key
+                }
+            }
+        ]
+        with self.assertLogs(level="WARNING") as logs:
+            self.create_optimization()
+        joined = "\n".join(logs.output)
+        # The singular typo is flagged and the correct list key is suggested.
+        self.assertIn("min_temperature", joined)
+        self.assertIn("min_temperatures", joined)
+        self.assertIn("target_temperature", joined)
+
     def test_intermediate_soc_target_below_soc_init_is_noop(self):
         """Issue #553: a soc_target at or below the SoC the battery already holds
         builds a non-biting floor, so the optimized plan is unchanged vs no target.


### PR DESCRIPTION
Follow-up to #943.

That issue turned out not to be a bug. The reporter's thermal load scheduled 0 W because their `thermal_config` used singular keys (`min_temperature`, `max_temperature`, `target_temperature`) that the model doesn't read, so the load had no temperature bound and, with a tiny `cooling_constant`, never needed to heat. The model only reads the plural list keys `min_temperatures` / `max_temperatures` (the hard comfort band) and `desired_temperatures` (soft, used with `overshoot_temperature`).

What made it hard to spot is that EMHASS silently ignores unknown keys in `thermal_config`, so a typo gives you a flat 0 W schedule with no feedback. This adds a warning for any unrecognized key, with a hint pointing at the right list key for the common singular typos.

The model behaviour is unchanged, this is log-only. The warning fires once per load at build time, for example:

```
Deferrable load 0 thermal_config: unknown key 'min_temperature' is ignored; did you mean 'min_temperatures'? Temperature bounds use the list keys min_temperatures/max_temperatures.
```

Recognized keys: heating_rate, cooling_constant, start_temperature, min_temperatures, max_temperatures, desired_temperatures, overshoot_temperature, penalty_factor, sense.

Test `test_thermal_config_unknown_key_warns` checks the singular-typo case warns and suggests the plural key. Full suite stays green.

Suggested changelog line:
- feat: warn when a thermal_config contains an unrecognized key (issue #943)

## Summary by Sourcery

Warn on unrecognized thermal_config keys for deferrable loads to make configuration typos visible without changing optimization behavior.

New Features:
- Log warnings when a thermal_config contains unknown keys, with hints for common singular-to-plural key typos.

Tests:
- Add a regression test ensuring unknown thermal_config keys emit warnings and suggest the correct list-based keys.