### PR TITLE
docs: rearranged main header Use Casses and Cookbook sections

### DIFF
--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -1,4 +1,4 @@
-# Cookbook
+# 🧑‍🍳 Cookbook
 
 Short, standalone, copy-pasteable recipes for common EMHASS patterns. Each recipe follows a fixed template: Goal / Prerequisites / Config / Snippet / Caveats / Credits.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,8 @@ EMHASS is a Python module designed to optimize your home energy interfacing with
 [🚀 Quick Start](quick_start) · [⚙️ Configuration](section_config) · [💻 API Reference](section_reference)
 
 [🗣️ Community](https://community.home-assistant.io/t/emhass-an-energy-management-for-home-assistant/338126) · [🛠️ Issues](https://github.com/davidusb-geek/emhass/issues) · [🧩 Home Assistant Add-on](https://github.com/davidusb-geek/emhass-add-on)
+
+[📁 Study cases](study_cases/index) · [🧑‍🍳 Cookbook](cookbook/index)
 :::
 
 <br>
@@ -237,8 +239,6 @@ section_getting_started
 section_config
 section_core
 section_thermal
-study_cases/index
-cookbook/index
 section_reference
 
 ```

--- a/docs/section_getting_started.md
+++ b/docs/section_getting_started.md
@@ -9,5 +9,6 @@ usage_guide
 automations
 differences
 study_cases/index
+cookbook/index
 
 ```


### PR DESCRIPTION
## Summary by Sourcery

Reorganize documentation navigation to surface Study cases and Cookbook sections more prominently and align headers with the main index.

Documentation:
- Add Study cases and Cookbook links to the main documentation header navigation.
- Expose the Cookbook section from the Getting Started section and update its page title with an icon-styled heading.