### PR TITLE
feat: optional def_current_power to pin a deferrable load's current power at t=0 (#605)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -117,6 +117,27 @@ Example:
   **Composes with `set_deferrable_max_startups`:** the two constraints are independent (count vs window) and coexist cleanly. A pathological combination of low max-startups, long min-on, and a short operating window can over-constrain a load; if you use both, ensure `max_startups x min_on_time <= available_timesteps`.
 
   **Initial-condition remainder:** to carry the remaining on-time across MPC ticks when the load is already running, also pass `def_current_on_timesteps` at runtime (see Passing data at runtime).
+- `def_current_power`: Per-load actual power (watts) each deferrable load is drawing right now at the start of the optimization horizon. **Default `[0, 0]` (or absent key) is an exact no-op** -- today's behaviour is preserved. One non-negative float per deferrable load, in the same order as `nominal_power_of_deferrable_loads`. Supply the real sensor reading in watts.
+
+  Unit: W (watts). Runtime-overridable on every MPC tick without rebuilding the solver cache.
+
+  When `def_current_power[k] > 0`, the optimizer applies three coordinated effects:
+
+  1. **Pin:** fixes `P_deferrable[k][t=0]` to the supplied power, correcting the t=0 power balance when the load is excluded from the main load sensor.
+  2. **Force ON:** forces the load's binary `bin2[0] = 1` at t=0, preventing the optimizer from immediately scheduling a stop.
+  3. **Suppress phantom startup:** sets the internal initial-state to ON so no startup penalty fires at t=0 (equivalent to also passing `def_current_state[k]=true`).
+
+  This is a separate runtime input rather than an extension of `def_current_state`, so the binary on/off decision stays strict 0/1 and a fractional watt value can never weaken it.
+
+  **Semi-continuous loads (`treat_deferrable_load_as_semi_cont: true`):** because semi-continuous power is strictly `nominal * bin` (cannot be an arbitrary fraction of nominal), the power pin is omitted for these loads. Supplying any non-zero value still triggers the force-ON and phantom-startup suppression, so the load is held ON at its full nominal power at t=0. The supplied wattage acts as an on/off signal only.
+
+  **Loads with minimum power (`minimum_power_of_deferrable_loads > 0`):** the supplied value should be at or above the configured minimum to avoid an infeasible t=0 power balance. Supplying a value below the minimum and above zero will produce an infeasible solve (the pin forces `p = supplied` while the min-power constraint forces `p >= min_power`).
+
+  **Supplied value exceeds nominal:** the existing window-mask upper bound (`p <= nominal * mask`) prevents values above nominal from being pinned; the solve will be infeasible. Supply values within `[min_power, nominal]`.
+
+  **Single-constant, sequence and thermal loads** ignore `def_current_power` (it is a no-op for those load types). A single-constant load runs as one fixed block, so its currently-running state is handled by `def_current_state` (which pins the remaining required timesteps); pinning a below-nominal power there would fight the required-energy target. Use `def_current_state` for a currently-running single-constant load.
+
+  **Typical MPC use:** read the load's power sensor at the start of each optimization tick and pass the reading in watts via the runtime API so the optimizer knows the load is running and at what level.
 - `deferrable_load_groups`: Define groups of deferrable loads that share a physical actuator (e.g. a heat pump serving both hot water and underfloor heating). Each group can enforce a shared power budget, mutual exclusion, or both. This is a list of group objects, each with the following fields:
 	- `names`: List of deferrable load names in the group (e.g. `["deferrable0", "deferrable1"]`).
 	- `max_power` *(optional when `mutual_exclusion` is `true`)*: Maximum combined power in Watts for all loads in the group at any timestep. Required when `mutual_exclusion` is `false`.

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -270,6 +270,8 @@ class OptimizationCache:
             # Per-call elapsed on-time for min-on remainder (issue #952); value
             # is read via cp.Parameter so no rebuild on cache hit.
             "def_current_on_timesteps",
+            # Per-call current power in watts (issue #605); pin value is a cp.Parameter.
+            "def_current_power",
             "minimum_power_of_deferrable_loads",
             "cost_forecast_per_deferrable_load",
             # shared_thermal_tanks has its own structural hash field above

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -371,6 +371,25 @@ class Optimization:
             cot.value = 0.0
             self.param_current_on_timesteps.append(cot)
 
+        # Current-power parameters (issue #605).
+        # param_def_current_power[k]: the actual power (W) the load is drawing at t=0.
+        # param_def_current_power_active[k]: 1 iff the power-pin constraint should be
+        #   tight (i.e. the load is affected AND pin-eligible, see below). Both are set
+        #   on every solve by _update_def_current_power_params. Default 0.0 = no-op.
+        # _def_current_power_affected[k]: True iff def_current_power changes anything for
+        #   load k (drives the t=0 force-on / phantom-startup suppression). Excludes
+        #   single_const / sequence / thermal loads entirely (see the update method).
+        self.param_def_current_power = []
+        self.param_def_current_power_active = []
+        self._def_current_power_affected = [False] * num_def_loads
+        for k in range(num_def_loads):
+            pw = cp.Parameter(nonneg=True, name=f"def_current_power_{k}")
+            pw.value = 0.0
+            self.param_def_current_power.append(pw)
+            active = cp.Parameter(nonneg=True, name=f"def_current_power_active_{k}")
+            active.value = 0.0
+            self.param_def_current_power_active.append(active)
+
         # Load active parameters: allows deactivating non-thermal loads with 0 operating
         # timesteps without rebuilding the problem. When param_load_active[k] = 0, all
         # binary variables for load k are forced to 0 by constraints, letting the solver
@@ -660,6 +679,108 @@ class Optimization:
             elapsed = self._coerce_nonneg_timesteps(val, k, "def_current_on_timesteps")
             if k < len(self.param_current_on_timesteps):
                 self.param_current_on_timesteps[k].value = float(elapsed)
+
+    @staticmethod
+    def _coerce_nonneg_power(value, k: int, param_name: str) -> float:
+        """Validate a per-load def_current_power entry into a non-negative float (issue #605).
+
+        A malformed value fails loudly with the param name and index for context.
+        """
+        try:
+            watts = float(value)
+        except (TypeError, ValueError) as err:
+            raise ValueError(
+                f"Invalid {param_name} value at index {k}: {value!r}. "
+                "Expected a non-negative number (watts)."
+            ) from err
+        if watts < 0:
+            raise ValueError(f"{param_name}[{k}]={watts} is negative; must be >= 0.")
+        return watts
+
+    def _update_def_current_power_params(self, num_def_loads: int) -> None:
+        """Update def_current_power CVXPY Parameters from optim_conf (issue #605).
+
+        Reads ``optim_conf["def_current_power"]`` (a per-load list of non-negative
+        floats in watts representing the power each load is currently drawing) and
+        writes the values into ``self.param_def_current_power`` and
+        ``self.param_def_current_power_active``.
+
+        Side-effect: when power[k] > 0, also bumps ``param_def_current_state[k]``
+        to max(existing, 1.0) so the t=0 phantom-startup penalty is suppressed
+        (mirrors the logic a caller would supply via def_current_state). The
+        *input* boolean def_current_state is left untouched; only the internal
+        CVXPY Parameter is shared.
+
+        When the key is absent from optim_conf all parameters reset to 0.0, which
+        is an exact no-op (no pin, no force-on, no phantom-startup suppression).
+
+        Must be called AFTER ``_update_def_current_state_params`` so the existing
+        param_def_current_state value is available for the max(...) bump.
+        """
+        self._def_current_power_affected = [False] * num_def_loads
+        if "def_current_power" not in self.optim_conf:
+            for k in range(min(num_def_loads, len(self.param_def_current_power))):
+                self.param_def_current_power[k].value = 0.0
+                self.param_def_current_power_active[k].value = 0.0
+            return
+
+        dcp_conf = self.optim_conf["def_current_power"]
+        n_conf = len(dcp_conf)
+        if n_conf != num_def_loads:
+            self.logger.warning(
+                "def_current_power length mismatch: "
+                "num_deferrable_loads=%d, len(def_current_power)=%d; "
+                "extra entries will be ignored or missing ones assumed 0",
+                num_def_loads,
+                n_conf,
+            )
+
+        # Eligibility is structural (determined at build time from load type).
+        # Re-derive it here using the same flags used in the constraint block so the
+        # parameters match what was baked into the problem.
+        nominal_powers = self.optim_conf.get("nominal_power_of_deferrable_loads", [])
+        semi_cont_flags = self.optim_conf.get("treat_deferrable_load_as_semi_cont", [])
+        single_const_flags = self.optim_conf.get("set_deferrable_load_single_constant", [])
+
+        for k in range(num_def_loads):
+            val = dcp_conf[k] if k < n_conf else 0
+            watts = self._coerce_nonneg_power(val, k, "def_current_power")
+
+            if k < len(self.param_def_current_power):
+                self.param_def_current_power[k].value = watts
+
+            is_semi_cont = semi_cont_flags[k] if k < len(semi_cont_flags) else False
+            is_single_const = single_const_flags[k] if k < len(single_const_flags) else False
+            is_sequence_load = k < len(nominal_powers) and isinstance(nominal_powers[k], list)
+            is_thermal = k in self.param_thermal
+
+            # A load is AFFECTED by def_current_power only when injecting its t=0
+            # power/on-state is meaningful and safe. Excluded entirely:
+            #   - single_const: runs as one fixed block; "currently running" is already
+            #     handled by def_current_state (which pins the remaining required
+            #     timesteps). A below-nominal pin here would fight the required-energy
+            #     target and silently relax the MIP, so use def_current_state for these.
+            #   - sequence (list-valued nominal power): shaped by convolution, no free
+            #     t=0 power variable to pin or force.
+            #   - thermal: governed by temperature dynamics, not an on/off binary.
+            affected = watts > 0 and not is_single_const and not is_sequence_load and not is_thermal
+            if k < len(self._def_current_power_affected):
+                self._def_current_power_affected[k] = affected
+
+            # The power PIN additionally needs a free t=0 power variable, so semi_cont
+            # is excluded from the pin (its power == nominal*bin); for an affected
+            # semi_cont load the t=0 force-on alone injects nominal, which is correct
+            # for an on/off device.
+            pin_active = affected and not is_semi_cont
+            if k < len(self.param_def_current_power_active):
+                self.param_def_current_power_active[k].value = 1.0 if pin_active else 0.0
+
+            # Suppress phantom startup: if this load is reported as running now,
+            # bump param_def_current_state so t=0 is not counted as a start event.
+            if affected and k < len(self.param_def_current_state):
+                self.param_def_current_state[k].value = max(
+                    self.param_def_current_state[k].value, 1.0
+                )
 
     def update_battery_power_limits(self, plant_conf: dict) -> None:
         """
@@ -2991,6 +3112,33 @@ class Optimization:
                 if k < len(self.param_load_active):
                     constraints.append(p_deferrable[k] <= M * self.param_load_active[k])
 
+            # Current-power pin at t=0 (issue #605).
+            # Applies to pin-eligible loads only: not semi_cont (strict p==nominal*bin),
+            # not single_const (fixed-energy block; a below-nominal pin would fight the
+            # required-energy target), not sequence (profile-shaped), not thermal
+            # (temperature dynamics govern). Uses parametric big-M so the constraint is a
+            # structural no-op when param_def_current_power_active[k]=0, enabling cache
+            # reuse across calls. The same M already used for this load (computed above)
+            # is reused so the bound is consistent with the p<=M*bin2 constraint.
+            if (
+                not is_semi_cont
+                and not is_single_const
+                and not is_sequence_load
+                and k not in self.param_thermal
+                and k < len(self.param_def_current_power)
+                and k < len(self.param_def_current_power_active)
+            ):
+                constraints.append(
+                    p_deferrable[k][0]
+                    <= self.param_def_current_power[k]
+                    + M * (1 - self.param_def_current_power_active[k])
+                )
+                constraints.append(
+                    p_deferrable[k][0]
+                    >= self.param_def_current_power[k]
+                    - M * (1 - self.param_def_current_power_active[k])
+                )
+
         # Process shared thermal tanks once each, after the per-load loop. Each
         # shared tank is fed by N >= 1 deferrable loads; their per-load
         # thermal_battery dynamics were skipped above.
@@ -3609,6 +3757,9 @@ class Optimization:
         # Update def_current_on_timesteps so the min-on remainder block (issue #952)
         # has the correct elapsed on-time when it runs in the per-load loop below.
         self._update_def_current_on_timesteps_params(num_deferrable_loads)
+        # Update def_current_power (issue #605): runs AFTER _update_def_current_state_params
+        # so it can bump param_def_current_state to suppress the phantom t=0 startup.
+        self._update_def_current_power_params(num_deferrable_loads)
 
         # Update Energy Constraint Parameters for Deferrable Loads
         # These control the Big-M relaxation of energy/timestep constraints
@@ -3808,9 +3959,32 @@ class Optimization:
                             effective_end_mot,
                         )
 
-                # ELEMENTWISE MAX: combine single-const pin and min-on remainder.
-                # Neither mechanism overwrites the other; the stricter force wins.
-                combined_lb = np.maximum(single_const_lb, min_on_lb)
+                # Current-power force-on (issue #605): when load k is affected by
+                # def_current_power, force bin2[k][0] = 1 so the load stays ON at
+                # t=0. Only index 0 matters here; for pinned loads the power-pin
+                # constraint already implies bin2[0]=1, so this is what keeps an affected
+                # semi_cont load ON (at nominal). Excludes single_const / sequence /
+                # thermal via _def_current_power_affected (set in the update method).
+                # Widen window_mask[0] too so a load whose window starts after t=0 is
+                # not immediately blocked by the mask (mirrors the single-const / min-on
+                # widen pattern above).
+                current_power_lb = np.zeros(n)
+                if (
+                    k < len(self._def_current_power_affected)
+                    and self._def_current_power_affected[k]
+                ):
+                    current_power_lb[0] = 1.0
+                    # Widen window mask at t=0 so the forced-on step is never blocked.
+                    if k < len(self.param_window_masks):
+                        wm_cp = self.param_window_masks[k].value.copy()
+                        if wm_cp[0] < 1.0:
+                            wm_cp[0] = 1.0
+                            self.param_window_masks[k].value = wm_cp
+
+                # ELEMENTWISE MAX: combine single-const pin, min-on remainder, and
+                # current-power force-on.  Neither mechanism overwrites the other;
+                # the stricter force wins.
+                combined_lb = np.maximum(np.maximum(single_const_lb, min_on_lb), current_power_lb)
                 self.param_running_lb[k].value = combined_lb
 
         # Update load active parameters: deactivate non-thermal loads with 0 operating timesteps,

--- a/src/emhass/static/data/runtime_params.json
+++ b/src/emhass/static/data/runtime_params.json
@@ -97,6 +97,13 @@
       "default_value": null,
       "unit": "timesteps"
     },
+    "def_current_power": {
+      "friendly_name": "Current power of deferrable loads",
+      "Description": "Per-load actual power (watts) each deferrable load is drawing right now, at the start of the optimization horizon. When greater than 0, the optimizer pins P_deferrable[k] at the first timestep to this value, forces the load ON at that timestep, and suppresses the phantom startup penalty for it. One non-negative float per deferrable load, in the same order as nominal_power_of_deferrable_loads; default null (absent key) is an exact no-op so today's behaviour is preserved. This is a separate runtime input rather than an extension of def_current_state, so the binary on/off decision stays strict and fractional watt values cannot weaken it. For treat_deferrable_load_as_semi_cont loads the power is fixed at nominal, so the supplied wattage acts only as an on/off signal (the load is forced ON at nominal; the value pin is omitted). For loads with minimum_power_of_deferrable_loads > 0 the supplied value should be >= the configured minimum, and for all loads it should be <= nominal_power_of_deferrable_loads; values outside those bounds make the solve infeasible (the value is never silently clamped). Single-constant, sequence (list-valued nominal power) and thermal loads ignore this input; use def_current_state for a currently-running single-constant load. Runtime-overridable on every optimization tick without a cache rebuild. Related to issue #605.",
+      "input": "array.float",
+      "default_value": null,
+      "unit": "W"
+    },
     "def_load_config": {
       "friendly_name": "Deferrable load special config",
       "Description": "Per-deferrable-load special configuration carrying the thermal_config / thermal_battery models. Deep, evolving nested schema; not inlined here. See the linked documentation for the full structure.",

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1941,6 +1941,22 @@ async def treat_runtimeparams(
             else:
                 params["optim_conf"]["def_current_on_timesteps"] = [int(dcot)] * n_loads
 
+        # def_current_power: per-load current power in watts (issue #605).
+        # Absent key -> no pin, no force-on (NOT assumed zero). Mirrors def_current_on_timesteps.
+        if "def_current_power" in runtimeparams:
+            dcp = runtimeparams["def_current_power"]
+            # String -> parse JSON list
+            if isinstance(dcp, str):
+                try:
+                    dcp = orjson.loads(dcp)
+                except Exception:
+                    logger.warning(f"Could not parse def_current_power string: {dcp}")
+            n_loads = len(params["optim_conf"]["nominal_power_of_deferrable_loads"])
+            if isinstance(dcp, list):
+                params["optim_conf"]["def_current_power"] = [float(v) for v in dcp]
+            else:
+                params["optim_conf"]["def_current_power"] = [float(dcp)] * n_loads
+
         # set_deferrable_load_single_constant arrives via the generic associations.csv
         # path as-is (may be a list of strings from runtimeparams JSON).  Apply the
         # same _cast_bool coercion so 'False' → False, not True (#873, mirrors #876).

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -7091,6 +7091,346 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             f"single-constant loads). Got: {_opt.optim_status}",
         )
 
+    # ---------------------------------------------------------------------------
+    # Tests for def_current_power (issue #605)
+    # All tests are base-safe: they read the new config key via optim_conf dict
+    # (not a new attribute) so Import/AttributeError is not possible on base code.
+    # RED tests are designed to FAIL on the behavioural assertion on base code,
+    # not on an exception.
+    # ---------------------------------------------------------------------------
+
+    def _make_current_power_scenario(self, n=10, prices=None, nominal=3000.0):
+        """Build a minimal input DataFrame for def_current_power tests.
+
+        n timesteps at 30-min steps; flat load=0, pv=0, custom prices allow
+        crafting cost incentives so the base solver would turn the load off at t=0.
+        """
+        if prices is None:
+            prices = [0.9] * n
+        index = pd.date_range(start="2023-01-01 00:00:00", periods=n, freq="30min", tz="UTC")
+        df = pd.DataFrame(index=index)
+        df["p_pv_forecast"] = 0.0
+        df["p_load_forecast"] = 0.0
+        df[self.fcst.var_load_cost] = prices
+        df[self.fcst.var_prod_price] = 0.0
+        return df
+
+    def _make_current_power_overrides(self, **extra):
+        """Return a base optim_conf override dict suitable for def_current_power tests."""
+        base = {
+            "costfun": "cost",
+            "number_of_deferrable_loads": 2,
+            "nominal_power_of_deferrable_loads": [3000.0, 750.0],
+            "minimum_power_of_deferrable_loads": [0.0, 0.0],
+            "operating_hours_of_each_deferrable_load": [1.0, 0.0],
+            "treat_deferrable_load_as_semi_cont": [False, False],
+            "set_deferrable_load_single_constant": [False, False],
+            "set_deferrable_startup_penalty": [0.0, 0.0],
+            "set_deferrable_max_startups": [0, 0],
+            "start_timesteps_of_each_deferrable_load": [0, 0],
+            "end_timesteps_of_each_deferrable_load": [0, 0],
+            "def_load_config": [],
+            "deferrable_load_groups": [],
+            "set_use_battery": False,
+        }
+        base.update(extra)
+        return base
+
+    def test_current_power_pin_red(self):
+        """RED (issue #605): continuous load, supplied partial watts < nominal.
+
+        With a high electricity price at t=0, the base solver sets P_def[0][0]=0
+        (load off at t=0). When def_current_power[0]=1500 (50% of 3000 W
+        nominal), the pin must force P_def[0][0]==1500.
+
+        Base code: ignores def_current_power -> P_def[0][0] is free / driven to 0.
+        This test FAILS on the assertAlmostEqual assertion on base code (P_def[0]=0,
+        not 1500), NOT on an Attribute/KeyError, so it is RED-on-base-safe.
+        """
+        n = 10
+        # Very high price at t=0 so the base solver wants to be OFF immediately.
+        prices = [0.9, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05]
+        df = self._make_current_power_scenario(n=n, prices=prices, nominal=3000.0)
+
+        # Counterfactual: without def_current_power, load turns off at t=0
+        overrides = self._make_current_power_overrides()
+
+        # --- Counterfactual: verify base truly turns load off at t=0 ---
+        _opt_base, res_base = self._run_min_on_optim(overrides, df, n)
+        self.assertIn(
+            _opt_base.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"Counterfactual solve non-optimal: {_opt_base.optim_status}",
+        )
+        p_def0_base = res_base["P_deferrable0"].values[0]
+        self.assertAlmostEqual(
+            p_def0_base,
+            0.0,
+            delta=1.0,
+            msg=(
+                "Counterfactual FAILED: base solver did not turn load off at t=0 on "
+                f"this price profile. P_def[0]={p_def0_base}. "
+                "Adjust the price profile so the base solver turns the load off."
+            ),
+        )
+
+        # --- With def_current_power=1500: pin must fix P_def[0][0] to 1500 W ---
+        with_pin = self._make_current_power_overrides(
+            **{"def_current_power": [1500.0, 0.0]},
+        )
+        _opt_pin, res_pin = self._run_min_on_optim(with_pin, df, n)
+        self.assertIn(
+            _opt_pin.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"Solve with def_current_power=[1500,0] non-optimal: {_opt_pin.optim_status}",
+        )
+        # BEHAVIOURAL assertion -- this line fails on base code (returns 0, not 1500).
+        p_def0_pin = res_pin["P_deferrable0"].values[0]
+        self.assertAlmostEqual(
+            p_def0_pin,
+            1500.0,
+            delta=1.0,
+            msg=(
+                f"def_current_power pin failed: expected P_def[0][0]=1500, got {p_def0_pin}. "
+                "Base code returns 0 here (turns load off) -- this is the RED assertion."
+            ),
+        )
+
+    def test_current_power_noop_no_key(self):
+        """def_current_power absent = results identical to all-zeros (no-op proven).
+
+        Run the same scenario twice (without def_current_power, then with all zeros)
+        and verify results are equal. Also confirm that with a cost incentive to be OFF
+        at t=0, the load truly is off (so the test cannot false-green by coincidence).
+        """
+        n = 10
+        prices = [0.9, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05]
+        df = self._make_current_power_scenario(n=n, prices=prices)
+
+        overrides_no_key = self._make_current_power_overrides()
+        overrides_zeros = self._make_current_power_overrides(
+            **{"def_current_power": [0.0, 0.0]},
+        )
+
+        _opt_a, res_a = self._run_min_on_optim(overrides_no_key, df, n)
+        _opt_b, res_b = self._run_min_on_optim(overrides_zeros, df, n)
+
+        self.assertIn(_opt_a.optim_status, VALID_OPTIMAL_STATUSES)
+        self.assertIn(_opt_b.optim_status, VALID_OPTIMAL_STATUSES)
+
+        np.testing.assert_allclose(
+            res_a["P_deferrable0"].values,
+            res_b["P_deferrable0"].values,
+            atol=1e-6,
+            err_msg="def_current_power=[0,0] changed the result vs absent key (should be no-op)",
+        )
+        np.testing.assert_allclose(
+            res_a["P_deferrable1"].values,
+            res_b["P_deferrable1"].values,
+            atol=1e-6,
+            err_msg="def_current_power=[0,0] changed load-1 result vs absent key",
+        )
+
+        # Also confirm the cost incentive actually drives load-0 off at t=0 (anti-green)
+        p0_t0 = res_a["P_deferrable0"].values[0]
+        self.assertAlmostEqual(
+            p0_t0,
+            0.0,
+            delta=1.0,
+            msg=(
+                f"No-op scenario: expected load-0 OFF at t=0 (P_def=0), got {p0_t0}. "
+                "The anti-green check failed; adjust the price profile."
+            ),
+        )
+
+    def test_current_power_semi_cont_force_on_nominal(self):
+        """semi_cont load + def_current_power > 0: force ON at t=0, P_def[0]==nominal.
+
+        For treat_deferrable_load_as_semi_cont loads the power pin is omitted
+        (power == nominal*bin strictly), but the force-ON must still apply.
+        The result at t=0 must be at nominal (3000 W), not the supplied 1500.
+        """
+        n = 10
+        # High price at t=0 so base solver wants to be OFF.
+        prices = [0.9, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05]
+        df = self._make_current_power_scenario(n=n, prices=prices, nominal=3000.0)
+
+        overrides = self._make_current_power_overrides(
+            treat_deferrable_load_as_semi_cont=[True, True],
+            def_current_power=[1500.0, 0.0],
+        )
+        _opt, res = self._run_min_on_optim(overrides, df, n)
+        self.assertIn(
+            _opt.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"semi_cont + def_current_power solve non-optimal: {_opt.optim_status}",
+        )
+        p0_t0 = res["P_deferrable0"].values[0]
+        # semi_cont: power must be at nominal (not the partial supplied value).
+        self.assertAlmostEqual(
+            p0_t0,
+            3000.0,
+            delta=1.0,
+            msg=(
+                f"semi_cont + def_current_power: expected P_def[0][0]=3000 (nominal), "
+                f"got {p0_t0}. Force-ON should give nominal, not the supplied partial."
+            ),
+        )
+
+    def test_current_power_phantom_startup_suppressed(self):
+        """def_current_power > 0 with no def_current_state must NOT incur a startup at t=0.
+
+        A startup penalty at t=0 for a load that is already running is wrong. The
+        phantom-startup suppression bumps param_def_current_state so startup detection
+        treats t=0 as 'was already ON'.
+        """
+        n = 10
+        prices = [0.05] * n
+        df = self._make_current_power_scenario(n=n, prices=prices, nominal=3000.0)
+
+        # With a startup penalty and def_current_state NOT set, base code fires a
+        # phantom start at t=0. With def_current_power the suppression must prevent it.
+        overrides = self._make_current_power_overrides(
+            treat_deferrable_load_as_semi_cont=[True, True],
+            set_deferrable_startup_penalty=[1.0, 0.0],
+            def_current_power=[3000.0, 0.0],
+            # def_current_state intentionally NOT set
+        )
+        _opt, res = self._run_min_on_optim(overrides, df, n)
+        self.assertIn(
+            _opt.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"phantom-startup suppression solve non-optimal: {_opt.optim_status}",
+        )
+        # p_def_start_0 at t=0 must be 0 (no startup event).
+        if "P_def_start_0" in res.columns:
+            start_t0 = res["P_def_start_0"].values[0]
+            self.assertAlmostEqual(
+                start_t0,
+                0.0,
+                delta=0.01,
+                msg=(
+                    f"Phantom startup not suppressed: P_def_start[0][0]={start_t0} "
+                    "(expected 0). def_current_power must bump param_def_current_state."
+                ),
+            )
+
+    def test_current_power_length_mismatch_warns(self):
+        """Length mismatch (len != num_def_loads) must warn, not crash."""
+        n = 5
+        prices = [0.5] * n
+        df = self._make_current_power_scenario(n=n, prices=prices)
+
+        overrides = self._make_current_power_overrides(
+            **{"def_current_power": [500.0]},  # len=1, num_loads=2 -> mismatch
+        )
+        # Should complete without raising; the logger warning is checked by inspection.
+        _opt, res = self._run_min_on_optim(overrides, df, n)
+        self.assertIn(
+            _opt.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"Length-mismatch must not crash the solve. Got: {_opt.optim_status}",
+        )
+
+    def test_current_power_invalid_value_raises(self):
+        """Negative or non-numeric def_current_power raises ValueError with context."""
+        n = 5
+        prices = [0.5] * n
+        df = self._make_current_power_scenario(n=n, prices=prices)
+
+        # Negative value
+        overrides_neg = self._make_current_power_overrides(
+            **{"def_current_power": [-100.0, 0.0]},
+        )
+        with self.assertRaises(ValueError, msg="Negative power should raise ValueError"):
+            self._run_min_on_optim(overrides_neg, df, n)
+
+        # Non-numeric string value
+        overrides_str = self._make_current_power_overrides(
+            **{"def_current_power": ["not_a_number", 0.0]},
+        )
+        with self.assertRaises(ValueError, msg="Non-numeric power should raise ValueError"):
+            self._run_min_on_optim(overrides_str, df, n)
+
+    def test_current_power_window_mask_widened(self):
+        """Window mask at t=0 is widened when def_current_power > 0 and window starts later.
+
+        A load whose configured start_timestep > 0 has mask[0]=0 by default. When
+        def_current_power[k] > 0 the force-ON must also widen mask[0] to 1 so the
+        load is not immediately blocked by the mask constraint.
+        """
+        n = 10
+        prices = [0.05] * n
+        df = self._make_current_power_scenario(n=n, prices=prices, nominal=3000.0)
+
+        # Window starts at t=3, but load is reported as running at t=0.
+        overrides = self._make_current_power_overrides(
+            operating_hours_of_each_deferrable_load=[1.0, 0.0],
+            start_timesteps_of_each_deferrable_load=[3, 0],
+            end_timesteps_of_each_deferrable_load=[0, 0],
+            def_current_power=[1500.0, 0.0],
+        )
+        _opt, res = self._run_min_on_optim(overrides, df, n)
+        self.assertIn(
+            _opt.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            (
+                "Window-mask widen: load running outside its window should still be "
+                f"feasible when def_current_power forces t=0 ON. Got: {_opt.optim_status}"
+            ),
+        )
+        p0_t0 = res["P_deferrable0"].values[0]
+        self.assertGreater(
+            p0_t0,
+            0.0,
+            msg=(
+                f"Window mask was not widened at t=0: P_def[0][0]={p0_t0} (expected > 0). "
+                "def_current_power force-ON must widen mask[0] to allow t=0 power."
+            ),
+        )
+
+    def test_current_power_single_const_ignored(self):
+        """single_const loads ignore def_current_power (issue #605 fix).
+
+        A single-constant load runs as one fixed block; "currently running" is
+        handled by def_current_state, not def_current_power. An earlier design
+        wrongly treated single_const as pin-eligible: pinning a below-nominal
+        power fought the required-energy block, made the MIP infeasible, and the
+        solver silently relaxed to a continuous LP returning an accepted-but-wrong
+        "Optimal (Relaxed)" dispatch. With the fix def_current_power is a no-op for
+        single_const loads, so the dispatch is identical to omitting it and the
+        solve stays cleanly optimal.
+        """
+        n = 10
+        prices = [0.9, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05]
+        df = self._make_current_power_scenario(n=n, prices=prices, nominal=3000.0)
+
+        base = self._make_current_power_overrides(
+            set_deferrable_load_single_constant=[True, False],
+        )
+        with_dcp = self._make_current_power_overrides(
+            set_deferrable_load_single_constant=[True, False],
+            def_current_power=[1500.0, 0.0],
+        )
+
+        opt_base, res_base = self._run_min_on_optim(base, df, n)
+        opt_dcp, res_dcp = self._run_min_on_optim(with_dcp, df, n)
+
+        self.assertIn(opt_base.optim_status, VALID_OPTIMAL_STATUSES)
+        self.assertIn(
+            opt_dcp.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"single_const + def_current_power non-optimal: {opt_dcp.optim_status}",
+        )
+        # def_current_power must be fully ignored for a single_const load, so the
+        # dispatch matches the run without it (not a relaxed / pinned result).
+        np.testing.assert_allclose(
+            res_dcp["P_deferrable0"].values,
+            res_base["P_deferrable0"].values,
+            atol=1e-6,
+            err_msg="def_current_power changed a single_const load (must be ignored)",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -7302,18 +7302,26 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             VALID_OPTIMAL_STATUSES,
             f"phantom-startup suppression solve non-optimal: {_opt.optim_status}",
         )
-        # p_def_start_0 at t=0 must be 0 (no startup event).
-        if "P_def_start_0" in res.columns:
-            start_t0 = res["P_def_start_0"].values[0]
-            self.assertAlmostEqual(
-                start_t0,
-                0.0,
-                delta=0.01,
-                msg=(
-                    f"Phantom startup not suppressed: P_def_start[0][0]={start_t0} "
-                    "(expected 0). def_current_power must bump param_def_current_state."
-                ),
-            )
+        # p_def_start_0 at t=0 must be 0 (no startup event). _run_min_on_optim runs
+        # with debug=True so the per-load start column is always emitted; assert its
+        # presence so the key check fails loudly if that ever changes instead of being
+        # silently skipped.
+        self.assertIn(
+            "P_def_start_0",
+            res.columns,
+            "P_def_start_0 missing from debug output; the phantom-startup assertion "
+            "would be skipped without it.",
+        )
+        start_t0 = res["P_def_start_0"].values[0]
+        self.assertAlmostEqual(
+            start_t0,
+            0.0,
+            delta=0.01,
+            msg=(
+                f"Phantom startup not suppressed: P_def_start[0][0]={start_t0} "
+                "(expected 0). def_current_power must bump param_def_current_state."
+            ),
+        )
 
     def test_current_power_length_mismatch_warns(self):
         """Length mismatch (len != num_def_loads) must warn, not crash."""

--- a/tests/test_runtime_params.py
+++ b/tests/test_runtime_params.py
@@ -58,6 +58,7 @@ EXPECTED_KEYS = {
     "weather_forecast_cache",
     "weather_forecast_cache_only",
     "def_current_state",
+    "def_current_power",
     "def_load_config",
 }
 


### PR DESCRIPTION
## What this does

Adds an opt-in runtime input `def_current_power` so the optimiser can be told the real power a deferrable load is drawing right now, at the first timestep of the horizon. This fixes #605.

When a deferrable load is started by hand (an EV charger, a pool heater), the main load sensor (`sensor_power_load_no_var_loads`) does not include it, so `P_load[0]` handed to the optimiser is too low. Two things go wrong: the t=0 power balance is built on bad data, and the optimiser, not seeing the load, often plans to switch off at t=0 exactly the thing the user just switched on. The existing `def_current_state` only suppresses the startup penalty. It does not force the load on and it does not correct the power value.

`def_current_power` is a per-load list of watts. When an entry is greater than 0 the optimiser, for that load:

1. pins the deferrable power at the first timestep to the supplied value, so the t=0 balance matches reality,
2. forces the load on at the first timestep, so it is not immediately switched off, and
3. treats the load as already running for startup detection, so no phantom startup penalty fires at t=0.

Default unset (or all zeros) is an exact no-op, so behaviour is unchanged for anyone who does not set it. The only behaviour change is when the new parameter is supplied.

## Why a separate parameter

The issue suggested overloading `def_current_state` to accept watt values instead of booleans. I went with a separate input instead so the binary on/off decision stays strict 0/1 and a fractional watt value can never weaken it. `def_current_state` is untouched.

## Scope by load type

The power pin only applies where the first-timestep power is a free variable: ordinary loads and loads with a minimum power. For `treat_deferrable_load_as_semi_cont` loads the power is strictly `nominal * bin`, so the pin is omitted and the force-on alone holds the load on at nominal (the supplied wattage acts only as an on/off signal, which is correct for an on/off device). Single-constant, sequence (list-valued nominal power) and thermal loads ignore the input. A currently-running single-constant load is already handled by `def_current_state`, which pins its remaining required timesteps, so injecting a below-nominal power there would fight the required-energy block.

For a load with a minimum power, the supplied value should sit in `[minimum_power, nominal]`. A value outside that range makes the solve infeasible rather than being silently clamped, so the input stays honest about what the hardware reported.

## How it is wired

`def_current_power` is a runtime-only input, plumbed like `def_current_state`: it lives in `runtime_params.json`, is handled in `treat_runtimeparams`, and is in the optim_conf runtime-key allowlist so a new value updates the pin on every MPC tick without rebuilding the solver (the value and an activation flag go through CVXPY Parameters, and the pin uses a parametric big-M that is a structural no-op when inactive). It composes with `def_current_on_timesteps` from #980 (how long a load has been running) by adding what power it is running at, so the optimiser can start from the real mid-run state at t=0. It is also a step towards #596 (per-deferrable metering), which is the standing-config counterpart of this runtime signal.

## Tests

In `tests/test_optimization.py`:
- pin forces `P_def[0]` to the supplied watts for an ordinary load (red against current master, which turns the load off at t=0),
- absent / all-zero input reproduces today's result (no-op, with a cost incentive that would otherwise turn the load off),
- semi-continuous load is forced on at nominal, not the partial value,
- phantom startup is suppressed at t=0,
- single-constant load ignores the input (dispatch identical to omitting it),
- window mask is widened when a load is reported running before its configured window,
- length-mismatch warning and invalid-value error mirror the sibling parameters.

Full suite green locally.

## Summary by Sourcery

Introduce an optional per-load runtime parameter to pin deferrable load power and on-state at the first timestep, aligning the optimizer with real-world load conditions while preserving existing behavior by default.

New Features:
- Add runtime optim_config parameter def_current_power to specify current per-load power at t=0 and influence deferrable load dispatch accordingly.

Enhancements:
- Wire def_current_power through optimization parameter updates and deferrable-load constraints to pin eligible loads' power at t=0, force them on, and suppress phantom startup penalties without rebuilding the solver cache.
- Extend window mask and running lower-bound logic so loads reported as running before their configured window remain feasible when def_current_power is used.
- Document def_current_power configuration, semantics, and interactions with different deferrable load types in the config reference.

Tests:
- Add optimization tests covering pin behavior, no-op semantics when absent or zero, semi-continuous handling, phantom-startup suppression, window-mask widening, single-constant no-op behavior, and validation of malformed def_current_power inputs.
- Add runtime parameter tests and wiring to ensure def_current_power is correctly parsed from runtime inputs and excluded from config hashing for cache invalidation.