### PR TITLE
style: green the code-quality CI (ruff format + import sort)

### DIFF
--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1618,13 +1618,14 @@ async def treat_runtimeparams(
                 float(runtimeparams["soc_final"]) if "soc_final" in runtimeparams else None
             )
             params["passed_data"]["soc_target"] = (
-              float(runtimeparams["soc_target"]) if "soc_target" in runtimeparams else None
+                float(runtimeparams["soc_target"]) if "soc_target" in runtimeparams else None
             )
             params["passed_data"]["soc_target_timestep"] = (
-                int(runtimeparams["soc_target_timestep"]) if "soc_target_timestep" in runtimeparams else None
+                int(runtimeparams["soc_target_timestep"])
+                if "soc_target_timestep" in runtimeparams
+                else None
             )
             params["passed_data"]["current_period_peak"] = None
-
 
         # Parsing the thermal model parameters
         # Load the default config

--- a/tests/test_soc_recovery_prototype.py
+++ b/tests/test_soc_recovery_prototype.py
@@ -7,7 +7,6 @@ import pandas as pd
 
 from emhass.optimization import Optimization
 
-
 TEST_ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 


### PR DESCRIPTION
Small one, completely optional.

The Code Quality workflow is currently red on master, on two files the latest `ruff` flags:

- `src/emhass/utils.py` needs a `ruff format` pass (a couple of long ternaries in `treat_runtimeparams`, plus a stray blank line)
- `tests/test_soc_recovery_prototype.py` trips I001 on its import block

Because that job runs on every PR, each new one inherits the red even when its own diff is clean, which makes a real failure harder to spot.

This is just the output of `ruff format` and `ruff check --fix` on those two files. No logic touched, nothing else changed. Afterwards `ruff check .` and `ruff format --check .` both pass, so the Code Quality check goes green.

Totally your call whether you want it. If you'd rather handle it your own way or leave it, no worries at all, just thought I'd save you the chore since I had the diff in front of me. Happy to close it if it clashes with anything you've got in flight.

## Summary by Sourcery

Normalize code formatting to satisfy code-quality checks and restore a green CI status.

Enhancements:
- Apply automated Ruff formatting to runtime parameter handling in utils to comply with style rules.

Tests:
- Tidy test import layout to satisfy Ruff import-order checks in the test suite.