### PR TITLE
fix: keep shared-tank sources active when operating_hours == 0

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -3907,6 +3907,10 @@ class Optimization:
         # so it can bump param_def_current_state to suppress the phantom t=0 startup.
         self._update_def_current_power_params(num_deferrable_loads)
 
+        # Shared-tank members are temperature-driven; used below to exempt them
+        # from the operating-timestep deactivation in the param_load_active loop.
+        shared_tank_membership = self._load_shared_tank_membership()
+
         # Update Energy Constraint Parameters for Deferrable Loads
         # These control the Big-M relaxation of energy/timestep constraints
         for k in range(min(num_deferrable_loads, len(self.param_target_energy))):
@@ -4186,15 +4190,20 @@ class Optimization:
 
         # Update load active parameters: deactivate non-thermal loads with 0 operating timesteps,
         # OR with a configured window that's entirely outside the optimization horizon.
-        # Thermal loads (thermal_config, thermal_battery) are always active since they're
-        # driven by temperature constraints, not operating timesteps. Sequence loads
+        # Thermal loads (thermal_config, thermal_battery, and shared-tank sources) are
+        # always active since they're driven by temperature constraints, not operating
+        # timesteps. Shared-tank members already skip the energy/operating constraints
+        # above (is_thermal_battery), so they must not be deactivated here either —
+        # otherwise a member with operating_hours == 0 (the natural setting for a
+        # temperature-driven source) is pinned to 0 W, the tank cannot hold its
+        # min_temperatures band, and the problem goes infeasible. Sequence loads
         # (list-valued nominal power) are likewise always active: their runtime is the
         # length of the sequence and operating_hours is meaningless for them, so a value
         # of 0 must not deactivate the load (issue #887). The energy constraint already
         # exempts sequence loads, so this keeps param_load_active consistent with it.
         nominal_powers = self.optim_conf["nominal_power_of_deferrable_loads"]
         for k in range(min(num_deferrable_loads, len(self.param_load_active))):
-            is_thermal = k in self.param_thermal
+            is_thermal = k in self.param_thermal or k in shared_tank_membership
             is_sequence = k < len(nominal_powers) and isinstance(nominal_powers[k], list)
             has_operating_requirement = (
                 def_total_timestep and k < len(def_total_timestep) and def_total_timestep[k] > 0
@@ -4204,6 +4213,20 @@ class Optimization:
                 # Thermal loads are still driven by temperature constraints
                 # even if their configured window is outside the horizon.
                 self.param_load_active[k].value = 1.0
+                # Shared-tank members must also keep an open window mask: a
+                # configured window outside the horizon zeroes the mask, which
+                # would pin every member to 0 W and make the tank's
+                # min_temperatures unreachable (infeasible, then the relaxed
+                # fallback fails too and nothing is published).
+                if k in shared_tank_membership and window_outside_horizon:
+                    if k < len(self.param_window_masks):
+                        self.param_window_masks[k].value = np.ones(n)
+                    self.logger.warning(
+                        "Deferrable load %d is a shared-tank source with a configured "
+                        "window outside the horizon; ignoring the window (temperature "
+                        "constraints drive this load).",
+                        k,
+                    )
             elif (has_operating_requirement or is_sequence) and not window_outside_horizon:
                 self.param_load_active[k].value = 1.0
             else:

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -3403,6 +3403,86 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         total = res["P_deferrable0"].sum() + res["P_deferrable1"].sum()
         self.assertGreater(total, 0, "Expected some dispatch to satisfy draw_off demand")
 
+    def _run_shared_tank_no_cap(
+        self, operating_hours, start_timesteps, end_timesteps, single_constant=(False, False)
+    ):
+        """One shared DHW tank fed by two temperature-driven sources (no caps).
+
+        A mid-horizon min_temperature of 55 C forces a heating dispatch so that
+        deactivating the members (pinning them to 0 W) would make the problem
+        infeasible. Used to exercise the param_load_active / window-mask handling
+        for shared-tank members independently of any source feature."""
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        self.df_input_data_dayahead["outdoor_temperature_forecast"] = [10.0] * 48
+        min_t = [45.0] * 48
+        for i in range(28, 34):
+            min_t[i] = 55.0
+        self.optim_conf["number_of_deferrable_loads"] = 2
+        self.optim_conf["nominal_power_of_deferrable_loads"] = [3500, 3000]
+        self.optim_conf["minimum_power_of_deferrable_loads"] = [0, 0]
+        self.optim_conf["operating_hours_of_each_deferrable_load"] = list(operating_hours)
+        self.optim_conf["treat_deferrable_load_as_semi_cont"] = [False, False]
+        self.optim_conf["set_deferrable_load_single_constant"] = list(single_constant)
+        self.optim_conf["set_deferrable_startup_penalty"] = [0.0, 0.0]
+        self.optim_conf["set_deferrable_max_startups"] = [0, 0]
+        self.optim_conf["start_timesteps_of_each_deferrable_load"] = list(start_timesteps)
+        self.optim_conf["end_timesteps_of_each_deferrable_load"] = list(end_timesteps)
+        self.optim_conf["def_load_config"] = [
+            {"thermal_source": {"supply_temperature": 55.0, "carnot_efficiency": 0.40}},
+            {"thermal_source": {"efficiency": 1.0}},
+        ]
+        self.optim_conf["shared_thermal_tanks"] = [
+            {
+                "id": "dhw",
+                "load_ids": [0, 1],
+                "volume": 0.20,
+                "density": 1000,
+                "heat_capacity": 4.186,
+                "start_temperature": 48.0,
+                "thermal_loss": 0.10,
+                "min_temperatures": min_t,
+                "max_temperatures": [65.0] * 48,
+            }
+        ]
+        opt = self.create_optimization()
+        ulc = self.df_input_data_dayahead[opt.var_load_cost].values
+        upp = self.df_input_data_dayahead[opt.var_prod_price].values
+        res = opt.perform_optimization(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast.values.ravel(),
+            self.p_load_forecast.values.ravel(),
+            ulc,
+            upp,
+        )
+        return opt, res
+
+    def test_shared_tank_member_zero_operating_hours_stays_active(self):
+        """A shared-tank source with operating_hours == 0 (the natural setting for a
+        temperature-driven load) must not be deactivated by the param_load_active
+        loop. Before the fix both members were pinned to 0 W, the tank could not
+        hold its min_temperatures band, and the problem went infeasible."""
+        opt, res = self._run_shared_tank_no_cap(
+            operating_hours=(0, 0), start_timesteps=(0, 0), end_timesteps=(0, 0)
+        )
+        self.assertEqual(opt.optim_status, "Optimal")
+        total = res["P_deferrable0"].sum() + res["P_deferrable1"].sum()
+        self.assertGreater(total, 0, "Shared-tank members were deactivated; tank cannot heat")
+
+    def test_shared_tank_window_outside_horizon_stays_optimal(self):
+        """A shared-tank source whose configured window is entirely outside the
+        horizon must have its window mask reset to all-ones (temperature
+        constraints drive the load). Before the fix the mask was zeroed, pinning
+        every member to 0 W and making the problem infeasible."""
+        opt, res = self._run_shared_tank_no_cap(
+            operating_hours=(0, 0),
+            start_timesteps=(600, 600),
+            end_timesteps=(800, 800),
+            single_constant=(True, True),
+        )
+        self.assertEqual(opt.optim_status, "Optimal")
+        total = res["P_deferrable0"].sum() + res["P_deferrable1"].sum()
+        self.assertGreater(total, 0, "Window outside horizon gagged the shared-tank members")
+
     def test_is_electric_load_excludes_load_from_grid_balance(self):
         """A load with is_electric_load[k]=False must not appear in p_def_sum
         (and hence not in grid_pos / grid_neg balance constraints).


### PR DESCRIPTION
<!-- PR-body voor de fix-branch fix/shared-tank-members-deactivated.
     DRAFT — door Stefan te plaatsen na het pushen. Vervang #974 door het
     nummer dat issue B krijgt. PR-titel = de commit-subject. -->

<!-- PR TITLE: fix: keep shared-tank sources active when operating_hours == 0 -->

Fixes #974.

Shared-tank sources are temperature-driven, but the `param_load_active` activation loop in `perform_optimization` only treated `k in self.param_thermal` as thermal. A shared-tank source is not in `param_thermal`, so with `operating_hours == 0` (the natural setting for a temperature-driven load) it was deactivated and pinned to 0 W for the whole horizon — the tank then cannot hold its `min_temperatures` band, the problem goes infeasible, the relaxed fallback is infeasible too, and nothing is published.

Master already exempts shared-tank members from the running-lb pinning and the energy constraint, so this just adds the same exemption to the third place that missed it. Same class as #887.

**Changes**
- Hoist `shared_tank_membership` into `perform_optimization` scope and add it to the `is_thermal` exemption in the activation loop.
- Reset the window mask to all-ones (with a warning) for a shared-tank member whose configured window falls entirely outside the horizon — the other 0-W path with the same end state.
- Two regression tests reproducing both infeasibility paths; both fail on master without the change.

The repro and before/after output are in #974. Full test suite passes locally (the one unrelated `test_open_meteo_legacy_pvlib` failure is pre-existing on master) and `ruff check .` is clean.

Happy to adjust the approach if you'd prefer the exemption handled differently.

---
*Co-authored with Claude Code (Anthropic).*

## Summary by Sourcery

Ensure temperature-driven shared-tank deferrable loads remain active and feasible under zero operating hours and out-of-horizon windows.

Bug Fixes:
- Prevent shared-tank deferrable sources from being deactivated when operating_hours is set to 0 by treating them as thermal loads in the activation logic.
- Avoid infeasibility when a shared-tank member’s configured operating window lies entirely outside the optimization horizon by resetting its window mask instead of zeroing it.

Tests:
- Add regression tests covering shared-tank sources with zero operating hours and with operating windows outside the optimization horizon to verify the optimization stays feasible and dispatches heat.