### PR TITLE
fix: schedule cooling for shared-tank comfort_sense: cool zones

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -2615,15 +2615,16 @@ class Optimization:
         where cop_k is resolved via utils.resolve_thermal_battery_cop (Carnot
         for heat pumps, flat for constant-efficiency sources like gas).
 
-        Returns: (predicted_temp_var, heating_demand_arr) for downstream
-        plotting / publishing.
+        Returns: (predicted_temp_var, heating_demand_arr, penalty_term) where
+        penalty_term is the signed comfort penalty (<= 0, added to the Maximize
+        objective) or None when no desired_temperatures are configured.
         """
         tank = self._get_shared_thermal_tanks()[tank_idx]
         tank_id = tank.get("id", f"tank{tank_idx}")
         required_len = self.num_timesteps
         load_ids = [int(k) for k in tank.get("load_ids", [])]
         if not load_ids:
-            return None, None
+            return None, None, None
 
         # Tank physics
         volume = tank["volume"]
@@ -2721,6 +2722,17 @@ class Optimization:
             )
             cop_arrays.append(np.asarray(cops))
 
+        # Comfort sense (heat vs cool). The compiler propagates the destination
+        # storage's comfort_sense onto tank["sense"]; default to heat for legacy
+        # configs. sense_coeff = +1 for heating (source adds heat), -1 for cooling
+        # (source removes heat) — mirrors the per-load thermal paths.
+        tank_sense = utils.normalize_heat_cool_mode(
+            tank.get("sense") or "heat",
+            field_name="sense",
+            context=f"shared tank {tank_id}",
+        )
+        sense_coeff = 1 if tank_sense == "heat" else -1
+
         # Build CVXPY tank temperature variable
         predicted_temp = cp.Variable(required_len, name=f"temp_shared_{tank_id}")
         constraints.append(predicted_temp[0] == start_temperature)
@@ -2733,11 +2745,12 @@ class Optimization:
             raw_heat = raw_heat + cp.multiply(cops[:-1], p_k[:-1]) / 1000 * self.time_step
 
         # First-order thermal dynamics
-        # T[t+1] = T[t] + conversion * (raw_heat[t] - demand[t] - loss[t])
+        # T[t+1] = T[t] + conversion * (sense_coeff*raw_heat[t] - demand[t] - loss[t])
+        # In cool mode (sense_coeff = -1) running a source LOWERS the tank temperature.
         constraints.append(
             predicted_temp[1:]
             == predicted_temp[:-1]
-            + conversion * (raw_heat - heating_demand[:-1] - thermal_losses[:-1])
+            + conversion * (sense_coeff * raw_heat - heating_demand[:-1] - thermal_losses[:-1])
         )
 
         # Hard min/max temperature constraints (skipping index 0 - already pinned)
@@ -2754,7 +2767,66 @@ class Optimization:
             max_vals = np.array([max_temperatures_list[i] for i in max_idx])
             constraints.append(predicted_temp[max_idx] <= max_vals)
 
-        return predicted_temp, heating_demand
+        # Soft comfort constraints (overshoot/desired/penalty) — same pattern as the
+        # per-load thermal_battery path. Without this the hard min/max are the ONLY
+        # temperature pressure, so in cool mode the zone drifts up to (just under) the
+        # hard max and no cooling is ever scheduled. The signed penalty creates the
+        # incentive to hold the tank near `desired_temperatures` in the comfort sense.
+        penalty_expr = 0
+        desired_temps_raw = tank.get("desired_temperatures", [])
+        # The compiler may store a scalar desired_temperature; broadcast to horizon.
+        if isinstance(desired_temps_raw, (int, float)):
+            desired_temps_list = [float(desired_temps_raw)] * required_len
+        else:
+            desired_temps_list = list(desired_temps_raw)
+        overshoot_temperature = tank.get("overshoot_temperature", None)
+
+        if desired_temps_list and overshoot_temperature is not None:
+            is_overshoot = cp.Variable(
+                required_len, boolean=True, name=f"is_overshoot_shared_{tank_id}"
+            )
+            big_m = 100
+
+            if tank_sense == "heat":
+                constraints.append(
+                    predicted_temp - overshoot_temperature - (big_m * is_overshoot) <= 0
+                )
+                constraints.append(
+                    predicted_temp - overshoot_temperature + (big_m * (1 - is_overshoot)) >= 0
+                )
+            else:
+                constraints.append(
+                    predicted_temp - overshoot_temperature - (-big_m * is_overshoot) >= 0
+                )
+                constraints.append(
+                    predicted_temp - overshoot_temperature + (-big_m * (1 - is_overshoot)) <= 0
+                )
+
+            # Suppress every member source while the tank is in the comfortable region.
+            for k in load_ids:
+                nominal_power = self.optim_conf["nominal_power_of_deferrable_loads"][k]
+                if isinstance(nominal_power, list):
+                    nominal_power = max(nominal_power)
+                constraints.append(
+                    self.vars["p_deferrable"][k] <= nominal_power * (1 - is_overshoot)
+                )
+
+        if desired_temps_list:
+            penalty_factor = tank.get("penalty_factor", 10)
+            valid_indices = [
+                i
+                for i, val in enumerate(desired_temps_list)
+                if val is not None and 0 < i < required_len
+            ]
+            if valid_indices:
+                des_temps = np.array([desired_temps_list[i] for i in valid_indices])
+                # deviation in the comfort sense: heat penalises T < desired,
+                # cool penalises T > desired (sense_coeff = -1 flips the sign).
+                deviation = (predicted_temp[valid_indices] - des_temps) * sense_coeff
+                penalty_expr = -cp.pos(-deviation * penalty_factor)
+
+        penalty_term = None if isinstance(penalty_expr, int) else cp.sum(penalty_expr)
+        return predicted_temp, heating_demand, penalty_term
 
     def _add_deferrable_load_constraints(
         self,
@@ -3286,9 +3358,11 @@ class Optimization:
         # shared tank is fed by N >= 1 deferrable loads; their per-load
         # thermal_battery dynamics were skipped above.
         for tank_idx, tank in enumerate(self._get_shared_thermal_tanks()):
-            shared_pred_temp, shared_demand = self._add_shared_thermal_tank_constraints(
-                constraints, tank_idx, data_opt, p_load
+            shared_pred_temp, shared_demand, shared_penalty = (
+                self._add_shared_thermal_tank_constraints(constraints, tank_idx, data_opt, p_load)
             )
+            if shared_penalty is not None:
+                penalty_terms_total += shared_penalty
             if shared_pred_temp is not None:
                 # Surface the tank state on the first member load so downstream
                 # publishing has a temperature column to report. Subsequent

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -647,6 +647,13 @@ def compile_heat_topology(topology: dict) -> dict:
                 "recognised. Allowed types: heatpump, heat_pump, gas, oil, "
                 "district, electric, constant_efficiency."
             )
+        # Propagate the target storage's comfort_sense onto the source block so the
+        # COP resolver computes the correct (heating vs cooling) Carnot lift. Without
+        # this, resolve_thermal_battery_cop defaults to "heat" and clamps the cooling
+        # COP to 1.0 on a warm day (a heat pump can then never cool the zone).
+        target_storage = sto_by_id.get(f["to"], {})
+        if "comfort_sense" in target_storage:
+            source_block["sense"] = str(target_storage["comfort_sense"]).lower()
         is_electric_load.append(bool(src.get("electric", type_is_electric.get(src_type, True))))
         def_load_config.append({"thermal_source": source_block})
         # Cost track resolution

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -3483,6 +3483,69 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         total = res["P_deferrable0"].sum() + res["P_deferrable1"].sum()
         self.assertGreater(total, 0, "Window outside horizon gagged the shared-tank members")
 
+    def test_shared_thermal_tank_cooling_schedules(self):
+        """A shared-tank heat-pump source feeding a comfort_sense: cool zone must
+        actively cool. With a warm outdoor forecast and a desired temperature below
+        the start, the source should run (>0 W) and pull the zone below its start.
+        Before the fix the shared-tank dynamics added source heat with a fixed +
+        sign (no sense_coeff) and built no comfort penalty, so the source stayed at
+        0 W and the zone drifted up toward the hard max instead of cooling."""
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        self.df_input_data_dayahead["outdoor_temperature_forecast"] = [33.0] * 48
+        self.optim_conf["number_of_deferrable_loads"] = 1
+        self.optim_conf["nominal_power_of_deferrable_loads"] = [2100]
+        self.optim_conf["minimum_power_of_deferrable_loads"] = [0]
+        self.optim_conf["operating_hours_of_each_deferrable_load"] = [0]
+        self.optim_conf["treat_deferrable_load_as_semi_cont"] = [False]
+        self.optim_conf["set_deferrable_load_single_constant"] = [False]
+        self.optim_conf["set_deferrable_startup_penalty"] = [0.0]
+        self.optim_conf["set_deferrable_max_startups"] = [0]
+        self.optim_conf["start_timesteps_of_each_deferrable_load"] = [0]
+        self.optim_conf["end_timesteps_of_each_deferrable_load"] = [0]
+        self.optim_conf["def_load_config"] = [
+            {
+                "thermal_source": {
+                    "supply_temperature": 18.0,
+                    "carnot_efficiency": 0.35,
+                    "sense": "cool",
+                }
+            },
+        ]
+        self.optim_conf["shared_thermal_tanks"] = [
+            {
+                "id": "zone",
+                "load_ids": [0],
+                "volume": 0.20,
+                "density": 1000,
+                "heat_capacity": 4.186,
+                "start_temperature": 24.0,
+                "thermal_loss": 0.30,
+                "sense": "cool",
+                "min_temperatures": [10.0] * 48,
+                "max_temperatures": [28.0] * 48,
+                "desired_temperatures": [22.0] * 48,
+                "penalty_factor": 10,
+            }
+        ]
+        opt = self.create_optimization()
+        ulc = self.df_input_data_dayahead[opt.var_load_cost].values
+        upp = self.df_input_data_dayahead[opt.var_prod_price].values
+        res = opt.perform_optimization(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast.values.ravel(),
+            self.p_load_forecast.values.ravel(),
+            ulc,
+            upp,
+        )
+        self.assertEqual(opt.optim_status, "Optimal")
+        # The cooling source actually runs (0 W before the fix).
+        self.assertGreater(res["P_deferrable0"].sum(), 0, "cooling source never ran")
+        tank_cols = [c for c in res.columns if "temp_shared_zone" in c or "temp_heater" in c]
+        self.assertTrue(tank_cols, f"Expected a tank temp column, got {res.columns.tolist()}")
+        pred = res[tank_cols[0]]
+        # Cooling holds the zone below its 24 C start (it drifts up without the fix).
+        self.assertLess(pred.mean(), 24.0, "zone was not cooled (drifted up instead)")
+
     def test_is_electric_load_excludes_load_from_grid_balance(self):
         """A load with is_electric_load[k]=False must not appear in p_def_sum
         (and hence not in grid_pos / grid_neg balance constraints).

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3502,6 +3502,41 @@ class TestCompileHeatTopology(unittest.TestCase):
         self.assertEqual(tank["penalty_factor"], 5.0)
         self.assertEqual(tank["sense"], "heat")
 
+    def test_storage_comfort_sense_propagates_to_source(self):
+        """A heat-pump source feeding a `comfort_sense: cool` storage must receive
+        sense="cool" on its compiled thermal_source block, so
+        resolve_thermal_battery_cop computes the cooling COP instead of defaulting
+        to "heat" and clamping the COP to 1.0 on a warm day (outdoor >= supply)."""
+        topo = {
+            "sources": [
+                {
+                    "id": "hp",
+                    "type": "heatpump",
+                    "supply_temperature": 18,
+                    "carnot_efficiency": 0.35,
+                    "nominal_power": 2100,
+                    "min_power": 250,
+                }
+            ],
+            "storage": [
+                {
+                    "id": "zone",
+                    "volume": 0.2,
+                    "start_temperature": 24,
+                    "min_temperatures": [10] * 48,
+                    "max_temperatures": [28] * 48,
+                    "comfort_sense": "cool",
+                }
+            ],
+            "flows": [{"from": "hp", "to": "zone"}],
+        }
+        out = utils.compile_heat_topology(topo)
+        source = out["def_load_config"][0]["thermal_source"]
+        self.assertEqual(source.get("sense"), "cool")
+        # On a warm day the cooling COP must not collapse to the clamped 1.0.
+        cop = utils.resolve_thermal_battery_cop(source, [31.0] * 48, length=48)
+        self.assertGreater(cop[0], 1.5)
+
     def test_storage_soft_comfort_scalar_desired_temperature(self):
         """Scalar `desired_temperature` is accepted and stored as a float."""
         topo = {


### PR DESCRIPTION
Fixes #991. On a `heat_topology` (shared-tank) setup, a heat-pump source feeding a `comfort_sense: cool` zone never schedules cooling — it sits at 0 W, or goes infeasible on a hot day.

Three small things in the shared-tank path that the per-load thermal paths already handle (#888/#898):

- the source COP was clamped to 1.0 because `compile_heat_topology` didn't pass the zone's `comfort_sense` down to the source — now it does;
- the tank dynamics used a fixed `+` sign, so a source could only ever heat — added the `sense_coeff` the per-load paths use;
- there was no penalty toward `desired_temperatures`, so idling was cost-optimal — added the same directional comfort penalty.

Builds on #975 (now merged), which keeps a shared-tank source active so it can schedule at all — this adds the cooling behaviour on top. Reproducer tests are included and the heating path is unchanged. Running it on a Daikin Altherma 3 + underfloor.

Happy to adjust the approach if you'd rather handle any of these differently.