### PR TITLE
fix: correct forecast dates when host clock differs from configured timezone (#984)

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -1383,7 +1383,7 @@ class Forecast:
         :rtype: pd.date_range
 
         """
-        start_forecast_csv = pd.Timestamp(datetime.now(), tz=self.time_zone).replace(microsecond=0)
+        start_forecast_csv = pd.Timestamp.now(tz=self.time_zone).replace(microsecond=0)
         if self.method_ts_round == "nearest":
             start_forecast_csv = pd.Timestamp.now(tz=self.time_zone).replace(microsecond=0)
         elif self.method_ts_round == "first":

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -106,8 +106,8 @@ def get_logger(
 
 
 def _get_now() -> datetime:
-    """Helper function to get the current time, for easier mocking."""
-    return datetime.now()
+    """Return the current instant as a timezone-aware UTC datetime. Separated out for easier mocking in tests."""
+    return datetime.now(UTC)
 
 
 def get_forecast_dates(
@@ -132,7 +132,9 @@ def get_forecast_dates(
     freq = pd.to_timedelta(freq, "minutes")
     start_time = _get_now()
 
-    start_forecast = pd.Timestamp(start_time, tz=time_zone).replace(microsecond=0).floor(freq=freq)
+    start_forecast = (
+        pd.Timestamp(start_time).tz_convert(time_zone).replace(microsecond=0).floor(freq=freq)
+    )
     end_forecast = start_forecast + pd.tseries.offsets.DateOffset(days=delta_forecast)
     final_end_date = end_forecast + pd.tseries.offsets.DateOffset(days=timedelta_days) - freq
 

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -132,6 +132,9 @@ def get_forecast_dates(
     freq = pd.to_timedelta(freq, "minutes")
     start_time = _get_now()
 
+    # start_time is the timezone-aware UTC instant from _get_now(); tz_convert expresses it in
+    # the configured timezone regardless of the host clock. It raises on a naive value, so a
+    # refactor that reintroduced a naive "now" here would fail loudly rather than silently shift.
     start_forecast = (
         pd.Timestamp(start_time).tz_convert(time_zone).replace(microsecond=0).floor(freq=freq)
     )

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -2647,7 +2647,7 @@ class TestDstForecastDates(unittest.IsolatedAsyncioTestCase):
         # utils.get_forecast_dates is the reference (uses DateOffset)
         # fcst_dst.freq is the optimization_time_step Timedelta
         freq_minutes = int(fcst_dst.freq.seconds // 60)
-        with patch("emhass.utils._get_now", return_value=dst_start_naive):
+        with patch("emhass.utils._get_now", return_value=dst_start_ts):
             ref_dates = utils.get_forecast_dates(freq_minutes, 7, self.paris_tz)
 
         self.assertEqual(
@@ -2698,7 +2698,7 @@ class TestDstForecastDates(unittest.IsolatedAsyncioTestCase):
         )
 
         freq_minutes = int(fcst_normal.freq.seconds // 60)
-        with patch("emhass.utils._get_now", return_value=normal_start_naive):
+        with patch("emhass.utils._get_now", return_value=normal_start_ts):
             ref_dates = utils.get_forecast_dates(freq_minutes, 7, self.paris_tz)
 
         self.assertEqual(len(fcst_normal.forecast_dates), len(ref_dates))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 import unittest
 from copy import deepcopy
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import numpy as np
@@ -160,8 +160,8 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
         )
         expected_dates = [ts.isoformat() for ts in expected_range]
 
-        # 3. Set the return value for the mock (which is now passed in as an argument)
-        mock_ts_now.return_value = mock_now
+        # 3. Set the return value for the mock - tz-aware UTC instant equal to the local time
+        mock_ts_now.return_value = time_zone.localize(mock_now).astimezone(UTC)
 
         actual_dates = utils.get_forecast_dates(freq, delta_forecast, time_zone)
 
@@ -189,8 +189,8 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
         )
         expected_dates = [ts.isoformat() for ts in expected_range]
 
-        # 3. Set the return value for the mock
-        mock_ts_now.return_value = mock_now
+        # 3. Set the return value for the mock - tz-aware UTC instant equal to the local time
+        mock_ts_now.return_value = time_zone.localize(mock_now).astimezone(UTC)
 
         actual_dates = utils.get_forecast_dates(freq, delta_forecast, time_zone)
         # 4. Perform assertions
@@ -199,6 +199,53 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
         self.assertListEqual(actual_dates, expected_dates)
         self.assertIn("+10:00", actual_dates[2])
         self.assertIn("+11:00", actual_dates[3])
+
+    def test_get_forecast_dates_host_tz_differs_from_config(self):
+        """Issue #984: forecast dates must be correct when host clock is UTC but EMHASS tz differs.
+
+        Simulates a UTC host by patching emhass.utils.datetime so both call forms
+        (datetime.now() and datetime.now(tz)) behave as on a UTC host. The fix converts
+        the aware UTC instant to the config tz (tz_convert) instead of localizing a naive
+        wall clock (which mislabels UTC wall-clock time as local time).
+        """
+
+        class _FakeDT(datetime):
+            """Subclass of datetime so isinstance checks in utils still work."""
+
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 6, 15, 11, 17, 0)  # UTC wall clock
+                if tz is None:
+                    # Base-code path: old _get_now() calls datetime.now() with no tz.
+                    # Kept so this same test runs (and fails) against the unfixed code.
+                    return base
+                return base.replace(tzinfo=UTC).astimezone(tz)
+
+        brisbane = pytz.timezone("Australia/Brisbane")
+
+        # --- host != config tz case (UTC host, Brisbane config) ---
+        with patch("emhass.utils.datetime", _FakeDT):
+            dates = utils.get_forecast_dates(5, 2, brisbane)
+        # Correct local now: 11:17 UTC -> 21:17 AEST (+10); floored to 5min -> 21:15
+        self.assertEqual(dates[0], "2026-06-15T21:15:00+10:00")
+
+        # --- control: host clock == config tz (Brisbane host, Brisbane config) ---
+        class _FakeDTLocal(datetime):
+            """Simulates a Brisbane host: naive now() is 21:17 local; aware now() is consistent."""
+
+            @classmethod
+            def now(cls, tz=None):
+                local_naive = datetime(2026, 6, 15, 21, 17, 0)
+                if tz is None:
+                    # Base-code path (datetime.now() with no tz); kept for base-safety.
+                    return local_naive
+                # Express the same instant tz-aware in the requested tz
+                return brisbane.localize(local_naive).astimezone(tz)
+
+        with patch("emhass.utils.datetime", _FakeDTLocal):
+            dates_local = utils.get_forecast_dates(5, 2, brisbane)
+        # Same correct local start expected
+        self.assertEqual(dates_local[0], "2026-06-15T21:15:00+10:00")
 
     async def test_treat_runtimeparams(self):
         # Test dayahead runtime params


### PR DESCRIPTION
## The bug

`forecast_dates` (the time grid the optimisation and the runtime forecast inputs are aligned to) is built from `datetime.now()`, a naive local wall clock, which `get_forecast_dates` then localises as the configured `time_zone` via `pd.Timestamp(now, tz=time_zone)`. That is only correct when the host system clock is in the same timezone as the EMHASS `time_zone` config.

On a host whose clock is in a different zone (a UTC Docker host or HA add-on is the common case) the naive wall clock is mislabelled: the UTC time digits get stamped with the local offset. So `forecast_dates` start the full UTC offset away from the real instant, while the retrieved data index is built correctly from `pd.Timestamp.now(tz="UTC")`. The two grids then disagree by the offset, and any runtime forecast aligned to `forecast_dates` (load cost, production price, PV, load) lands shifted by that offset.

This is what was reported in #984: a user at `+10:00` saw the MPC plan import to charge the battery during the most expensive window and export when the export price was zero. The optimiser was correct, but on a price array pinned to the wrong times. Reproduced exactly: the free 11:00 to 14:00 import window landed at 21:00 to 23:00, a clean +10 hour shift equal to the UTC offset. Users near UTC see a small shift that often goes unnoticed; far from UTC it is dramatic.

## The fix

Make the current instant timezone-aware at the source and convert, instead of localising a naive value:

- `_get_now()` returns `datetime.now(UTC)` (timezone-aware) instead of naive `datetime.now()`.
- `get_forecast_dates` uses `pd.Timestamp(start_time).tz_convert(time_zone)` instead of `pd.Timestamp(start_time, tz=time_zone)`.

`forecast_dates` now reflect the true instant in the configured timezone regardless of the host clock, matching the data index. There is also a one line consistency fix in `get_forecast_days_csv` (`pd.Timestamp(datetime.now(), tz=...)` to `pd.Timestamp.now(tz=...)`) for the same pattern, currently only reachable on an invalid `method_ts_round`.

## Behaviour change

For users whose host clock already matches their EMHASS timezone (most setups, and what the existing tests covered) the output is unchanged. The behaviour changes only where the host clock differs from the configured timezone, which is now correct. As a side benefit this also removes a latent `AmbiguousTimeError` that the old `pd.Timestamp(naive, tz=...)` could raise during the daylight-saving fall-back hour, since converting a real UTC instant is never ambiguous.

## Tests

- New `test_get_forecast_dates_host_tz_differs_from_config` (issue #984): simulates a UTC host and asserts `forecast_dates` start at the correct local instant, with a control case for host clock equal to the configured timezone. Fails on the current code, passes with the fix.
- Updated the existing timezone and DST tests (`test_get_forecast_dates_standard_day`, `test_get_forecast_dates_dst_crossing`, and the two `Forecast` DST tests) to mock the now-source with timezone-aware instants, preserving their intent and assertions (including the spring-forward 23 slot count and the +10:00/+11:00 crossing).

Full test suite green locally.

Out of scope, noted for a possible follow-up: after this fix the default and `method_ts_round == "nearest"` branches in `get_forecast_days_csv` are identical, a small pre-existing duplication.

Reported by @F21 in #984.

## Summary by Sourcery

Fix forecast date generation to be timezone-robust when the host system clock differs from the configured EMHASS timezone.

Bug Fixes:
- Ensure forecast date grids are based on a timezone-aware UTC instant converted to the configured timezone so host and config timezones can differ without misalignment.
- Align get_forecast_days_csv start time handling with a timezone-aware timestamp helper to avoid incorrect labelling and potential DST-related issues.

Tests:
- Add regression test covering hosts running in UTC with a different configured timezone to verify forecast dates start at the correct local instant.
- Update existing forecast date and DST-related tests to use timezone-aware instants consistent with the new now-source.