### PR TITLE
feat: support arithmetic expressions in InfluxDB var_list entries

### DIFF
--- a/docs/passing_data.md
+++ b/docs/passing_data.md
@@ -253,6 +253,27 @@ Then on the EMHASS configuration you need to set:
 Finally, if using the Add-on, you need to fill both "influxdb_password" and "influxdb_username" in the Add-on **Configuration** pane.
 If using the Docker standalone or legacy installation method, then you need to set these in the `secrets_emhass.yaml` file.
 
+### Arithmetic expressions in the sensor list
+
+When using InfluxDB, the entity id you would normally give to a sensor list parameter (such as `sensor_power_photovoltaics` or `sensor_power_load_no_var_loads`) can instead be an arithmetic expression that combines several InfluxDB time series. Wrap the expression in `{{ ... }}` and quote each entity id:
+
+```text
+{{'sensor.power_a' - 'sensor.power_b' * 1000}}
+```
+
+Each quoted entity is queried separately and the operation is applied element-wise on the values returned for the matching timestamps. The supported operators are `+`, `-`, `*`, `/`, `**`, `%`, unary `+`/`-` and numeric constants. Anything else (function calls, attribute access, comparisons, names that are not quoted entities, ...) is rejected, so an expression cannot run arbitrary code. An entity referenced more than once within expressions is only queried once. This is useful when the quantity EMHASS needs is not stored as a single sensor, for example a net power that is the difference of two meters, or a unit conversion.
+
+```{note}
+
+A few caveats apply because of how InfluxDB 1.x aggregates data:
+
+- Each series is bucketed with `GROUP BY time() FILL(previous)`, so every entity in an expression lands on the same time grid and the arithmetic stays aligned. For the leading buckets of the requested window, EMHASS queries each entity slightly earlier (by one day) so the first values can be forward-filled from the most recent prior reading; a sensor whose previous reading is older than that still starts with a short gap, which the downstream regression absorbs.
+- If a referenced sensor updates less often than once per day, that one-day lookback may not reach its previous reading and the expression starts with leading `NaN`. If that affects your setup, add the expression to `sensor_replace_zero` or `sensor_linear_interp` so the gap is filled before the optimization.
+- An entity used both as a plain sensor and inside an expression is queried twice (the plain entry over the requested window, the expression entity over the padded window), so its plain column and its value inside an expression can differ at the leading buckets.
+- InfluxDB 1.x cannot time-weight inside `GROUP BY`, so a source that updates more slowly than the optimization time step simply repeats its last value within each bucket. Keep this in mind when combining series that report at very different rates.
+- If any entity referenced by an expression returns no data, the whole InfluxDB retrieval fails (a plain sensor that returns no data is still skipped, as before).
+```
+
 
 ## Passing in secret parameters
 Secret parameters are passed differently, depending on which method you choose. Alternative options are also present for passing secrets, if you are running EMHASS separately from Home Assistant. _(I.e. not via EMHASS-Add-on)_ 

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -866,9 +866,10 @@ class RetrieveHass:
 
         try:
             expression_result = self._evaluate_influx_expression(parsed_expression, series_mapping)
-        except (ValueError, SyntaxError, ArithmeticError, RecursionError, MemoryError):
-            # A malformed or pathological entry (deep nesting, integer overflow, ...) must fail
-            # the retrieval cleanly rather than propagate out and abort the whole optimization.
+        except (TypeError, ValueError, SyntaxError, ArithmeticError, RecursionError, MemoryError):
+            # A malformed or pathological entry (deep nesting, integer overflow, a dtype mismatch
+            # raising TypeError, division by zero, ...) must fail the retrieval cleanly rather than
+            # propagate out and abort the whole optimization.
             self.logger.exception(f"Failed to evaluate InfluxDB expression '{expression}'")
             return None
 

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1,8 +1,11 @@
+import ast
 import asyncio
 import copy
 import logging
+import operator
 import os
 import pathlib
+import re
 import time
 from datetime import datetime, timezone
 from typing import Any, Self
@@ -29,6 +32,19 @@ header_accept = "application/json"
 header_auth = "Bearer"
 hass_url = "http://supervisor/core/api"
 sensor_prefix = "sensor."
+
+# When a var_list entry is an arithmetic expression, every entity it references is
+# queried over a window padded this much earlier than the requested start, then sliced
+# back. This lets InfluxDB's GROUP BY time() FILL(previous) seed the leading in-window
+# buckets from the most recent prior value instead of returning leading NaNs (which would
+# misalign two series that update at different phases). A prior value older than this is
+# not recovered; the downstream regression absorbs the residual leading gap.
+INFLUX_EXPRESSION_LOOKBACK = pd.Timedelta(days=1)
+
+# Upper bound on a constant exponent in an InfluxDB var_list expression. Real energy
+# arithmetic never needs large exponents; the cap stops a crafted ``10 ** 1000000`` style
+# entry from materializing a multi-megabyte integer and exhausting CPU/memory.
+INFLUX_EXPRESSION_MAX_POW_EXPONENT = 1000
 
 
 class RetrieveHass:
@@ -634,7 +650,13 @@ class RetrieveHass:
 
         :param days_list: A list of days to retrieve data for
         :type days_list: pandas.date_range
-        :param var_list: List of sensor entity IDs to retrieve
+        :param var_list: List of variables to retrieve. Each entry is either a plain
+            sensor entity id (e.g. ``'sensor.power_a'``) or an arithmetic expression
+            combining several timeseries with the ``{{ ... }}`` syntax, for example
+            ``"{{'sensor.power_a' - 'sensor.power_b' * 1000}}"``. For an expression every
+            referenced entity is queried separately and the operation (``+``, ``-``,
+            ``*``, ``/``, ``**``, ``%``, unary ``+``/``-`` and numeric constants only) is
+            applied element-wise on the values returned for the matching timestamps.
         :type var_list: list
         :return: Success status of data retrieval
         :rtype: bool
@@ -679,22 +701,52 @@ class RetrieveHass:
         if end_time < requested_end:
             self.logger.debug(f"End time capped at current time (requested: {requested_end})")
 
-        # Collect sensor dataframes
+        # Collect dataframes for every variable (plain sensors and expression outputs).
+        # Plain sensors and expression entities use separate caches: plain sensors are queried
+        # over the requested window (the same query as before, now de-duplicated through the
+        # cache), expression entities over a padded window so leading buckets can be
+        # forward-filled (see _build_influx_expression_df).
         sensor_dfs = []
+        sensor_cache: dict[str, pd.DataFrame | None] = {}
+        expr_entity_cache: dict[str, pd.DataFrame | None] = {}
+        failed_variables: list[str] = []
         global_min_time = None
         global_max_time = None
 
-        for sensor in filter(None, var_list):
-            df_sensor = self._fetch_sensor_data(client, sensor, start_time, end_time)
-            if df_sensor is not None:
-                sensor_dfs.append(df_sensor)
-                # Track global time range
-                sensor_min = df_sensor.index.min()
-                sensor_max = df_sensor.index.max()
-                global_min_time = min(global_min_time or sensor_min, sensor_min)
-                global_max_time = max(global_max_time or sensor_max, sensor_max)
+        for variable in filter(None, var_list):
+            if self._is_influx_expression(variable):
+                df_variable = self._build_influx_expression_df(
+                    client, variable, start_time, end_time, expr_entity_cache
+                )
+                if df_variable is None or df_variable.empty:
+                    failed_variables.append(variable)
+                    continue
+            else:
+                if variable not in sensor_cache:
+                    sensor_cache[variable] = self._fetch_sensor_data(
+                        client, variable, start_time, end_time
+                    )
+                df_variable = sensor_cache[variable]
+                if df_variable is None:
+                    # Preserve existing behavior: a missing plain sensor is skipped, not
+                    # treated as a hard failure. Only expressions abort the retrieval, since
+                    # they cannot be evaluated when a referenced entity has no data.
+                    continue
+
+            sensor_dfs.append(df_variable)
+            # Track global time range
+            sensor_min = df_variable.index.min()
+            sensor_max = df_variable.index.max()
+            global_min_time = min(global_min_time or sensor_min, sensor_min)
+            global_max_time = max(global_max_time or sensor_max, sensor_max)
 
         client.close()
+
+        if failed_variables:
+            self.logger.error(
+                f"InfluxDB expression evaluation failed for: {sorted(set(failed_variables))}"
+            )
+            return False
 
         if not sensor_dfs:
             self.logger.error("No data retrieved from InfluxDB")
@@ -726,6 +778,172 @@ class RetrieveHass:
         self.var_list = var_list
         self.logger.info(f"InfluxDB data retrieval completed: {self.df_final.shape}")
         return True
+
+    def _is_influx_expression(self, variable: str) -> bool:
+        """Check if a var_list entry uses the arithmetic expression syntax: ``{{ ... }}``."""
+        stripped = variable.strip() if isinstance(variable, str) else ""
+        return stripped.startswith("{{") and stripped.endswith("}}")
+
+    def _extract_influx_expression_entities(
+        self, expression: str
+    ) -> tuple[str, list[str], dict[str, str]]:
+        """Replace quoted entity IDs in an expression with safe variable tokens.
+
+        Example::
+
+            "{{'sensor.a' - 'sensor.b' * 1000}}"
+            -> ("_v0 - _v1 * 1000", ["sensor.a", "sensor.b"], {"_v0": "sensor.a", "_v1": "sensor.b"})
+
+        A repeated entity reuses its token (so it is only queried once).
+        """
+        expression_body = expression.strip()[2:-2].strip()
+        quoted_entity = r"'([^']+)'|\"([^\"]+)\""
+        if not re.search(quoted_entity, expression_body):
+            raise ValueError("Expression does not contain quoted entity IDs.")
+
+        entities: list[str] = []
+        token_to_entity: dict[str, str] = {}
+        entity_to_token: dict[str, str] = {}
+
+        def replace_entity(match: re.Match[str]) -> str:
+            entity = match.group(1) or match.group(2)
+            if entity not in entity_to_token:
+                token = f"_v{len(entity_to_token)}"
+                entity_to_token[entity] = token
+                token_to_entity[token] = entity
+                entities.append(entity)
+            return entity_to_token[entity]
+
+        parsed_expression = re.sub(quoted_entity, replace_entity, expression_body)
+        return parsed_expression, entities, token_to_entity
+
+    def _build_influx_expression_df(
+        self,
+        client,
+        expression: str,
+        start_time: pd.Timestamp,
+        end_time: pd.Timestamp,
+        entity_cache: dict[str, pd.DataFrame | None],
+    ) -> pd.DataFrame | None:
+        """Fetch the referenced entities and evaluate an arithmetic var_list expression.
+
+        Returns a single-column DataFrame named after the ``expression`` string, or None if
+        the expression is invalid or any referenced entity returned no data. Each entity is
+        queried over a window padded by ``INFLUX_EXPRESSION_LOOKBACK`` and sliced back to
+        ``[start_time, end_time)`` so the leading buckets are forward-filled from the most
+        recent prior value, keeping series that update at different phases aligned.
+        """
+        try:
+            parsed_expression, entities, token_to_entity = self._extract_influx_expression_entities(
+                expression
+            )
+        except ValueError:
+            self.logger.exception(f"Invalid InfluxDB expression '{expression}'")
+            return None
+
+        padded_start = start_time - INFLUX_EXPRESSION_LOOKBACK
+        start_aware = (
+            start_time.tz_localize("UTC")
+            if start_time.tzinfo is None
+            else start_time.tz_convert("UTC")
+        )
+
+        series_mapping: dict[str, pd.Series] = {}
+        for token, entity in token_to_entity.items():
+            if entity not in entity_cache:
+                df_entity = self._fetch_sensor_data(client, entity, padded_start, end_time)
+                if df_entity is not None:
+                    df_entity = df_entity.loc[df_entity.index >= start_aware]
+                entity_cache[entity] = df_entity
+            df_entity = entity_cache[entity]
+            if df_entity is None or df_entity.empty:
+                self.logger.error(
+                    f"InfluxDB expression '{expression}' references entity '{entity}' "
+                    "which returned no data"
+                )
+                return None
+            series_mapping[token] = df_entity[entity]
+
+        try:
+            expression_result = self._evaluate_influx_expression(parsed_expression, series_mapping)
+        except (ValueError, SyntaxError, ArithmeticError, RecursionError, MemoryError):
+            # A malformed or pathological entry (deep nesting, integer overflow, ...) must fail
+            # the retrieval cleanly rather than propagate out and abort the whole optimization.
+            self.logger.exception(f"Failed to evaluate InfluxDB expression '{expression}'")
+            return None
+
+        self.logger.debug(f"Evaluated InfluxDB expression '{expression}' with entities: {entities}")
+        return pd.DataFrame({expression: expression_result})
+
+    def _evaluate_influx_expression(
+        self, parsed_expression: str, series_mapping: dict[str, pd.Series]
+    ) -> pd.Series:
+        """Safely evaluate an arithmetic expression over pandas Series and numeric constants.
+
+        Only the arithmetic operators ``+ - * / ** %``, unary ``+``/``-`` and int/float
+        constants are allowed; entity tokens resolve to their fetched Series. Any other AST
+        node (attribute access, calls, subscripts, comparisons, bare names, booleans, ...)
+        raises ValueError, so a crafted var_list entry cannot reach arbitrary code.
+        """
+        tree = ast.parse(parsed_expression, mode="eval")
+
+        binary_operators = {
+            ast.Add: operator.add,
+            ast.Sub: operator.sub,
+            ast.Mult: operator.mul,
+            ast.Div: operator.truediv,
+            ast.Pow: operator.pow,
+            ast.Mod: operator.mod,
+        }
+        unary_operators = {
+            ast.UAdd: operator.pos,
+            ast.USub: operator.neg,
+        }
+
+        def eval_node(node):
+            if isinstance(node, ast.Expression):
+                return eval_node(node.body)
+            if isinstance(node, ast.BinOp):
+                op_type = type(node.op)
+                if op_type not in binary_operators:
+                    raise ValueError(f"Unsupported binary operator: {op_type.__name__}")
+                left = eval_node(node.left)
+                right = eval_node(node.right)
+                # Guard against a huge integer power exhausting CPU/memory. Cap BOTH operands:
+                # a large exponent (``_v0 ** 1e6``) and a large base built by a chained power
+                # (``(10 ** 1000) ** 100``) are both rejected before the expensive computation.
+                if op_type is ast.Pow:
+                    for operand in (left, right):
+                        if (
+                            isinstance(operand, (int, float))
+                            and not isinstance(operand, bool)
+                            and abs(operand) > INFLUX_EXPRESSION_MAX_POW_EXPONENT
+                        ):
+                            raise ValueError(
+                                "Power operand magnitude too large in InfluxDB expression"
+                            )
+                return binary_operators[op_type](left, right)
+            if isinstance(node, ast.UnaryOp):
+                op_type = type(node.op)
+                if op_type not in unary_operators:
+                    raise ValueError(f"Unsupported unary operator: {op_type.__name__}")
+                return unary_operators[op_type](eval_node(node.operand))
+            if isinstance(node, ast.Name):
+                if node.id not in series_mapping:
+                    raise ValueError(f"Unknown entity token in expression: {node.id}")
+                return series_mapping[node.id]
+            if isinstance(node, ast.Constant):
+                value = node.value
+                # bool is a subclass of int; reject it so True/False can't silently mean 1/0
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    raise ValueError(f"Unsupported constant type: {type(value).__name__}")
+                return value
+            raise ValueError(f"Unsupported expression element: {type(node).__name__}")
+
+        result = eval_node(tree)
+        if not isinstance(result, pd.Series):
+            raise ValueError("Expression must produce a pandas Series result.")
+        return result
 
     def _init_influx_client(self):
         """Initialize InfluxDB client connection."""

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -435,6 +435,326 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
             450.0,
         )
 
+    # ------------------------------------------------------------------
+    # InfluxDB arithmetic expression support in var_list
+    # ------------------------------------------------------------------
+    # A var_list entry may use the "{{ ... }}" syntax to combine several timeseries
+    # with simple arithmetic, e.g. "{{'sensor.power_a' - 'sensor.power_b' * 1000}}".
+    # Each referenced entity is queried separately and the operation is applied
+    # element-wise on the values for the matching timestamps. (Idea by @dewi-ny-je, #803.)
+
+    def _make_influxdb_rh(self):
+        """Build a RetrieveHass instance configured to use InfluxDB."""
+        params_influx = {
+            "retrieve_hass_conf": {
+                "use_influxdb": True,
+                "influxdb_host": "fake-host",
+                "influxdb_port": 8086,
+                "influxdb_username": "fake-user",
+                "influxdb_password": "fake-pass",  # pragma: allowlist secret
+                "influxdb_database": "fake-db",
+                "influxdb_measurement": "W",
+            }
+        }
+        return RetrieveHass(
+            self.retrieve_hass_conf["hass_url"],
+            self.retrieve_hass_conf["long_lived_token"],
+            self.retrieve_hass_conf["optimization_time_step"],
+            self.retrieve_hass_conf["time_zone"],
+            params_influx,
+            emhass_conf,
+            logger,
+            get_data_from_file=False,
+        )
+
+    @staticmethod
+    def _influx_query_side_effect(entity_data, tag_values=None):
+        """Build a client.query side_effect serving discovery and data queries.
+
+        :param entity_data: mapping of InfluxDB entity_id -> list of points (each a dict
+            with "time" and "mean_value"). An empty list emulates a sensor that exists
+            but returns no data.
+        :param tag_values: entity_ids advertised by "SHOW TAG VALUES" (defaults to the
+            keys of entity_data).
+        """
+        if tag_values is None:
+            tag_values = list(entity_data)
+
+        def query_side_effect(query):
+            mock_result = MagicMock()
+            if "SHOW MEASUREMENTS" in query:
+                mock_result.get_points.return_value = [{"name": "W"}]
+            elif "SHOW TAG VALUES" in query:
+                mock_result.get_points.return_value = [{"value": value} for value in tag_values]
+            else:
+                points = []
+                for entity_id, data in entity_data.items():
+                    if f"'{entity_id}'" in query:
+                        points = data
+                        break
+                mock_result.get_points.return_value = points
+            return mock_result
+
+        return query_side_effect
+
+    def test_influx_is_expression(self):
+        """_is_influx_expression detects the {{ ... }} arithmetic syntax."""
+        self.assertTrue(self.rh._is_influx_expression("{{'sensor.a' - 'sensor.b'}}"))
+        self.assertTrue(self.rh._is_influx_expression("  {{ 'sensor.a' * 2 }}  "))
+        self.assertFalse(self.rh._is_influx_expression("sensor.power_a"))
+        self.assertFalse(self.rh._is_influx_expression("{{ not closed"))
+        self.assertFalse(self.rh._is_influx_expression("not opened }}"))
+        self.assertFalse(self.rh._is_influx_expression(""))
+
+    def test_influx_extract_expression_entities(self):
+        """Quoted entity IDs are replaced by safe tokens and de-duplicated."""
+        parsed, entities, token_to_entity = self.rh._extract_influx_expression_entities(
+            "{{'sensor.power_a' - 'sensor.power_b' * 1000}}"
+        )
+        self.assertEqual(parsed, "_v0 - _v1 * 1000")
+        self.assertEqual(entities, ["sensor.power_a", "sensor.power_b"])
+        self.assertEqual(token_to_entity, {"_v0": "sensor.power_a", "_v1": "sensor.power_b"})
+        # Double quotes are accepted as well
+        parsed2, entities2, _ = self.rh._extract_influx_expression_entities(
+            '{{"sensor.a" + "sensor.b"}}'
+        )
+        self.assertEqual(parsed2, "_v0 + _v1")
+        self.assertEqual(entities2, ["sensor.a", "sensor.b"])
+        # A repeated entity reuses the same token (a single query is enough)
+        parsed3, entities3, _ = self.rh._extract_influx_expression_entities(
+            "{{'sensor.a' + 'sensor.a' / 2}}"
+        )
+        self.assertEqual(entities3, ["sensor.a"])
+        self.assertEqual(parsed3, "_v0 + _v0 / 2")
+        # An expression without any entity is rejected
+        with self.assertRaises(ValueError):
+            self.rh._extract_influx_expression_entities("{{1 + 2}}")
+
+    def test_influx_evaluate_expression(self):
+        """Arithmetic is applied element-wise with standard operator precedence."""
+        idx = pd.date_range("2023-04-01 10:00", periods=3, freq="30min", tz="UTC")
+        series_a = pd.Series([1500.0, 1800.0, 2000.0], index=idx)
+        series_b = pd.Series([0.5, 0.3, 1.0], index=idx)
+        mapping = {"_v0": series_a, "_v1": series_b}
+        # Multiplication binds tighter than subtraction: a - (b * 1000)
+        result = self.rh._evaluate_influx_expression("_v0 - _v1 * 1000", mapping)
+        pd.testing.assert_series_equal(result, series_a - series_b * 1000, check_names=False)
+        # Division combined with a unary minus
+        result_div = self.rh._evaluate_influx_expression("-_v0 / _v1", mapping)
+        pd.testing.assert_series_equal(result_div, -series_a / series_b, check_names=False)
+        # An unknown token raises (no silent zero-fill)
+        with self.assertRaises(ValueError):
+            self.rh._evaluate_influx_expression("_v0 + _v9", mapping)
+        # A malformed expression surfaces a SyntaxError
+        with self.assertRaises(SyntaxError):
+            self.rh._evaluate_influx_expression("_v0 +", mapping)
+        # An expression that does not yield a Series is rejected
+        with self.assertRaises(ValueError):
+            self.rh._evaluate_influx_expression("1 + 2", {})
+
+    def test_influx_evaluate_expression_rejects_unsafe(self):
+        """The evaluator allows only arithmetic over Series and numeric constants."""
+        idx = pd.date_range("2023-04-01 10:00", periods=2, freq="30min", tz="UTC")
+        mapping = {
+            "_v0": pd.Series([1.0, 2.0], index=idx),
+            "_v1": pd.Series([3.0, 4.0], index=idx),
+        }
+        rejected = [
+            "_v0.__class__",  # attribute access
+            "_v0[0]",  # subscript
+            "_v0 > _v1",  # comparison
+            "_v0 and _v1",  # boolean operator
+            "_v0 * True",  # bool constant (must not be treated as 1)
+            "__import__('os')",  # function call
+            "os",  # bare name not in the mapping
+            "_v0 + 'x'",  # string constant
+            "_v0 ** 100000",  # exponent magnitude over the DoS cap
+            "(10 ** 1000) ** 100",  # chained power building a huge base is also rejected
+        ]
+        for expr in rejected:
+            with self.assertRaises(ValueError, msg=f"should reject: {expr}"):
+                self.rh._evaluate_influx_expression(expr, mapping)
+        # A reasonable exponent is still allowed
+        result = self.rh._evaluate_influx_expression("_v0 ** 2", mapping)
+        pd.testing.assert_series_equal(result, mapping["_v0"] ** 2, check_names=False)
+
+    async def test_influx_expression_pads_and_slices_entity_fetch(self):
+        """Expression entities are queried over a padded window then sliced to [start, end)."""
+        from emhass.retrieve_hass import INFLUX_EXPRESSION_LOOKBACK
+
+        rh = self._make_influxdb_rh()
+        start = pd.Timestamp("2026-06-01 00:00:00")
+        end = pd.Timestamp("2026-06-02 00:00:00")
+        full_idx = pd.date_range("2026-05-31 12:00", "2026-06-01 12:00", freq="30min", tz="UTC")
+        captured = {}
+
+        def fake_fetch(client, entity, fetch_start, fetch_end):
+            captured["start"] = fetch_start
+            return pd.DataFrame({entity: range(len(full_idx))}, index=full_idx)
+
+        with patch.object(rh, "_fetch_sensor_data", side_effect=fake_fetch):
+            df = rh._build_influx_expression_df(MagicMock(), "{{'sensor.a' * 2}}", start, end, {})
+
+        # The entity was fetched over a window padded earlier than the requested start
+        self.assertEqual(captured["start"], start - INFLUX_EXPRESSION_LOOKBACK)
+        # The result is sliced back to [start, end): no pre-window rows leak through
+        start_utc = pd.Timestamp("2026-06-01 00:00:00", tz="UTC")
+        self.assertEqual(int((df.index < start_utc).sum()), 0)
+        self.assertGreaterEqual(df.index.min(), start_utc)
+
+    async def test_influx_expression_pathological_fails_soft(self):
+        """A pathological expression (deep nesting, integer overflow) fails soft, not crash.
+
+        These raise RecursionError / OverflowError rather than ValueError, so they must be
+        caught and turned into a clean retrieval failure instead of aborting the run.
+        """
+        rh = self._make_influxdb_rh()
+        idx = pd.date_range("2026-06-01 00:00", periods=4, freq="30min", tz="UTC")
+        series_df = pd.DataFrame({"sensor.a": [1.0, 2.0, 3.0, 4.0]}, index=idx)
+        start = pd.Timestamp("2026-06-01 00:00:00")
+        end = pd.Timestamp("2026-06-02 00:00:00")
+
+        with patch.object(rh, "_fetch_sensor_data", return_value=series_df):
+            # Deep nesting overflows the parser/evaluator recursion limit
+            deep = "{{" + "(" * 3000 + "'sensor.a'" + ")" * 3000 + "}}"
+            self.assertIsNone(rh._build_influx_expression_df(MagicMock(), deep, start, end, {}))
+            # A large constant power overflows when converted to float during the multiply
+            overflow = "{{'sensor.a' * (10 ** 1000)}}"
+            self.assertIsNone(rh._build_influx_expression_df(MagicMock(), overflow, start, end, {}))
+
+    @patch("influxdb.InfluxDBClient", autospec=True)
+    async def test_get_data_influxdb_expression(self, mock_influx_client_class):
+        """get_data_influxdb evaluates an arithmetic expression across sensors."""
+        rh_influx = self._make_influxdb_rh()
+        mock_client_instance = mock_influx_client_class.return_value
+        mock_client_instance.query.side_effect = self._influx_query_side_effect(
+            {
+                "power_a": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 1500.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 1800.0},
+                ],
+                "power_b": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 0.5},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 0.3},
+                ],
+            }
+        )
+        days_list = pd.date_range(start="2023-04-01", periods=1, freq="D", tz="UTC")
+        expression = "{{'sensor.power_a' - 'sensor.power_b' * 1000}}"
+        success = await rh_influx.get_data(days_list, [expression])
+        self.assertTrue(success)
+
+        df = rh_influx.df_final
+        self.assertEqual(list(df.columns), [expression])
+        self.assertAlmostEqual(df.loc["2023-04-01 10:00:00+00:00"][expression], 1500.0 - 0.5 * 1000)
+        self.assertAlmostEqual(df.loc["2023-04-01 10:30:00+00:00"][expression], 1800.0 - 0.3 * 1000)
+        mock_client_instance.close.assert_called_once()
+
+    @patch("influxdb.InfluxDBClient", autospec=True)
+    async def test_get_data_influxdb_expression_entity_cached(self, mock_influx_client_class):
+        """An entity used in multiple expressions is queried only once."""
+        rh_influx = self._make_influxdb_rh()
+        mock_client_instance = mock_influx_client_class.return_value
+        mock_client_instance.query.side_effect = self._influx_query_side_effect(
+            {
+                "power_a": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 1000.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 1200.0},
+                ],
+                "power_b": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 100.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 200.0},
+                ],
+            }
+        )
+        days_list = pd.date_range(start="2023-04-01", periods=1, freq="D", tz="UTC")
+        e1 = "{{'sensor.power_a' + 'sensor.power_b'}}"
+        e2 = "{{'sensor.power_a' - 'sensor.power_b'}}"
+        success = await rh_influx.get_data(days_list, [e1, e2])
+        self.assertTrue(success)
+
+        df = rh_influx.df_final
+        self.assertAlmostEqual(df.loc["2023-04-01 10:00:00+00:00"][e1], 1100.0)
+        self.assertAlmostEqual(df.loc["2023-04-01 10:00:00+00:00"][e2], 900.0)
+        power_a_data_queries = [
+            c.args[0]
+            for c in mock_client_instance.query.call_args_list
+            if 'AND "entity_id"=' in c.args[0] and "'power_a'" in c.args[0]
+        ]
+        self.assertEqual(len(power_a_data_queries), 1)
+
+    @patch("influxdb.InfluxDBClient", autospec=True)
+    async def test_get_data_influxdb_expression_mixed(self, mock_influx_client_class):
+        """var_list may mix a plain sensor and an expression."""
+        rh_influx = self._make_influxdb_rh()
+        mock_client_instance = mock_influx_client_class.return_value
+        mock_client_instance.query.side_effect = self._influx_query_side_effect(
+            {
+                "power_a": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 1500.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 1800.0},
+                ],
+                "power_b": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 500.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 450.0},
+                ],
+            }
+        )
+        days_list = pd.date_range(start="2023-04-01", periods=1, freq="D", tz="UTC")
+        expression = "{{'sensor.power_a' + 'sensor.power_b'}}"
+        var_list = ["sensor.power_a", expression]
+        success = await rh_influx.get_data(days_list, var_list)
+        self.assertTrue(success)
+
+        df = rh_influx.df_final
+        self.assertEqual(list(df.columns), var_list)
+        self.assertAlmostEqual(df.loc["2023-04-01 10:00:00+00:00"]["sensor.power_a"], 1500.0)
+        self.assertAlmostEqual(df.loc["2023-04-01 10:00:00+00:00"][expression], 2000.0)
+        self.assertAlmostEqual(df.loc["2023-04-01 10:30:00+00:00"][expression], 2250.0)
+
+    @patch("influxdb.InfluxDBClient", autospec=True)
+    async def test_get_data_influxdb_expression_missing_entity(self, mock_influx_client_class):
+        """An expression referencing a sensor with no data fails cleanly."""
+        rh_influx = self._make_influxdb_rh()
+        mock_client_instance = mock_influx_client_class.return_value
+        mock_client_instance.query.side_effect = self._influx_query_side_effect(
+            {
+                "power_a": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 1500.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 1800.0},
+                ],
+                "power_missing": [],
+            },
+            tag_values=["power_a"],
+        )
+        days_list = pd.date_range(start="2023-04-01", periods=1, freq="D", tz="UTC")
+        expression = "{{'sensor.power_a' + 'sensor.power_missing'}}"
+        success = await rh_influx.get_data(days_list, [expression])
+        self.assertFalse(success)
+
+    @patch("influxdb.InfluxDBClient", autospec=True)
+    async def test_get_data_influxdb_plain_missing_sensor_skipped(self, mock_influx_client_class):
+        """A missing PLAIN sensor is skipped, not a hard failure (unchanged behavior).
+
+        Only expressions abort the retrieval; a plain var_list keeps its prior behavior
+        of dropping a sensor that returned no data and proceeding with the rest.
+        """
+        rh_influx = self._make_influxdb_rh()
+        mock_client_instance = mock_influx_client_class.return_value
+        mock_client_instance.query.side_effect = self._influx_query_side_effect(
+            {
+                "power_a": [
+                    {"time": "2023-04-01T10:00:00Z", "mean_value": 1500.0},
+                    {"time": "2023-04-01T10:30:00Z", "mean_value": 1800.0},
+                ],
+            },
+            tag_values=["power_a"],
+        )
+        days_list = pd.date_range(start="2023-04-01", periods=1, freq="D", tz="UTC")
+        success = await rh_influx.get_data(days_list, ["sensor.power_a", "sensor.power_missing"])
+        self.assertTrue(success)
+        self.assertEqual(list(rh_influx.df_final.columns), ["sensor.power_a"])
+
     # Test publish data
     async def test_publish_data(self):
         response, data = await self.rh.post_data(

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -603,10 +603,11 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
         self.assertGreaterEqual(df.index.min(), start_utc)
 
     async def test_influx_expression_pathological_fails_soft(self):
-        """A pathological expression (deep nesting, integer overflow) fails soft, not crash.
+        """A pathological expression (deep nesting, overflow, /0) fails soft, not crash.
 
-        These raise RecursionError / OverflowError rather than ValueError, so they must be
-        caught and turned into a clean retrieval failure instead of aborting the run.
+        These raise RecursionError / OverflowError / ZeroDivisionError rather than ValueError,
+        so they must be caught and turned into a clean retrieval failure instead of aborting the
+        run.
         """
         rh = self._make_influxdb_rh()
         idx = pd.date_range("2026-06-01 00:00", periods=4, freq="30min", tz="UTC")
@@ -621,6 +622,25 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
             # A large constant power overflows when converted to float during the multiply
             overflow = "{{'sensor.a' * (10 ** 1000)}}"
             self.assertIsNone(rh._build_influx_expression_df(MagicMock(), overflow, start, end, {}))
+            # A constant division-by-zero raises ZeroDivisionError (an ArithmeticError). Note a
+            # Series-by-zero divide does NOT raise (pandas yields inf), so the /0 must be between
+            # scalar constants to exercise this branch.
+            div_zero = "{{'sensor.a' + 1 / 0}}"
+            self.assertIsNone(rh._build_influx_expression_df(MagicMock(), div_zero, start, end, {}))
+
+    async def test_influx_expression_dtype_mismatch_fails_soft(self):
+        """A non-numeric (object-dtype) series raises TypeError under arithmetic and fails soft."""
+        rh = self._make_influxdb_rh()
+        idx = pd.date_range("2026-06-01 00:00", periods=3, freq="30min", tz="UTC")
+        # A sensor that returned text values: subtracting a number raises TypeError in pandas
+        string_df = pd.DataFrame({"sensor.a": ["on", "off", "on"]}, index=idx)
+        start = pd.Timestamp("2026-06-01 00:00:00")
+        end = pd.Timestamp("2026-06-02 00:00:00")
+
+        with patch.object(rh, "_fetch_sensor_data", return_value=string_df):
+            self.assertIsNone(
+                rh._build_influx_expression_df(MagicMock(), "{{'sensor.a' - 1000}}", start, end, {})
+            )
 
     @patch("influxdb.InfluxDBClient", autospec=True)
     async def test_get_data_influxdb_expression(self, mock_influx_client_class):


### PR DESCRIPTION
## Support arithmetic expressions in InfluxDB `var_list` entries

This picks up #803 (idea by @dewi-ny-je). It lets an entry in the InfluxDB sensor list be a small arithmetic expression over several time series instead of a single sensor, for example:

```text
{{'sensor.power_a' - 'sensor.power_b' * 1000}}
```

Each quoted entity is queried separately and the operation is applied element-wise on the values for the matching timestamps. Supported operators are `+ - * / ** %`, unary `+`/`-` and numeric constants. This is handy when the quantity EMHASS needs is not stored as one sensor: a net power that is the difference of two meters, a unit conversion, and so on.

It carries forward @dewi-ny-je's proposal in #803 (which was opened as a not-yet-tested draft from his fork's `master`, so it could not be pushed to). He kindly blessed the handoff. This branch keeps his expression parser and safe evaluator, adds the time alignment he and David discussed, hardens the evaluator a little, and adds tests plus docs.

### Alignment (the main review point on #803)

I reproduced the behaviour against a real InfluxDB 1.8 container before deciding the fix. Two findings shaped it:

- `GROUP BY time() FILL(previous)` already returns every entity on an identical bucket grid over the query window, so the element-wise arithmetic is aligned by construction. A reindex to a shared grid is a no-op.
- The real gap is leading nulls when a sensor's most recent reading sits just outside the queried window (`WHERE time >= start` hides it, so `FILL(previous)` has nothing to carry). For two series that update at different phases this shows up as spurious leading-edge NaN in the result.

So expression entities are queried over a window padded one day earlier than the requested start, then sliced back to `[start, end)`. That lets `FILL(previous)` seed the first in-window buckets from the most recent prior reading. This follows @dewi-ny-je's leading-bucket-padding suggestion. A prior reading older than the lookback still leaves a short leading gap, which the downstream regression absorbs (documented).

### Behaviour and scope

- No new config parameter. `var_list` already exists; this only changes how an entry is interpreted.
- True no-op for existing setups: a `var_list` with no `{{ }}` entry behaves exactly as before. There is a test pinning that a plain missing sensor is still skipped (not a hard failure).
- One deliberate behaviour difference, confined to the new feature: if an entity referenced by an expression returns no data, the InfluxDB retrieval fails (an expression cannot be partially computed). Plain sensors are unchanged. The padding only applies to expression entities, so plain-sensor columns keep their existing values.

### Safety

Expressions are parsed with `ast` and walked against a strict node whitelist: only the arithmetic operators above, unary plus/minus and int/float constants are allowed; entity tokens resolve to their fetched Series. Anything else (function calls, attribute access, subscripts, comparisons, names that are not quoted entities, bool/str constants) is rejected, so a `var_list` entry cannot reach arbitrary code. Both operands of a power are magnitude-capped so a crafted `10 ** 1000000` or chained `(10 ** 1000) ** 100` cannot build a huge integer, and a pathological entry that still overflows or nests too deep (`OverflowError`, `RecursionError`, ...) fails the retrieval cleanly instead of propagating out and aborting the optimization.

### Validation

- Verified end to end against a real InfluxDB 1.8 container: the padded fetch fills the leading buckets, a mixed plain+expression `var_list` resolves, and a missing entity fails cleanly.
- `tests/test_retrieve_hass.py` passes, as does the full suite (595 passed, 22 xfailed).

### Tests added (`tests/test_retrieve_hass.py`)

- `test_influx_is_expression`, `test_influx_extract_expression_entities`, `test_influx_evaluate_expression` - the helper contracts (precedence, de-duplication, unknown token, malformed input, non-Series result).
- `test_influx_evaluate_expression_rejects_unsafe` - attribute access, subscript, comparison, boolean op, bool/str constants, function call, bare name, and the power-operand caps are all rejected; a reasonable exponent still works.
- `test_influx_expression_pads_and_slices_entity_fetch` - expression entities are fetched over the padded window and sliced back to `[start, end)`.
- `test_influx_expression_pathological_fails_soft` - a deeply nested or overflowing expression returns a clean failure instead of crashing.
- `test_get_data_influxdb_expression`, `_entity_cached`, `_mixed`, `_missing_entity` - the end-to-end paths with a mocked client, including single-query caching and the missing-entity hard fail.
- `test_get_data_influxdb_plain_missing_sensor_skipped` - a plain missing sensor is still skipped, preserving prior behaviour.

Docs: a new "Arithmetic expressions in the sensor list" subsection in `docs/passing_data.md`, including the alignment/lookback note and the InfluxDB 1.x off-grid-resolution caveat.

@dewi-ny-je if you get a chance to point this at your real InfluxDB setup that would be a great sanity check. Happy to adjust the lookback default, drop the `**`/`%` operators if you would rather keep the surface smaller, or split anything out.

## Summary by Sourcery

Add support for arithmetic expressions in InfluxDB var_list entries, safely evaluating multi-series expressions and integrating their results into data retrieval.

New Features:
- Allow InfluxDB var_list entries to be arithmetic expressions over multiple sensors using a {{ ... }} syntax, evaluating supported operations element-wise across aligned time series.

Enhancements:
- Introduce safe parsing and evaluation of InfluxDB arithmetic expressions with strict operator and constant whitelisting and protections against resource exhaustion.
- Align expression operands by querying referenced entities over a padded lookback window and slicing back to the requested range, while caching shared entities across expressions.

Documentation:
- Document how to use arithmetic expressions in InfluxDB-backed sensor lists, including alignment behavior, limitations, and failure modes.

Tests:
- Add comprehensive unit tests for expression detection, entity extraction, safe evaluation (including rejection of unsafe constructs), lookback padding behavior, error handling of pathological expressions, expression caching, mixed plain/expression var_lists, and differing failure behavior for expressions vs plain sensors.