### PR TITLE
feat: schedule PV curtailment as late as possible (closes #342)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -201,7 +201,7 @@ Then the additional technical parameters:
 - `modules_per_string`: The number of modules per string. Defaults to 16. This parameter can be a list of items to enable the simulation of mixed orientation systems, for example, one east-facing array (azimuth=90) and one west-facing array (azimuth=270). 
 - `strings_per_inverter`: The number of used strings per inverter. Defaults to 1. This parameter can be a list of items to enable the simulation of mixed orientation systems, for example one east-facing array (azimuth=90) and one west-facing array (azimuth=270).
 - `inverter_is_hybrid`: Set to True to consider that the installation inverter is hybrid for PV and batteries (Default False).
-- `compute_curtailment`: Set to True to compute a special PV curtailment variable (Default False).
+- `compute_curtailment`: Set to True to compute a special PV curtailment variable (Default False). When enabled, curtailment that is cost-equivalent is scheduled as late as possible in the optimization horizon (issue #342).
 - `inverter_stress_cost`: The virtual penalty cost (in currency/kWh) applied if the inverter runs at its maximum nominal power (Recommended: 0.05 - 0.20).
 - `inverter_stress_segments`: The number of linear segments used to approximate the quadratic curve. Higher values are more accurate but increase computation slightly (Recommended: 10).
 

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -42,6 +42,12 @@ THERMAL_CONFIG_KEY_HINTS = {
     ),
 }
 
+# Tie-break weight for PV curtailment timing (issue #342): must be far below
+# real tariff coefficients (~1e-4 $/W per step) yet large enough for the LP to
+# act on (above HiGHS dual feasibility tolerance once multiplied by realistic
+# curtailment powers in W).
+CURTAILMENT_TIEBREAK_EPS = 1e-7
+
 
 class Optimization:
     r"""
@@ -1286,6 +1292,20 @@ class Optimization:
         capacity_cost_per_kw = self._get_capacity_cost_per_kw()
         if capacity_cost_per_kw > 0 and "peak_import" in self.vars:
             objective_terms.append(-capacity_cost_per_kw * (self.vars["peak_import"] / 1000.0))
+
+        # Curtailment timing tie-break (issue #342). p_pv_curtailment carries no cost
+        # of its own, so among equal-cost optima the solver may curtail early in the
+        # horizon even when storing now and curtailing later is equally cheap. Add a
+        # tiny time-decreasing penalty so the latest feasible timesteps are preferred.
+        # The weight is normalized by the horizon length and the epsilon is orders of
+        # magnitude below any real tariff coefficient, so it breaks ties without ever
+        # flipping a real economic decision.
+        if self.plant_conf["compute_curtailment"]:
+            p_pv_curtailment = self.vars["p_pv_curtailment"]
+            tiebreak_weights = np.arange(self.num_timesteps, 0, -1) / self.num_timesteps
+            objective_terms.append(
+                -CURTAILMENT_TIEBREAK_EPS * cp.sum(cp.multiply(tiebreak_weights, p_pv_curtailment))
+            )
 
         # Sum all terms to create the final objective expression
         return cp.Maximize(cp.sum(objective_terms))
@@ -2848,6 +2868,15 @@ class Optimization:
                 # Just bound by nominal power. No binary variables involved.
                 constraints.append(p_deferrable[k] >= 0)
                 constraints.append(p_deferrable[k] <= M)
+
+                # Load deactivation parity with the binary branch above: a pure
+                # continuous load has no binaries for param_load_active to act on,
+                # so an inactive load (operating hours = 0, or window outside the
+                # horizon) would be left as a free energy sink for surplus PV.
+                # Bound it by the same activation parameter instead. Thermal loads
+                # are unaffected (param_load_active is pinned to 1 for them).
+                if k < len(self.param_load_active):
+                    constraints.append(p_deferrable[k] <= M * self.param_load_active[k])
 
         # Process shared thermal tanks once each, after the per-load loop. Each
         # shared tank is fed by N >= 1 deferrable loads; their per-load

--- a/src/emhass/static/data/param_definitions.json
+++ b/src/emhass/static/data/param_definitions.json
@@ -310,7 +310,7 @@
     },
     "compute_curtailment": {
       "friendly_name": "Set compute curtailment (grid export limit)",
-      "Description": "Set to True to compute a special PV curtailment variable (Default False)",
+      "Description": "Set to True to compute a special PV curtailment variable (Default False). When enabled, curtailment that is cost-equivalent is scheduled as late as possible in the optimization horizon",
       "input": "boolean",
       "default_value": false,
       "unit": "none"

--- a/src/emhass/static/openapi.json
+++ b/src/emhass/static/openapi.json
@@ -506,7 +506,7 @@
             "type": "boolean",
             "default": false,
             "title": "Set compute curtailment (grid export limit)",
-            "description": "Set to True to compute a special PV curtailment variable (Default False)"
+            "description": "Set to True to compute a special PV curtailment variable (Default False). When enabled, curtailment that is cost-equivalent is scheduled as late as possible in the optimization horizon"
           },
           "load_cost_forecast_method": {
             "type": "string",

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -6399,6 +6399,344 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(np.allclose(opt_res["P_deferrable0"], 0.0))
         self.assertTrue(np.allclose(opt_res["P_deferrable1"], [0, 1000, 1000, 0]))
 
+    def _make_curtailment_scenario(self):
+        """Build shared config and input DataFrame for curtailment tie-break tests (issue #342).
+
+        Scenario: 8 steps @ 30-min. PV=1200W, load=200W, surplus=1000W/step.
+        Export cap=0 (no grid export). Battery cap=2000Wh, charge_rate=2000W
+        (absorbs up to 1000Wh/step == the per-step surplus energy).
+        soc_init=0, soc_final=1.0: battery stores exactly 2000Wh net.
+        Total surplus = 8 * 1000W * 0.5h = 4000Wh; battery absorbs 2000Wh;
+        so exactly 2000Wh must be curtailed.
+
+        Temporal freedom: any 4 of the 8 steps can be the curtailment steps (battery
+        covers the other 4). Flat prices make all allocations cost-equal; the
+        tie-break is the ONLY thing that distinguishes them.
+        """
+        import emhass.optimization as opt_module
+
+        self.plant_conf.update(
+            {
+                "inverter_is_hybrid": False,
+                "compute_curtailment": True,
+                "battery_nominal_energy_capacity": 2000,  # 2 kWh
+                "battery_charge_power_max": 2000,  # 2 kW -> 1000 Wh/step max
+                "battery_discharge_power_max": 2000,
+                "battery_discharge_efficiency": 1.0,
+                "battery_charge_efficiency": 1.0,
+                "battery_minimum_state_of_charge": 0.0,
+                "battery_maximum_state_of_charge": 1.0,
+                "battery_target_state_of_charge": 1.0,
+                "maximum_power_to_grid": 0,  # no export
+            }
+        )
+        self.optim_conf.update(
+            {
+                "set_use_battery": True,
+                "set_nocharge_from_grid": True,
+                "set_nodischarge_to_grid": True,
+                "weight_battery_discharge": 0.0,
+                "weight_battery_charge": 0.0,
+                "operating_hours_of_each_deferrable_load": [0, 0],
+            }
+        )
+
+        n = 8
+        dates = pd.date_range(
+            start=pd.Timestamp("2024-01-01 06:00:00", tz=self.retrieve_hass_conf["time_zone"]),
+            periods=n,
+            freq=self.retrieve_hass_conf["optimization_time_step"],
+        )
+        df = pd.DataFrame(index=dates)
+        df["p_pv_forecast"] = 1200.0  # W
+        df["p_load_forecast"] = 200.0  # W  (net surplus = 1000 W/step)
+        df[self.fcst.var_load_cost] = 0.1  # flat, no real cost difference across steps
+        df[self.fcst.var_prod_price] = 0.0  # no export revenue (export blocked anyway)
+
+        return df, opt_module
+
+    def test_curtailment_scheduled_late(self):
+        """Discriminating test (issue #342): with temporal freedom the solver must prefer
+        the LATEST feasible timesteps for curtailment.
+
+        See _make_curtailment_scenario: battery absorbs half of the horizon's surplus
+        (soc 0->1.0). The other half must be curtailed. All allocations share the same
+        real cost (flat prices) so the tie-break penalty is the only distinguisher.
+        Without it the solver places curtailment arbitrarily; with it curtailment must
+        concentrate in the SECOND HALF (center-of-mass > midpoint).
+        """
+        df_input, opt_module = self._make_curtailment_scenario()
+
+        def run(eps_override=None):
+            original = getattr(opt_module, "CURTAILMENT_TIEBREAK_EPS", 0.0)
+            if eps_override is not None:
+                opt_module.CURTAILMENT_TIEBREAK_EPS = eps_override
+            try:
+                opt = Optimization(
+                    self.retrieve_hass_conf,
+                    self.optim_conf,
+                    self.plant_conf,
+                    self.fcst.var_load_cost,
+                    self.fcst.var_prod_price,
+                    "profit",
+                    emhass_conf,
+                    logger,
+                )
+                res = opt.perform_optimization(
+                    df_input,
+                    df_input["p_pv_forecast"].values,
+                    df_input["p_load_forecast"].values,
+                    df_input[opt.var_load_cost].values,
+                    df_input[opt.var_prod_price].values,
+                    soc_init=0.0,
+                    soc_final=1.0,
+                )
+                self.assertIn(opt.optim_status, VALID_OPTIMAL_STATUSES)
+                return res
+            finally:
+                opt_module.CURTAILMENT_TIEBREAK_EPS = original
+
+        opt_res = run()
+
+        self.assertIn("P_PV_curtailment", opt_res.columns)
+        curtailment = opt_res["P_PV_curtailment"].values
+        n = len(curtailment)
+
+        # Scenario guarantees forced curtailment (total surplus > battery capacity)
+        self.assertGreater(
+            curtailment.sum(),
+            0,
+            "No curtailment occurred - scenario misconfigured",
+        )
+
+        indices = np.arange(n)
+        total_curtail = curtailment.sum()
+        com = np.dot(indices, curtailment) / total_curtail
+        midpoint = (n - 1) / 2.0  # 3.5 for n=8
+
+        # With tie-break: curtailment mass in LATE timesteps -> CoM > midpoint
+        self.assertGreater(
+            com,
+            midpoint,
+            f"Curtailment CoM {com:.2f} should be > midpoint {midpoint:.2f}. "
+            f"Curtailment per step: {curtailment}",
+        )
+
+        # Counterfactual discriminating-power check: negate EPS -> EARLY preference -> CoM < midpoint
+        res_early = run(eps_override=-getattr(opt_module, "CURTAILMENT_TIEBREAK_EPS", 1e-7))
+        c_early = res_early["P_PV_curtailment"].values
+        total_early = c_early.sum()
+        if total_early > 0:
+            com_early = np.dot(indices, c_early) / total_early
+            self.assertLess(
+                com_early,
+                midpoint,
+                f"With negative EPS, curtailment CoM {com_early:.2f} should be < midpoint "
+                f"{midpoint:.2f}. Curtailment per step: {c_early}",
+            )
+
+    def test_curtailment_tiebreak_cost_invariant(self):
+        """Issue #342: The tie-break must not change the real economic cost.
+        Solve the same scenario with normal EPS and EPS=0; assert that real cost
+        (grid import minus export revenue) and total curtailed energy are equal
+        within tight tolerance.
+        """
+        df_input, opt_module = self._make_curtailment_scenario()
+
+        def run_with_eps(eps_value):
+            original = getattr(opt_module, "CURTAILMENT_TIEBREAK_EPS", 0.0)
+            opt_module.CURTAILMENT_TIEBREAK_EPS = eps_value
+            try:
+                opt = Optimization(
+                    self.retrieve_hass_conf,
+                    self.optim_conf,
+                    self.plant_conf,
+                    self.fcst.var_load_cost,
+                    self.fcst.var_prod_price,
+                    "profit",
+                    emhass_conf,
+                    logger,
+                )
+                res = opt.perform_optimization(
+                    df_input,
+                    df_input["p_pv_forecast"].values,
+                    df_input["p_load_forecast"].values,
+                    df_input[opt.var_load_cost].values,
+                    df_input[opt.var_prod_price].values,
+                    soc_init=0.0,
+                    soc_final=1.0,
+                )
+                self.assertIn(opt.optim_status, VALID_OPTIMAL_STATUSES)
+                return res
+            finally:
+                opt_module.CURTAILMENT_TIEBREAK_EPS = original
+
+        res_with = run_with_eps(getattr(opt_module, "CURTAILMENT_TIEBREAK_EPS", 1e-7))
+        res_without = run_with_eps(0.0)
+
+        time_step_h = self.retrieve_hass_conf["optimization_time_step"].seconds / 3600.0
+        unit_load_cost = df_input[self.fcst.var_load_cost].values
+        unit_prod_price = df_input[self.fcst.var_prod_price].values
+
+        def real_cost(res):
+            # Real import cost minus export revenue (tie-break term excluded)
+            import_cost = np.sum(res["P_grid_pos"].values * unit_load_cost) * time_step_h * 0.001
+            export_rev = np.sum(-res["P_grid_neg"].values * unit_prod_price) * time_step_h * 0.001
+            return import_cost - export_rev
+
+        cost_with = real_cost(res_with)
+        cost_without = real_cost(res_without)
+
+        denom = max(abs(cost_without), 1e-10)
+        self.assertLess(
+            abs(cost_with - cost_without) / denom,
+            1e-6,
+            f"Real cost changed: with_eps={cost_with:.8f}, without_eps={cost_without:.8f}",
+        )
+
+        # Total curtailed energy must be unchanged
+        curtail_with = res_with["P_PV_curtailment"].values.sum() * time_step_h * 0.001
+        curtail_without = res_without["P_PV_curtailment"].values.sum() * time_step_h * 0.001
+        self.assertAlmostEqual(
+            curtail_with,
+            curtail_without,
+            places=4,
+            msg=f"Total curtailed energy changed: {curtail_with:.6f} vs {curtail_without:.6f}",
+        )
+
+    def test_curtailment_tiebreak_absent_when_disabled(self):
+        """Issue #342: When compute_curtailment=False, the tie-break term must not
+        reference p_pv_curtailment in the objective (structurally absent).
+        """
+        self.plant_conf.update(
+            {
+                "inverter_is_hybrid": False,
+                "compute_curtailment": False,
+            }
+        )
+        self.optim_conf.update(
+            {
+                "set_use_battery": False,
+                "operating_hours_of_each_deferrable_load": [0, 0],
+            }
+        )
+
+        periods = 4
+        dates = pd.date_range(
+            start=pd.Timestamp("2024-01-01 06:00:00", tz=self.retrieve_hass_conf["time_zone"]),
+            periods=periods,
+            freq=self.retrieve_hass_conf["optimization_time_step"],
+        )
+        df_input = pd.DataFrame(index=dates)
+        df_input["p_pv_forecast"] = 1000.0
+        df_input["p_load_forecast"] = 200.0
+        df_input[self.fcst.var_load_cost] = 0.1
+        df_input[self.fcst.var_prod_price] = 0.05
+
+        opt = Optimization(
+            self.retrieve_hass_conf,
+            self.optim_conf,
+            self.plant_conf,
+            self.fcst.var_load_cost,
+            self.fcst.var_prod_price,
+            "profit",
+            emhass_conf,
+            logger,
+        )
+
+        opt.perform_optimization(
+            df_input,
+            df_input["p_pv_forecast"].values,
+            df_input["p_load_forecast"].values,
+            df_input[opt.var_load_cost].values,
+            df_input[opt.var_prod_price].values,
+        )
+
+        self.assertIsNotNone(opt.prob, "prob should be built after perform_optimization")
+
+        # p_pv_curtailment must NOT appear in the objective when compute_curtailment=False
+        obj_var_names = {v.name() for v in opt.prob.objective.variables()}
+        self.assertNotIn(
+            "p_pv_curtailment",
+            obj_var_names,
+            f"p_pv_curtailment should not be in objective when compute_curtailment=False. "
+            f"Objective variables: {obj_var_names}",
+        )
+
+    def test_continuous_deferrable_inactive_no_phantom_consumption(self):
+        """An inactive pure-continuous deferrable load (0 operating hours, no
+        binaries) must not absorb surplus PV. Without the param_load_active bound
+        in the continuous branch it acts as a free energy sink, and the
+        curtailment tie-break (issue #342) would then deterministically route
+        surplus into the disabled load instead of booking it as curtailment.
+        """
+        self.plant_conf.update(
+            {
+                "inverter_is_hybrid": False,
+                "compute_curtailment": True,
+                "maximum_power_to_grid": 0,  # no export
+            }
+        )
+        self.optim_conf.update(
+            {
+                "set_use_battery": False,
+                "operating_hours_of_each_deferrable_load": [0, 0],
+                # Pure continuous: no binaries, so the load-active bound is the
+                # only thing standing between an inactive load and the surplus
+                "treat_deferrable_load_as_semi_cont": [False, False],
+                "set_deferrable_load_single_constant": [False, False],
+            }
+        )
+
+        n = 8
+        dates = pd.date_range(
+            start=pd.Timestamp("2024-01-01 06:00:00", tz=self.retrieve_hass_conf["time_zone"]),
+            periods=n,
+            freq=self.retrieve_hass_conf["optimization_time_step"],
+        )
+        df_input = pd.DataFrame(index=dates)
+        df_input["p_pv_forecast"] = 1200.0  # W
+        df_input["p_load_forecast"] = 200.0  # W (surplus = 1000 W/step, unexportable)
+        df_input[self.fcst.var_load_cost] = 0.1
+        df_input[self.fcst.var_prod_price] = 0.0
+
+        opt = Optimization(
+            self.retrieve_hass_conf,
+            self.optim_conf,
+            self.plant_conf,
+            self.fcst.var_load_cost,
+            self.fcst.var_prod_price,
+            "profit",
+            emhass_conf,
+            logger,
+        )
+        opt_res = opt.perform_optimization(
+            df_input,
+            df_input["p_pv_forecast"].values,
+            df_input["p_load_forecast"].values,
+            df_input[opt.var_load_cost].values,
+            df_input[opt.var_prod_price].values,
+        )
+        self.assertIn(opt.optim_status, VALID_OPTIMAL_STATUSES)
+
+        # Inactive loads must consume nothing
+        for col in ("P_deferrable0", "P_deferrable1"):
+            self.assertTrue(
+                np.allclose(opt_res[col].values, 0.0, atol=1e-6),
+                f"{col} should be zero for an inactive continuous load, got {opt_res[col].values}",
+            )
+
+        # The full surplus must be booked as curtailment, not silently dumped
+        time_step_h = self.retrieve_hass_conf["optimization_time_step"].seconds / 3600.0
+        expected_curtail_wh = 1000.0 * n * time_step_h
+        actual_curtail_wh = opt_res["P_PV_curtailment"].values.sum() * time_step_h
+        self.assertAlmostEqual(
+            actual_curtail_wh,
+            expected_curtail_wh,
+            delta=1.0,
+            msg=f"Expected {expected_curtail_wh} Wh curtailed, got {actual_curtail_wh}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -6,6 +6,7 @@ import pickle
 import random
 import unittest
 from datetime import datetime
+from unittest import mock
 
 import aiofiles
 import numpy as np
@@ -6468,10 +6469,12 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         df_input, opt_module = self._make_curtailment_scenario()
 
         def run(eps_override=None):
-            original = getattr(opt_module, "CURTAILMENT_TIEBREAK_EPS", 0.0)
-            if eps_override is not None:
-                opt_module.CURTAILMENT_TIEBREAK_EPS = eps_override
-            try:
+            eps = (
+                eps_override
+                if eps_override is not None
+                else getattr(opt_module, "CURTAILMENT_TIEBREAK_EPS", 0.0)
+            )
+            with mock.patch.object(opt_module, "CURTAILMENT_TIEBREAK_EPS", eps, create=True):
                 opt = Optimization(
                     self.retrieve_hass_conf,
                     self.optim_conf,
@@ -6493,8 +6496,6 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
                 )
                 self.assertIn(opt.optim_status, VALID_OPTIMAL_STATUSES)
                 return res
-            finally:
-                opt_module.CURTAILMENT_TIEBREAK_EPS = original
 
         opt_res = run()
 
@@ -6544,9 +6545,7 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         df_input, opt_module = self._make_curtailment_scenario()
 
         def run_with_eps(eps_value):
-            original = getattr(opt_module, "CURTAILMENT_TIEBREAK_EPS", 0.0)
-            opt_module.CURTAILMENT_TIEBREAK_EPS = eps_value
-            try:
+            with mock.patch.object(opt_module, "CURTAILMENT_TIEBREAK_EPS", eps_value, create=True):
                 opt = Optimization(
                     self.retrieve_hass_conf,
                     self.optim_conf,
@@ -6568,8 +6567,6 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
                 )
                 self.assertIn(opt.optim_status, VALID_OPTIMAL_STATUSES)
                 return res
-            finally:
-                opt_module.CURTAILMENT_TIEBREAK_EPS = original
 
         res_with = run_with_eps(getattr(opt_module, "CURTAILMENT_TIEBREAK_EPS", 1e-7))
         res_without = run_with_eps(0.0)


### PR DESCRIPTION
When `compute_curtailment` is enabled, `p_pv_curtailment` carries no cost of its own, so among equal-cost plans the solver places curtailment anywhere in the horizon, and it often lands early in the day. That skews the SoC forecast and feeds the plan flip-flopping between MPC runs that @TD944 described. This implements the option 1 tie-break you greenlit in #342.

The change adds a tiny time-decreasing penalty on curtailed power, active only when `compute_curtailment` is true. The weight is `EPS * (T - t) / T`, so early curtailment costs slightly more than late curtailment and the solver pushes it as far right as the other constraints allow. One small departure from the issue sketch: the weight is normalized by the horizon length, so the worst-case weight is exactly EPS per watt no matter how long the window is. Without that, a 288-step run would see weights 288 times larger than a short one.

EPS is 1e-7 per W. Typical tariff coefficients in the objective are 1e-5 to 1e-4 per W per step, so the tie-break sits two to three orders of magnitude below any real price signal. I probed near-tie scenarios where a tiny export price favours early curtailment: the real signal wins for any price difference above 0.0001 $/kWh, far below real tariffs. The cost-invariance test pins that real cost and total curtailed energy are unchanged with the term on or off. Long horizons were checked too (n up to 288, curtailment still lands in the latest feasible steps).

No new configuration parameter, per your note in the issue.

One related fix that validation surfaced: a pure continuous deferrable load (not semi-continuous, no min power, no startup penalty) skips the binary logic, and the existing `param_load_active` deactivation only binds the binaries. So an inactive continuous load (0 operating hours) is left as a free energy sink bounded only by nominal power. Today that is a latent degeneracy; with the tie-break it becomes deterministic, because dumping surplus into the disabled load is cheaper than booking curtailment. The fix is one constraint in the continuous branch, `p_deferrable[k] <= M * param_load_active[k]`, exact parity with what the binary branch already does. Thermal loads are unaffected since `param_load_active` is pinned to 1 for them, and loads whose window falls outside the horizon stay feasible because the energy constraint is already relaxed in the same cases. The relaxed LP fallback inherits the fix as well since it rebuilds through the same code path. Happy to split this into its own PR if you would rather keep them separate, but the tie-break should not ship without it.

Tests (there were no curtailment behaviour tests before):
- `test_curtailment_scheduled_late`: forced-curtailment scenario with temporal freedom (battery absorbs half the surplus, the rest must be curtailed somewhere); asserts the curtailment mass lands in the late half, and that negating the weight flips it early, so the test cannot pass by solver luck. Fails on master.
- `test_curtailment_tiebreak_cost_invariant`: same scenario with the term on vs off; real grid cost and total curtailed energy are identical.
- `test_curtailment_tiebreak_absent_when_disabled`: with `compute_curtailment` false the objective does not reference the curtailment variable at all.
- `test_continuous_deferrable_inactive_no_phantom_consumption`: regression test for the free-sink fix; fails without the new constraint (each disabled load was absorbing 250 W per step).

Docs: one sentence on the new behaviour in docs/config.md and in the param_definitions.json description, with openapi.json regenerated from it.

Full test_optimization.py passes (119), whole suite green locally (578 passed), ruff check and format clean.

The diagnosis and the option 1 design are @purcell-lab's (#342), handed over earlier this week. @TD944 and @tbrasser corroborated the behaviour from their setups. I run `compute_curtailment` daily on a hard-capped export setup, so I will be validating this on live data as soon as it lands.

## Summary by Sourcery

Prioritize scheduling PV curtailment as late as possible in the optimization horizon while fixing a deferrable-load degeneracy revealed by the new tie-break logic.

New Features:
- Introduce a small time-weighted tie-break term so that, when curtailment is enabled and economically neutral, PV curtailment is pushed to later timesteps in the horizon.

Bug Fixes:
- Prevent inactive pure-continuous deferrable loads from acting as free energy sinks by bounding their power with the load-activation parameter.

Enhancements:
- Ensure the PV curtailment tie-break term is only present in the objective when curtailment computation is enabled.

Documentation:
- Document the curtailment timing behaviour when compute_curtailment is enabled and propagate the change into the API parameter definitions.

Tests:
- Add scenario-based tests that verify late scheduling of curtailment, cost invariance of the tie-break term, absence of the tie-break when curtailment is disabled, and correct behaviour of inactive continuous deferrable loads.