### PR TITLE
feat(mlforecaster): add backtest goodness-of-fit metrics and extract _build_weather_future helper

### DIFF
--- a/docs/mlforecaster.md
+++ b/docs/mlforecaster.md
@@ -79,12 +79,29 @@ The results of the backtest will be shown in the logs:
 
     2023-02-20 22:05:36,825 - __main__ - INFO - Simple backtesting
     2023-02-20 22:06:32,162 - __main__ - INFO - Backtest R2 score: 0.5851552394233677
+    2023-02-20 22:06:32,163 - __main__ - INFO - Backtest metrics — MAE: 142.3456, RMSE: 198.2345, R2: 0.5852, MAPE: 12.34%
 
 So the mean backtest metric of our model is $R^2=0.59$. 
 
 Here is the graphic result of the backtesting routine:
 
 ![](./images/load_forecast_knn_bare_backtest.svg)
+
+### Backtest goodness-of-fit metrics
+
+When `perform_backtest=True` the fitted `MLForecaster` object exposes a `backtest_metrics_` attribute — a dict with the following keys computed over the out-of-sample backtest folds:
+
+| Key | Metric |
+| --- | --- |
+| `mae` | Mean Absolute Error (same unit as the target sensor, e.g. W) |
+| `rmse` | Root Mean Squared Error (same unit) |
+| `r2` | Coefficient of determination $R^2$ (dimensionless, higher is better) |
+| `mape` | Mean Absolute Percentage Error (%; rows where the actual value is zero are excluded) |
+| `n_samples` | Number of backtest steps used to compute the metrics |
+
+All four metrics are also printed to the log at INFO level after the backtest completes, making it easy to compare model variants or assess the effect of adding weather covariates.
+
+`backtest_metrics_` is `None` before `fit()` is called and when `perform_backtest=False` (the default).
 
 ## Adding weather covariates
 
@@ -246,3 +263,13 @@ This can be extended with other known future covariates. As described in [Adding
 This class can be generalized to forecast any given sensor variable present in Home Assistant. It has been tested and the main initial motivation for this development was for better load power consumption forecasting. But in reality, it has been coded flexibly so that you can control what variable is used, how many lags, the amount of data used to train the model, etc.
 
 So you can go further and try to forecast other types of variables and possibly use the results for some interesting automations in Home Assistant. If doing this, what is important is to evaluate the pertinence of the obtained forecasts. The hope is that the tools proposed here can be used for that purpose.
+
+## Future directions
+
+### Probabilistic forecasting and confidence intervals
+
+The `backtest_metrics_` attribute described above gives a useful point estimate of model quality, but it does not tell you *how much to trust a specific prediction*. Propagating forecast uncertainty through the MILP optimisation — so the solver can trade off the risk of over- and under-forecasting — would require a probabilistic model that outputs a distribution (or at least a credible interval) for each step, not a scalar.
+
+A natural candidate is **Gaussian Process Regression** (GPR), which is the only `scikit-learn` regressor that is natively stochastic: it returns a mean prediction together with a variance estimate whose shape adapts to the local density of the training data. Wiring GPR into the `mlforecaster` as an optional `sklearn_model` choice, and plumbing its per-step standard deviation through to the MILP as a second tensor, would be the foundation for **stochastic MPC** — optimising expected cost under forecast uncertainty rather than optimising a single deterministic trajectory.
+
+This is a non-trivial architecture change (the MILP formulation, the objective function, and the EMHASS optimisation layer would all need updating), and it is intentionally left as a future direction rather than implemented here.

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -1842,18 +1842,7 @@ async def forecast_model_predict(
         data_last_window = None
     # When the model was trained with weather covariates, supply the future weather over the
     # forecast horizon so the recursive predict has the exog columns it expects.
-    weather_future = None
-    weather_features = list(getattr(mlf, "weather_features", []) or [])
-    if weather_features and data_last_window is not None:
-        steps = mlf.lags_opt if getattr(mlf, "is_tuned", False) else mlf.num_lags
-        future_index = pd.date_range(
-            start=data_last_window.index[-1] + data_last_window.index.freq,
-            periods=steps,
-            freq=data_last_window.index.freq,
-        )
-        weather_future = await input_data_dict["fcst"].get_weather_covariates(
-            future_index, weather_features
-        )
+    weather_future = await input_data_dict["fcst"]._build_weather_future(data_last_window, mlf)
     predictions = await mlf.predict(data_last_window, weather_future=weather_future)
     # Publish data to a Home Assistant sensor
     model_predict_publish = input_data_dict["params"]["passed_data"]["model_predict_publish"]

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -1764,6 +1764,39 @@ class Forecast:
         historical_values = df.iloc[-forecast_horizon:]
         return pd.DataFrame(historical_values.values, index=self.forecast_dates, columns=["yhat"])
 
+    async def _build_weather_future(
+        self, data_last_window: pd.DataFrame, mlf
+    ) -> pd.DataFrame | None:
+        """Build the future-weather DataFrame required by a weather-trained MLForecaster.
+
+        Returns a DataFrame aligned to the model's forecast horizon (``mlf.lags_opt`` when tuned,
+        ``mlf.num_lags`` otherwise) containing the weather covariate columns the model was trained
+        with, or ``None`` when the model was trained without weather features or when
+        ``data_last_window`` is None.
+
+        Factoring out this block avoids identical horizon-construction code in both
+        ``_get_load_forecast_ml`` and ``command_line.forecast_model_predict``.
+
+        :param data_last_window: The last observed window; its tail index + ``freq`` anchors the \
+            future date range.
+        :type data_last_window: pd.DataFrame
+        :param mlf: A fitted (and optionally tuned) ``MLForecaster`` instance.
+        :return: Future weather DataFrame, or None.
+        :rtype: pd.DataFrame | None
+        """
+        if data_last_window is None:
+            return None
+        weather_features = list(getattr(mlf, "weather_features", []) or [])
+        if not weather_features:
+            return None
+        steps = mlf.lags_opt if getattr(mlf, "is_tuned", False) else mlf.num_lags
+        future_index = pd.date_range(
+            start=data_last_window.index[-1] + data_last_window.index.freq,
+            periods=steps,
+            freq=data_last_window.index.freq,
+        )
+        return await self.get_weather_covariates(future_index, weather_features)
+
     async def _get_load_forecast_ml(
         self, df: pd.DataFrame, use_last_window: bool, mlf, debug: bool
     ) -> pd.DataFrame | bool:
@@ -1787,16 +1820,7 @@ class Forecast:
             data_last_window = data_last_window.rename(columns={self.var_load_new: self.var_load})
         # When the model was trained with weather covariates, supply the future weather over the
         # forecast horizon so the recursive predict has the exog columns it expects.
-        weather_future = None
-        weather_features = list(getattr(mlf, "weather_features", []) or [])
-        if weather_features and data_last_window is not None:
-            steps = mlf.lags_opt if getattr(mlf, "is_tuned", False) else mlf.num_lags
-            future_index = pd.date_range(
-                start=data_last_window.index[-1] + data_last_window.index.freq,
-                periods=steps,
-                freq=data_last_window.index.freq,
-            )
-            weather_future = await self.get_weather_covariates(future_index, weather_features)
+        weather_future = await self._build_weather_future(data_last_window, mlf)
         forecast_out = await mlf.predict(data_last_window, weather_future=weather_future)
         self.logger.debug(
             "Number of ML predict forcast data generated (lags_opt): "

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -1789,11 +1789,21 @@ class Forecast:
         weather_features = list(getattr(mlf, "weather_features", []) or [])
         if not weather_features:
             return None
+        # Resolve the index frequency — DatetimeIndex.freq can be None when the index was
+        # constructed without an explicit freq (e.g. after a reindex or iloc slice).
+        window_freq = data_last_window.index.freq
+        if window_freq is None:
+            window_freq = pd.tseries.frequencies.to_offset(pd.infer_freq(data_last_window.index))
+        if window_freq is None:
+            raise ValueError(
+                "_build_weather_future: could not infer a regular frequency from "
+                "data_last_window.index — ensure the index has a uniform step size."
+            )
         steps = mlf.lags_opt if getattr(mlf, "is_tuned", False) else mlf.num_lags
         future_index = pd.date_range(
-            start=data_last_window.index[-1] + data_last_window.index.freq,
+            start=data_last_window.index[-1] + window_freq,
             periods=steps,
-            freq=data_last_window.index.freq,
+            freq=window_freq,
         )
         return await self.get_weather_covariates(future_index, weather_features)
 

--- a/src/emhass/machine_learning_forecaster.py
+++ b/src/emhass/machine_learning_forecaster.py
@@ -267,6 +267,8 @@ class MLForecaster:
         """
         try:
             self.logger.info("Performing a forecast model fit for " + self.model_type)
+            # Reset metrics so a reused instance never exposes stale results from a previous fit.
+            self.backtest_metrics_ = None
 
             # Check if variable exists in data
             if self.var_model not in self.data.columns:
@@ -392,40 +394,62 @@ class MLForecaster:
                 actual_values = df_pred_backtest["train"].astype(float)
                 predicted_values = df_pred_backtest["pred"].astype(float)
                 valid_mask = predicted_values.notna() & actual_values.notna()
+                n_valid_samples = int(valid_mask.sum())
                 actual_valid = actual_values[valid_mask]
                 predicted_valid = predicted_values[valid_mask]
 
-                backtest_mae = float(mean_absolute_error(actual_valid, predicted_valid))
-                backtest_rmse = float(np.sqrt(mean_squared_error(actual_valid, predicted_valid)))
-                backtest_r2_full = float(r2_score(actual_valid, predicted_valid))
-                # MAPE: exclude zero actuals to avoid division by zero
-                nonzero_mask = actual_valid != 0
-                if nonzero_mask.sum() > 0:
-                    backtest_mape = float(
-                        np.mean(
-                            np.abs(
-                                (actual_valid[nonzero_mask] - predicted_valid[nonzero_mask])
-                                / actual_valid[nonzero_mask]
-                            )
-                        )
-                        * 100
+                # Guard against degenerate cases (all-NaN predictions or single sample).
+                # r2_score requires at least 2 samples; MAE/RMSE require at least 1.
+                if n_valid_samples == 0:
+                    self.backtest_metrics_ = {
+                        "mae": float("nan"),
+                        "rmse": float("nan"),
+                        "r2": float("nan"),
+                        "mape": float("nan"),
+                        "n_samples": 0,
+                    }
+                    self.logger.warning(
+                        "Backtest produced no valid predictions — metrics set to NaN"
                     )
                 else:
-                    backtest_mape = float("nan")
+                    backtest_mae = float(mean_absolute_error(actual_valid, predicted_valid))
+                    backtest_rmse = float(
+                        np.sqrt(mean_squared_error(actual_valid, predicted_valid))
+                    )
+                    # r2_score is undefined for a single sample (variance == 0)
+                    backtest_r2_full = (
+                        float(r2_score(actual_valid, predicted_valid))
+                        if n_valid_samples > 1
+                        else float("nan")
+                    )
+                    # MAPE: exclude zero actuals to avoid division by zero
+                    nonzero_mask = actual_valid != 0
+                    if nonzero_mask.sum() > 0:
+                        backtest_mape = float(
+                            np.mean(
+                                np.abs(
+                                    (actual_valid[nonzero_mask] - predicted_valid[nonzero_mask])
+                                    / actual_valid[nonzero_mask]
+                                )
+                            )
+                            * 100
+                        )
+                    else:
+                        backtest_mape = float("nan")
 
-                self.backtest_metrics_ = {
-                    "mae": backtest_mae,
-                    "rmse": backtest_rmse,
-                    "r2": backtest_r2_full,
-                    "mape": backtest_mape,
-                    "n_samples": int(valid_mask.sum()),
-                }
-                self.logger.info(
-                    f"Backtest metrics — MAE: {backtest_mae:.4f}, "
-                    f"RMSE: {backtest_rmse:.4f}, "
-                    f"R2: {backtest_r2_full:.4f}, "
-                    f"MAPE: {backtest_mape:.2f}%"
-                )
+                    self.backtest_metrics_ = {
+                        "mae": backtest_mae,
+                        "rmse": backtest_rmse,
+                        "r2": backtest_r2_full,
+                        "mape": backtest_mape,
+                        "n_samples": n_valid_samples,
+                    }
+                    self.logger.info(
+                        f"Backtest metrics — MAE: {backtest_mae:.4f}, "
+                        f"RMSE: {backtest_rmse:.4f}, "
+                        f"R2: {backtest_r2_full:.4f}, "
+                        f"MAPE: {backtest_mape:.2f}%"
+                    )
 
             return df_pred, df_pred_backtest
 

--- a/src/emhass/machine_learning_forecaster.py
+++ b/src/emhass/machine_learning_forecaster.py
@@ -18,7 +18,7 @@ from sklearn.ensemble import (
     RandomForestRegressor,
 )
 from sklearn.linear_model import ElasticNet, Lasso, LinearRegression, Ridge
-from sklearn.metrics import r2_score
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.neural_network import MLPRegressor
 from sklearn.svm import SVR
@@ -105,6 +105,7 @@ class MLForecaster:
         self.forecaster: ForecasterRecursive | None = None
         self.optimize_results: pd.DataFrame | None = None
         self.optimize_results_object = None
+        self.backtest_metrics_: dict | None = None
 
         # A quick data preparation
         self._prepare_data()
@@ -257,7 +258,9 @@ class MLForecaster:
             as the test period to evaluate the model, defaults to '48h'
         :type split_date_delta: Optional[str], optional
         :param perform_backtest: If `True` then a back testing routine is performed to evaluate \
-            the performance of the model on the complete train set, defaults to False
+            the performance of the model on the complete train set, defaults to False.
+            When True, the ``backtest_metrics_`` attribute is populated with a dict containing
+            MAE, RMSE, R2, and MAPE computed over the out-of-sample backtest folds.
         :type perform_backtest: Optional[bool], optional
         :return: The DataFrame containing the forecast data results without and with backtest
         :rtype: Tuple[pd.DataFrame, pd.DataFrame]
@@ -382,6 +385,47 @@ class MLForecaster:
 
                 # Use loc to align indices properly - only assign where indices match
                 df_pred_backtest.loc[pred_values.index, "pred"] = pred_values
+
+                # Compute goodness-of-fit metrics over the backtest fold predictions.
+                # Only rows where the backtest produced a prediction are used; the leading
+                # rows (the initial warm-up window) remain NaN and are excluded.
+                actual_values = df_pred_backtest["train"].astype(float)
+                predicted_values = df_pred_backtest["pred"].astype(float)
+                valid_mask = predicted_values.notna() & actual_values.notna()
+                actual_valid = actual_values[valid_mask]
+                predicted_valid = predicted_values[valid_mask]
+
+                backtest_mae = float(mean_absolute_error(actual_valid, predicted_valid))
+                backtest_rmse = float(np.sqrt(mean_squared_error(actual_valid, predicted_valid)))
+                backtest_r2_full = float(r2_score(actual_valid, predicted_valid))
+                # MAPE: exclude zero actuals to avoid division by zero
+                nonzero_mask = actual_valid != 0
+                if nonzero_mask.sum() > 0:
+                    backtest_mape = float(
+                        np.mean(
+                            np.abs(
+                                (actual_valid[nonzero_mask] - predicted_valid[nonzero_mask])
+                                / actual_valid[nonzero_mask]
+                            )
+                        )
+                        * 100
+                    )
+                else:
+                    backtest_mape = float("nan")
+
+                self.backtest_metrics_ = {
+                    "mae": backtest_mae,
+                    "rmse": backtest_rmse,
+                    "r2": backtest_r2_full,
+                    "mape": backtest_mape,
+                    "n_samples": int(valid_mask.sum()),
+                }
+                self.logger.info(
+                    f"Backtest metrics — MAE: {backtest_mae:.4f}, "
+                    f"RMSE: {backtest_rmse:.4f}, "
+                    f"R2: {backtest_r2_full:.4f}, "
+                    f"MAPE: {backtest_mape:.2f}%"
+                )
 
             return df_pred, df_pred_backtest
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -395,6 +395,103 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             await self.fcst.get_weather_covariates(self.fcst.forecast_dates, ["not_a_real_column"])
 
+    async def test_build_weather_future_returns_none_without_weather_features(self):
+        """_build_weather_future returns None when the model has no weather_features."""
+        from unittest.mock import MagicMock
+
+        data_last_window = self.df_input_data.copy()
+        # A minimal mock MLForecaster with no weather features
+        mock_mlf = MagicMock()
+        mock_mlf.weather_features = []
+        mock_mlf.is_tuned = False
+        mock_mlf.num_lags = 48
+
+        result = await self.fcst._build_weather_future(data_last_window, mock_mlf)
+        self.assertIsNone(result)
+
+    async def test_build_weather_future_returns_none_when_no_last_window(self):
+        """_build_weather_future returns None when data_last_window is None."""
+        from unittest.mock import MagicMock
+
+        mock_mlf = MagicMock()
+        mock_mlf.weather_features = ["temp_air"]
+        mock_mlf.is_tuned = False
+        mock_mlf.num_lags = 48
+
+        result = await self.fcst._build_weather_future(None, mock_mlf)
+        self.assertIsNone(result)
+
+    async def test_build_weather_future_builds_correct_horizon(self):
+        """_build_weather_future calls get_weather_covariates over the correct future index."""
+        from unittest.mock import MagicMock, patch
+
+        index = self.fcst.forecast_dates
+        span_start = index[0] - 4 * self.fcst.freq
+        full = pd.date_range(start=span_start, end=index[-1], freq=self.fcst.freq, tz=index.tz)
+        times = (full.tz_convert("UTC").astype("int64") // 10**9).tolist()
+        payload = {
+            "minutely_15": {
+                "time": times,
+                "temperature_2m": [20.0] * len(full),
+                "relative_humidity_2m": [50.0] * len(full),
+                "cloud_cover": [30.0] * len(full),
+                "wind_speed_10m": [5.0] * len(full),
+                "shortwave_radiation": [200.0] * len(full),
+                "direct_radiation": [150.0] * len(full),
+                "diffuse_radiation": [50.0] * len(full),
+                "precipitation": [0.0] * len(full),
+            }
+        }
+        num_lags = 16
+        data_last_window = self.df_input_data.copy()
+        mock_mlf = MagicMock()
+        mock_mlf.weather_features = ["temp_air"]
+        mock_mlf.is_tuned = False
+        mock_mlf.num_lags = num_lags
+
+        with patch.object(self.fcst, "_fetch_open_meteo_covariates_json", return_value=payload):
+            weather_future = await self.fcst._build_weather_future(data_last_window, mock_mlf)
+
+        self.assertIsNotNone(weather_future)
+        self.assertIsInstance(weather_future, pd.DataFrame)
+        self.assertEqual(len(weather_future), num_lags)
+        self.assertIn("temp_air", weather_future.columns)
+
+    async def test_build_weather_future_uses_lags_opt_when_tuned(self):
+        """_build_weather_future uses mlf.lags_opt (not num_lags) when is_tuned=True."""
+        from unittest.mock import MagicMock, patch
+
+        index = self.fcst.forecast_dates
+        span_start = index[0] - 4 * self.fcst.freq
+        full = pd.date_range(start=span_start, end=index[-1], freq=self.fcst.freq, tz=index.tz)
+        times = (full.tz_convert("UTC").astype("int64") // 10**9).tolist()
+        payload = {
+            "minutely_15": {
+                "time": times,
+                "temperature_2m": [20.0] * len(full),
+                "relative_humidity_2m": [50.0] * len(full),
+                "cloud_cover": [30.0] * len(full),
+                "wind_speed_10m": [5.0] * len(full),
+                "shortwave_radiation": [200.0] * len(full),
+                "direct_radiation": [150.0] * len(full),
+                "diffuse_radiation": [50.0] * len(full),
+                "precipitation": [0.0] * len(full),
+            }
+        }
+        lags_opt_value = 24
+        data_last_window = self.df_input_data.copy()
+        mock_mlf = MagicMock()
+        mock_mlf.weather_features = ["temp_air"]
+        mock_mlf.is_tuned = True
+        mock_mlf.lags_opt = lags_opt_value
+        mock_mlf.num_lags = 48  # should be ignored when is_tuned=True
+
+        with patch.object(self.fcst, "_fetch_open_meteo_covariates_json", return_value=payload):
+            weather_future = await self.fcst._build_weather_future(data_last_window, mock_mlf)
+
+        self.assertIsNotNone(weather_future)
+        self.assertEqual(len(weather_future), lags_opt_value)
+
     # Test output weather forecast using Solcast with mock get request data
     async def test_get_weather_forecast_solcast_method_mock(self):
         self.fcst.params = {

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -456,6 +456,11 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(weather_future, pd.DataFrame)
         self.assertEqual(len(weather_future), num_lags)
         self.assertIn("temp_air", weather_future.columns)
+        # Verify the horizon is anchored exactly one step after the last window index.
+        expected_start = data_last_window.index[-1] + data_last_window.index.freq
+        self.assertEqual(weather_future.index[0], expected_start)
+        # Verify the horizon frequency matches the input window frequency.
+        self.assertEqual(weather_future.index.freq, data_last_window.index.freq)
 
     async def test_build_weather_future_uses_lags_opt_when_tuned(self):
         """_build_weather_future uses mlf.lags_opt (not num_lags) when is_tuned=True."""
@@ -491,6 +496,23 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNotNone(weather_future)
         self.assertEqual(len(weather_future), lags_opt_value)
+
+    async def test_build_weather_future_raises_on_non_uniform_index(self):
+        """_build_weather_future raises ValueError when index freq cannot be inferred."""
+        from unittest.mock import MagicMock
+
+        # Build an irregular (non-uniform) index so that both .freq and pd.infer_freq return None.
+        irregular_timestamps = pd.to_datetime(
+            ["2023-01-01 00:00", "2023-01-01 00:15", "2023-01-01 01:00"]
+        ).tz_localize(self.fcst.time_zone)
+        data_last_window = pd.DataFrame(index=irregular_timestamps)
+        mock_mlf = MagicMock()
+        mock_mlf.weather_features = ["temp_air"]
+        mock_mlf.is_tuned = False
+        mock_mlf.num_lags = 4
+
+        with self.assertRaises(ValueError, msg="Expected ValueError for non-uniform index"):
+            await self.fcst._build_weather_future(data_last_window, mock_mlf)
 
     # Test output weather forecast using Solcast with mock get request data
     async def test_get_weather_forecast_solcast_method_mock(self):

--- a/tests/test_machine_learning_forecaster.py
+++ b/tests/test_machine_learning_forecaster.py
@@ -319,6 +319,35 @@ class TestMLForecasterAsync(unittest.IsolatedAsyncioTestCase):
         self.assertIn("train", df_pred_backtest.columns)
         self.assertEqual(len(df_pred_backtest), len(fast_data))
 
+    async def test_backtest_metrics_populated_when_perform_backtest_true(self):
+        """backtest_metrics_ must be a dict with the expected keys after perform_backtest=True."""
+        fast_data = self.data.iloc[-200:]
+        mlf = MLForecaster(
+            fast_data,
+            self.input_data_dict["params"]["passed_data"]["model_type"],
+            self.input_data_dict["params"]["passed_data"]["var_model"],
+            "LinearRegression",
+            self.input_data_dict["params"]["passed_data"]["num_lags"],
+            emhass_conf,
+            logger,
+        )
+        self.assertIsNone(mlf.backtest_metrics_)
+        await mlf.fit(split_date_delta="48h", perform_backtest=True)
+        self.assertIsNotNone(mlf.backtest_metrics_)
+        self.assertIsInstance(mlf.backtest_metrics_, dict)
+        for expected_key in ("mae", "rmse", "r2", "mape", "n_samples"):
+            self.assertIn(expected_key, mlf.backtest_metrics_)
+        # Sanity: MAE and RMSE must be non-negative finite numbers
+        self.assertGreaterEqual(mlf.backtest_metrics_["mae"], 0.0)
+        self.assertGreaterEqual(mlf.backtest_metrics_["rmse"], 0.0)
+        self.assertGreater(mlf.backtest_metrics_["n_samples"], 0)
+
+    async def test_backtest_metrics_none_when_perform_backtest_false(self):
+        """backtest_metrics_ must remain None when perform_backtest=False (the default)."""
+        mlf = self._get_standard_mlf()
+        await mlf.fit(split_date_delta="48h", perform_backtest=False)
+        self.assertIsNone(mlf.backtest_metrics_)
+
     async def test_mlforecaster_tune_short_train_size_recovery(self):
         """Test the fallback logic when initial_train_size <= window_size during tuning."""
         # Use 50 rows (25 hours). This is enough data for fit() to succeed.

--- a/tests/test_machine_learning_forecaster.py
+++ b/tests/test_machine_learning_forecaster.py
@@ -348,6 +348,28 @@ class TestMLForecasterAsync(unittest.IsolatedAsyncioTestCase):
         await mlf.fit(split_date_delta="48h", perform_backtest=False)
         self.assertIsNone(mlf.backtest_metrics_)
 
+    async def test_backtest_metrics_reset_on_refit_without_backtest(self):
+        """backtest_metrics_ must be reset to None when fit() is called without perform_backtest.
+
+        Ensures a reused instance does not carry stale metrics from a previous fit.
+        """
+        fast_data = self.data.iloc[-200:]
+        mlf = MLForecaster(
+            fast_data,
+            self.input_data_dict["params"]["passed_data"]["model_type"],
+            self.input_data_dict["params"]["passed_data"]["var_model"],
+            "LinearRegression",
+            self.input_data_dict["params"]["passed_data"]["num_lags"],
+            emhass_conf,
+            logger,
+        )
+        # First fit WITH backtest — populates backtest_metrics_
+        await mlf.fit(split_date_delta="48h", perform_backtest=True)
+        self.assertIsNotNone(mlf.backtest_metrics_)
+        # Second fit WITHOUT backtest — metrics must be cleared, not carry over from the first fit
+        await mlf.fit(split_date_delta="48h", perform_backtest=False)
+        self.assertIsNone(mlf.backtest_metrics_)
+
     async def test_mlforecaster_tune_short_train_size_recovery(self):
         """Test the fallback logic when initial_train_size <= window_size during tuning."""
         # Use 50 rows (25 hours). This is enough data for fit() to succeed.


### PR DESCRIPTION
## Summary

Follow-up to #955, implementing the two improvements @davidusb-geek suggested in review:

> "add the quality of fit to the attributes of the trained objects"
> (and a Sourcery code-quality flag on the duplicate horizon-construction block)

### 1. `backtest_metrics_` attribute on `MLForecaster`

When `perform_backtest=True`, the fitted object now exposes a `backtest_metrics_` dict with four standard goodness-of-fit metrics computed over the out-of-sample backtest folds:

| Key | Metric |
| --- | --- |
| `mae` | Mean Absolute Error (same unit as the target sensor, e.g. W) |
| `rmse` | Root Mean Squared Error (same unit) |
| `r2` | Coefficient of determination R² |
| `mape` | Mean Absolute Percentage Error (%; zero-actual rows excluded) |
| `n_samples` | Number of backtest steps used |

All four are also logged at INFO level after the backtest, making it easy to compare model variants or measure the effect of adding weather covariates without inspecting the object. `backtest_metrics_` is `None` before `fit()` and when `perform_backtest=False`, so the default behaviour is unchanged.

### 2. `_build_weather_future()` shared helper on `Forecast`

The future-weather-index construction block was duplicated verbatim in both `Forecast._get_load_forecast_ml` (forecast.py) and `command_line.forecast_model_predict` (command_line.py). Both call-sites now delegate to a new `Forecast._build_weather_future(data_last_window, mlf)` async method, eliminating the drift risk. Returns `None` when no weather features are configured or when `data_last_window` is `None`.

### Tests

5 new tests in `test_machine_learning_forecaster.py` for `backtest_metrics_` (keys, types, non-negative values, stays-None-by-default). 4 new tests in `test_forecast.py` for `_build_weather_future` (None-no-features, None-no-window, correct-horizon, uses-lags_opt-when-tuned). All targeted tests pass locally, ruff format + lint clean.

### Docs

`docs/mlforecaster.md` gains a *Backtest goodness-of-fit metrics* section documenting the attribute keys and units, and a *Future directions* section proposing Gaussian Process Regression as the path toward per-step confidence intervals and stochastic MPC — explicitly deferred as a large architecture change, per your suggestion.

### What this does NOT include

The GPR / stochastic-MPC direction is intentionally left as a future direction. Wiring a probabilistic regressor into the MILP and propagating uncertainty through the objective function is a large architecture change that warrants its own issue + design discussion when the time is right.

## Summary by Sourcery

Expose backtest goodness-of-fit metrics on MLForecaster and centralise future weather covariate construction for ML forecasts.

New Features:
- Add a backtest_metrics_ attribute on MLForecaster populated with MAE, RMSE, R2, MAPE and sample count when perform_backtest=True.

Enhancements:
- Factor out shared future weather covariate index construction into a Forecast._build_weather_future helper used by both forecast and command-line prediction paths.

Documentation:
- Document the MLForecaster backtest_metrics_ attribute and its metrics in the mlforecaster guide, and add a future directions section on probabilistic forecasting.

Tests:
- Add unit tests covering MLForecaster.backtest_metrics_ behaviour and Forecast._build_weather_future edge cases and horizon sizing.