### PR TITLE
feat(api): add GET /api/v1/plan structured plan output

### DIFF
--- a/docs/api/v1/plan.schema.json
+++ b/docs/api/v1/plan.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://emhass.github.io/api/v1/plan.schema.json",
+  "title": "EMHASS /api/v1/plan response",
+  "description": "Response shape for GET /api/v1/plan. The latest optimization plan as JSON records. Columns follow docs/plan_output_schema.md (versioned by emhass_schema_version).",
+  "type": "object",
+  "required": ["status", "generated_at", "emhass_schema_version", "plan"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["no-run", "ok"],
+      "description": "Discriminator: 'no-run' before any optimization, 'ok' once a plan exists."
+    },
+    "generated_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 UTC instant the optimization that produced this plan completed. Equals /api/v1/last-run's timestamp for the same run. Null when status='no-run'."
+    },
+    "emhass_schema_version": {
+      "type": ["string", "null"],
+      "description": "EMHASS_SCHEMA_VERSION. The plan columns follow docs/plan_output_schema.md at this version."
+    },
+    "plan": {
+      "type": ["array", "null"],
+      "items": {"type": "object"},
+      "description": "Per-timestep optimization records (one object per timestep; columns per docs/plan_output_schema.md, plus a 'timestamp' field). Null when status='no-run'."
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"status": {"const": "no-run"}}, "required": ["status"]},
+      "then": {"properties": {"generated_at": {"const": null}, "plan": {"const": null}}}
+    }
+  ]
+}

--- a/docs/api/v1/plan.schema.json
+++ b/docs/api/v1/plan.schema.json
@@ -23,7 +23,7 @@
     "plan": {
       "type": ["array", "null"],
       "items": {"type": "object"},
-      "description": "Per-timestep optimization records (one object per timestep; columns per docs/plan_output_schema.md, plus a 'timestamp' field). Null when status='no-run'."
+      "description": "Per-timestep optimization records (one object per timestep; columns per docs/plan_output_schema.md, plus a 'timestamp' field). Each record's 'timestamp' is an ISO 8601 UTC instant (Z suffix), the same instant the CSV export and HA publish use, not the configured local timezone — align consumers on UTC, like generated_at. Null when status='no-run'."
     }
   },
   "allOf": [

--- a/prek.toml
+++ b/prek.toml
@@ -30,4 +30,4 @@ name = "regenerate openapi.json from param_definitions"
 entry = "python scripts/generate_openapi.py"
 language = "system"
 pass_filenames = false
-files = '^(src/emhass/static/data/param_definitions\.json|scripts/generate_openapi\.py|docs/api/v1/last-run\.schema\.json|docs/api/healthz\.schema\.json)$'
+files = '^(src/emhass/static/data/param_definitions\.json|scripts/generate_openapi\.py|docs/api/v1/last-run\.schema\.json|docs/api/v1/plan\.schema\.json|docs/api/healthz\.schema\.json)$'

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -22,6 +22,7 @@ CURATED = {
     "/get-json": {"POST"},
     "/action/{action_name}": {"POST"},
     "/api/v1/last-run": {"GET"},
+    "/api/v1/plan": {"GET"},
     "/healthz": {"GET"},
 }
 
@@ -118,6 +119,7 @@ def assert_no_undocumented(routes: set, curated: dict, skip: set) -> None:
 _REPO = Path(__file__).resolve().parents[1]
 _PARAM_DEFS = _REPO / "src" / "emhass" / "static" / "data" / "param_definitions.json"
 _LAST_RUN_SCHEMA = _REPO / "docs" / "api" / "v1" / "last-run.schema.json"
+_PLAN_SCHEMA = _REPO / "docs" / "api" / "v1" / "plan.schema.json"
 _HEALTHZ_SCHEMA = _REPO / "docs" / "api" / "healthz.schema.json"
 _OUT = _REPO / "src" / "emhass" / "static" / "openapi.json"
 
@@ -146,6 +148,7 @@ def build_spec(routes: set | None = None) -> dict:
     components = {
         "Config": build_config_component(param_defs),
         "LastRun": _load_json(_LAST_RUN_SCHEMA),
+        "Plan": _load_json(_PLAN_SCHEMA),
         "Healthz": _load_json(_HEALTHZ_SCHEMA),
     }
     config_ref = {"$ref": "#/components/schemas/Config"}
@@ -222,6 +225,17 @@ def build_spec(routes: set | None = None) -> dict:
                     "200": {
                         "description": "Last-run envelope",
                         **json_ct({"$ref": "#/components/schemas/LastRun"}),
+                    }
+                },
+            }
+        },
+        "/api/v1/plan": {
+            "get": {
+                "summary": "Latest optimization plan",
+                "responses": {
+                    "200": {
+                        "description": "Plan envelope",
+                        **json_ct({"$ref": "#/components/schemas/Plan"}),
                     }
                 },
             }

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -18,7 +18,7 @@ import numpy as np
 import orjson
 import pandas as pd
 
-from emhass import last_run, utils
+from emhass import last_run, plan_store, utils
 from emhass.forecast import Forecast
 from emhass.machine_learning_forecaster import MLForecaster
 from emhass.machine_learning_regressor import MLRegressor
@@ -51,7 +51,7 @@ def _record_optim_snapshot(
             if isinstance(opt_res, pd.DataFrame) and "optim_status" in opt_res
             else "Unknown"
         )
-        last_run.record(
+        ts = last_run.record(
             input_data_dict["emhass_conf"]["data_path"],
             action=action,
             stage_times=input_data_dict["stage_times"],
@@ -60,6 +60,16 @@ def _record_optim_snapshot(
             duration_total_seconds=_time.monotonic() - t0_monotonic,
             schema_version=EMHASS_SCHEMA_VERSION,
         )
+        # Write the structured plan snapshot reusing the SAME timestamp last_run
+        # stamped, so GET /api/v1/plan and GET /api/v1/last-run agree on the run
+        # instant. Backs the /api/v1/plan endpoint (AC-6).
+        if isinstance(opt_res, pd.DataFrame):
+            plan_store.record(
+                input_data_dict["emhass_conf"]["data_path"],
+                plan=plan_store.serialize(opt_res),
+                generated_at=ts,
+                schema_version=EMHASS_SCHEMA_VERSION,
+            )
     except Exception as exc:  # noqa: BLE001
         logger.warning("last_run: failed to record %s snapshot", action, exc_info=exc)
 

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -60,10 +60,15 @@ def _record_optim_snapshot(
             duration_total_seconds=_time.monotonic() - t0_monotonic,
             schema_version=EMHASS_SCHEMA_VERSION,
         )
-        # Write the structured plan snapshot reusing the SAME timestamp last_run
-        # stamped, so GET /api/v1/plan and GET /api/v1/last-run agree on the run
-        # instant. Backs the /api/v1/plan endpoint (AC-6).
-        if isinstance(opt_res, pd.DataFrame):
+        # Publish the structured plan ONLY for a successful (Optimal) run, reusing
+        # the SAME timestamp last_run stamped so /api/v1/plan's generated_at matches
+        # /api/v1/last-run for that run. Only the timestamp is shared, not the
+        # verdict: a failed/infeasible run is still recorded by last_run (status
+        # error/infeasible) but must not surface on /api/v1/plan as status "ok" —
+        # the plan endpoint keeps serving the last VALID plan (or no-run). Gating on
+        # optim_status == "Optimal" mirrors last_run's own "ok" criterion, so the
+        # two endpoints stay consistent (plan published iff last-run is "ok").
+        if optim_status == "Optimal":
             plan_store.record(
                 input_data_dict["emhass_conf"]["data_path"],
                 plan=plan_store.serialize(opt_res),

--- a/src/emhass/last_run.py
+++ b/src/emhass/last_run.py
@@ -64,7 +64,7 @@ def record(
     duration_total_seconds: float,
     schema_version: str,
     error_message: str | None = None,
-) -> None:
+) -> str:
     """Persist a snapshot after a completed optimization run.
 
     Writes to both the in-memory cache and <data_path>/last_run.json under
@@ -107,6 +107,12 @@ def record(
             target.write_text(payload, encoding="utf-8")
         except OSError as exc:
             _logger.warning("last_run: failed to write snapshot file", exc_info=exc)
+
+    # Return the stamped timestamp so callers (e.g. _record_optim_snapshot)
+    # can reuse the exact same instant for the plan snapshot's generated_at,
+    # keeping /api/v1/last-run and /api/v1/plan in agreement. Existing callers
+    # that ignore the return value are unaffected.
+    return snap["timestamp"]
 
 
 def read(data_path: Path) -> dict | None:

--- a/src/emhass/plan_store.py
+++ b/src/emhass/plan_store.py
@@ -1,0 +1,69 @@
+"""Persistent state for the most-recent EMHASS optimization PLAN.
+
+Backs the GET /api/v1/plan endpoint. Mirrors last_run.py: in-memory cache
+(_cache) + write-through to <data_path>/plan_latest.json, lock-guarded for
+multi-worker Quart deployments. The plan is the opt_res schedule serialized
+to JSON records; generated_at is supplied by the caller (the same timestamp
+last_run.record stamps) so the two endpoints agree.
+"""
+
+import json
+import logging
+import threading
+from pathlib import Path
+
+import pandas as pd
+
+_PLAN_FILENAME = "plan_latest.json"
+_lock = threading.Lock()
+_cache: dict | None = None
+_logger = logging.getLogger(__name__)
+
+
+def _path(data_path: Path) -> Path:
+    return Path(data_path) / _PLAN_FILENAME
+
+
+def serialize(opt_res: pd.DataFrame) -> list[dict]:
+    """opt_res DataFrame -> JSON-safe records (index as 'timestamp', NaN -> null)."""
+    # to_json handles Timestamp -> ISO and NaN -> null; json.loads gives clean dicts.
+    df = opt_res.copy()
+    df.index.name = "timestamp"  # guarantee the reset_index column is 'timestamp', not 'index'
+    return json.loads(df.reset_index().to_json(orient="records", date_format="iso"))
+
+
+def record(data_path: Path, plan: list[dict], generated_at: str, schema_version: str) -> None:
+    """Persist the latest plan snapshot to cache + <data_path>/plan_latest.json.
+
+    Best-effort file write: an OSError is logged-and-swallowed so a disk error
+    never breaks the optimization wrapper's return path.
+    """
+    global _cache
+    snap = {
+        "emhass_schema_version": schema_version,
+        "generated_at": generated_at,
+        "plan": plan,
+    }
+    with _lock:
+        _cache = snap
+        try:
+            _path(data_path).write_text(json.dumps(snap), encoding="utf-8")
+        except OSError as exc:
+            _logger.warning("plan_store: failed to write snapshot file", exc_info=exc)
+
+
+def read(data_path: Path) -> dict | None:
+    """Return the latest plan snapshot, or None if no run yet."""
+    global _cache
+    with _lock:
+        if _cache is not None:
+            return dict(_cache)
+        try:
+            data = json.loads(_path(data_path).read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return None
+        except (OSError, json.JSONDecodeError) as exc:
+            _logger.warning("plan_store: corrupt or unreadable snapshot file", exc_info=exc)
+            return None
+        _cache = data
+        return dict(data)

--- a/src/emhass/static/openapi.json
+++ b/src/emhass/static/openapi.json
@@ -158,6 +158,23 @@
         }
       }
     },
+    "/api/v1/plan": {
+      "get": {
+        "summary": "Latest optimization plan",
+        "responses": {
+          "200": {
+            "description": "Plan envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Plan"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/healthz": {
       "get": {
         "summary": "Liveness/readiness probe",
@@ -1111,6 +1128,76 @@
                   "const": null
                 },
                 "error_message": {
+                  "const": null
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Plan": {
+        "title": "EMHASS /api/v1/plan response",
+        "description": "Response shape for GET /api/v1/plan. The latest optimization plan as JSON records. Columns follow docs/plan_output_schema.md (versioned by emhass_schema_version).",
+        "type": "object",
+        "required": [
+          "status",
+          "generated_at",
+          "emhass_schema_version",
+          "plan"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "no-run",
+              "ok"
+            ],
+            "description": "Discriminator: 'no-run' before any optimization, 'ok' once a plan exists."
+          },
+          "generated_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO 8601 UTC instant the optimization that produced this plan completed. Equals /api/v1/last-run's timestamp for the same run. Null when status='no-run'."
+          },
+          "emhass_schema_version": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "EMHASS_SCHEMA_VERSION. The plan columns follow docs/plan_output_schema.md at this version."
+          },
+          "plan": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object"
+            },
+            "description": "Per-timestep optimization records (one object per timestep; columns per docs/plan_output_schema.md, plus a 'timestamp' field). Null when status='no-run'."
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "status": {
+                  "const": "no-run"
+                }
+              },
+              "required": [
+                "status"
+              ]
+            },
+            "then": {
+              "properties": {
+                "generated_at": {
+                  "const": null
+                },
+                "plan": {
                   "const": null
                 }
               }

--- a/src/emhass/static/openapi.json
+++ b/src/emhass/static/openapi.json
@@ -1177,7 +1177,7 @@
             "items": {
               "type": "object"
             },
-            "description": "Per-timestep optimization records (one object per timestep; columns per docs/plan_output_schema.md, plus a 'timestamp' field). Null when status='no-run'."
+            "description": "Per-timestep optimization records (one object per timestep; columns per docs/plan_output_schema.md, plus a 'timestamp' field). Each record's 'timestamp' is an ISO 8601 UTC instant (Z suffix), the same instant the CSV export and HA publish use, not the configured local timezone — align consumers on UTC, like generated_at. Null when status='no-run'."
           }
         },
         "allOf": [

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -20,7 +20,7 @@ from markupsafe import Markup
 from quart import Quart, make_response, request
 from quart import logging as log
 
-from emhass import last_run
+from emhass import last_run, plan_store
 from emhass.command_line import (
     EMHASS_SCHEMA_VERSION,
     continual_publish,
@@ -670,6 +670,33 @@ async def api_v1_last_run():
         }
     else:
         response_body = snap
+
+    response = await make_response(orjson.dumps(response_body))
+    response.headers["Content-Type"] = "application/json"
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+@app.route("/api/v1/plan", methods=["GET"])
+async def api_v1_plan():
+    """Return the latest optimization plan as structured JSON.
+
+    Always-200 envelope with status enum:
+      - "no-run": no optim has completed yet (state lost on restart with no disk file)
+      - "ok": a plan is available
+
+    Schema: docs/api/v1/plan.schema.json (JSON Schema draft 2020-12).
+    """
+    snap = plan_store.read(emhass_conf["data_path"])
+    if snap is None:
+        response_body = {
+            "status": "no-run",
+            "generated_at": None,
+            "emhass_schema_version": EMHASS_SCHEMA_VERSION,
+            "plan": None,
+        }
+    else:
+        response_body = {"status": "ok", **snap}
 
     response = await make_response(orjson.dumps(response_body))
     response.headers["Content-Type"] = "application/json"

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -1,0 +1,40 @@
+"""Tests for the plan snapshot persistence layer (AC-6, GET /api/v1/plan).
+
+Mirrors the unittest layout of the rest of tests/ so the CI gating job
+(`python -m unittest`) collects them. Covers:
+  - last_run.record() returning the stamped timestamp (Task 1)
+  - plan_store serialize / record / read (Task 2)
+  - _record_optim_snapshot writing the plan with the shared timestamp (Task 3)
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from emhass import last_run
+
+
+class TestLastRunRecordReturn(unittest.TestCase):
+    """last_run.record() returns the ISO timestamp it stamps (single source for AC-6)."""
+
+    def setUp(self):
+        self.tmp_path = Path(tempfile.mkdtemp())
+        last_run._cache = None
+
+    def tearDown(self):
+        last_run._cache = None
+
+    def test_record_returns_stamped_timestamp(self):
+        ts = last_run.record(
+            self.tmp_path,
+            action=last_run.ACTION_DAYAHEAD_OPTIM,
+            stage_times={},
+            optim_status="Optimal",
+            infeasible=False,
+            duration_total_seconds=1.0,
+            schema_version="1.0",
+        )
+        # the returned value is exactly what was persisted as the snapshot timestamp
+        snap = last_run.read(self.tmp_path)
+        self.assertIsNotNone(ts)
+        self.assertEqual(ts, snap["timestamp"])

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -11,7 +11,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from emhass import last_run
+import numpy as np
+import pandas as pd
+
+from emhass import last_run, plan_store
 
 
 class TestLastRunRecordReturn(unittest.TestCase):
@@ -38,3 +41,39 @@ class TestLastRunRecordReturn(unittest.TestCase):
         snap = last_run.read(self.tmp_path)
         self.assertIsNotNone(ts)
         self.assertEqual(ts, snap["timestamp"])
+
+
+class TestPlanStore(unittest.TestCase):
+    """plan_store serialize / record / read (cache + write-through)."""
+
+    def setUp(self):
+        self.tmp_path = Path(tempfile.mkdtemp())
+        plan_store._cache = None
+
+    def tearDown(self):
+        plan_store._cache = None
+
+    def test_serialize_opt_res_records_iso_and_nan(self):
+        idx = pd.to_datetime(["2026-06-17T00:00:00+00:00", "2026-06-17T00:30:00+00:00"], utc=True)
+        idx.name = "timestamp"
+        df = pd.DataFrame(
+            {"P_Load": [100.0, np.nan], "optim_status": ["Optimal", "Optimal"]}, index=idx
+        )
+        records = plan_store.serialize(df)
+        self.assertTrue(records[0]["timestamp"].startswith("2026-06-17T00:00:00"))
+        self.assertEqual(records[0]["P_Load"], 100.0)
+        self.assertIsNone(records[1]["P_Load"])  # NaN -> null
+
+    def test_record_then_read_roundtrip(self):
+        self.assertIsNone(plan_store.read(self.tmp_path))  # cold start, no run yet
+        plan_store.record(
+            self.tmp_path,
+            plan=[{"timestamp": "2026-06-17T00:00:00Z", "P_Load": 100.0}],
+            generated_at="2026-06-17T00:00:05Z",
+            schema_version="1.0",
+        )
+        snap = plan_store.read(self.tmp_path)
+        self.assertEqual(snap["generated_at"], "2026-06-17T00:00:05Z")
+        self.assertEqual(snap["emhass_schema_version"], "1.0")
+        self.assertEqual(snap["plan"][0]["P_Load"], 100.0)
+        self.assertTrue((self.tmp_path / "plan_latest.json").exists())  # write-through

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -116,3 +116,31 @@ class TestRecordOptimSnapshotWritesPlan(unittest.TestCase):
         self.assertEqual(plan["plan"][0]["P_Load"], 100.0)
         # shared timestamp: plan generated_at equals the last_run timestamp
         self.assertEqual(plan["generated_at"], lr["timestamp"])
+
+    def test_record_optim_snapshot_skips_plan_on_non_optimal(self):
+        """A failed/infeasible run is recorded by last_run but must NOT publish a
+        plan: /api/v1/plan would otherwise report status='ok' for the same run
+        that /api/v1/last-run reports as 'infeasible'. The plan is published iff
+        the run is Optimal (i.e. iff last_run's status is 'ok')."""
+        import logging
+
+        from emhass import command_line
+
+        idx = pd.to_datetime(["2026-06-17T00:00:00+00:00"], utc=True)
+        idx.name = "timestamp"
+        opt_res = pd.DataFrame({"P_Load": [100.0], "optim_status": ["Infeasible"]}, index=idx)
+        input_data_dict = {
+            "emhass_conf": {"data_path": self.tmp_path},
+            "stage_times": {},
+        }
+        command_line._record_optim_snapshot(
+            input_data_dict,
+            last_run.ACTION_DAYAHEAD_OPTIM,
+            opt_res,
+            0.0,
+            logging.getLogger("test_plan_store"),
+        )
+        # no plan published for a non-Optimal run
+        self.assertIsNone(plan_store.read(self.tmp_path))
+        # last_run still records the failed run, as 'infeasible'
+        self.assertEqual(last_run.read(self.tmp_path)["status"], "infeasible")

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -77,3 +77,42 @@ class TestPlanStore(unittest.TestCase):
         self.assertEqual(snap["emhass_schema_version"], "1.0")
         self.assertEqual(snap["plan"][0]["P_Load"], 100.0)
         self.assertTrue((self.tmp_path / "plan_latest.json").exists())  # write-through
+
+
+class TestRecordOptimSnapshotWritesPlan(unittest.TestCase):
+    """_record_optim_snapshot writes the plan with generated_at == last_run timestamp."""
+
+    def setUp(self):
+        self.tmp_path = Path(tempfile.mkdtemp())
+        last_run._cache = None
+        plan_store._cache = None
+
+    def tearDown(self):
+        last_run._cache = None
+        plan_store._cache = None
+
+    def test_record_optim_snapshot_writes_plan_with_shared_timestamp(self):
+        import logging
+
+        from emhass import command_line
+
+        idx = pd.to_datetime(["2026-06-17T00:00:00+00:00"], utc=True)
+        idx.name = "timestamp"
+        opt_res = pd.DataFrame({"P_Load": [100.0], "optim_status": ["Optimal"]}, index=idx)
+        input_data_dict = {
+            "emhass_conf": {"data_path": self.tmp_path},
+            "stage_times": {},
+        }
+        command_line._record_optim_snapshot(
+            input_data_dict,
+            last_run.ACTION_DAYAHEAD_OPTIM,
+            opt_res,
+            0.0,
+            logging.getLogger("test_plan_store"),
+        )
+        plan = plan_store.read(self.tmp_path)
+        lr = last_run.read(self.tmp_path)
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan["plan"][0]["P_Load"], 100.0)
+        # shared timestamp: plan generated_at equals the last_run timestamp
+        self.assertEqual(plan["generated_at"], lr["timestamp"])

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -765,6 +765,61 @@ class TestAPIV1LastRun(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(body["error_message"], "Solver failed to converge")
 
 
+class TestAPIV1Plan(unittest.IsolatedAsyncioTestCase):
+    """Integration tests for GET /api/v1/plan (AC-6)."""
+
+    async def asyncSetUp(self):
+        self.client = web_server.app.test_client()
+        self.original_conf = web_server.emhass_conf.copy()
+        self.tmp_path = pathlib.Path(tempfile.mkdtemp())
+        web_server.emhass_conf = {
+            "data_path": self.tmp_path,
+        }
+        from emhass import plan_store
+
+        plan_store._cache = None
+
+    async def asyncTearDown(self):
+        web_server.emhass_conf = self.original_conf
+        from emhass import plan_store
+
+        plan_store._cache = None
+
+    async def test_api_v1_plan_no_run(self):
+        """GET before any optim returns 200 with status='no-run' and null plan."""
+        import json
+
+        resp = await self.client.get("/api/v1/plan")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers.get("Cache-Control"), "no-store")
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["status"], "no-run")
+        self.assertIsNone(body["generated_at"])
+        self.assertIsNone(body["plan"])
+        self.assertIn("emhass_schema_version", body)
+
+    async def test_api_v1_plan_after_record(self):
+        """After plan_store.record() runs, GET returns the plan with status='ok'."""
+        import json
+
+        from emhass import plan_store
+
+        plan_store.record(
+            self.tmp_path,
+            plan=[{"timestamp": "2026-06-17T00:00:00Z", "P_Load": 100.0}],
+            generated_at="2026-06-17T00:00:05Z",
+            schema_version="1.0",
+        )
+
+        resp = await self.client.get("/api/v1/plan")
+        self.assertEqual(resp.status_code, 200)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["generated_at"], "2026-06-17T00:00:05Z")
+        self.assertEqual(body["emhass_schema_version"], "1.0")
+        self.assertEqual(body["plan"][0]["P_Load"], 100.0)
+
+
 class TestHealthVerdict(unittest.TestCase):
     """Unit tests for the pure _health_verdict helper (AC-4). Recency-only."""
 


### PR DESCRIPTION
## Summary
Adds a read-only `GET /api/v1/plan` returning the latest optimization result (`opt_res`) as machine-readable JSON (records + `generated_at` + `emhass_schema_version`), with a no-run discriminator before the first solve. Mirrors `GET /api/v1/last-run`: a small `plan_store` module persists the latest plan to `<data_path>/plan_latest.json` at optim-completion, reusing the timestamp `last_run.record` stamps so the two endpoints agree. Today `/action/*` returns only a plain-text ack and the schedule reaches consumers via the HA publish or `opt_res_latest.csv`; this exposes the structured plan the schema (`docs/plan_output_schema.md`) already documents. Read-only, additive, non-breaking; the core stays stateless.

## Test plan
- [ ] `plan_store` unit tests: serialize (ISO timestamps, NaN -> null), record/read roundtrip, no-run
- [ ] `_record_optim_snapshot` writes the plan with `generated_at` == the `last_run` timestamp
- [ ] `GET /api/v1/plan`: no-run discriminator cold, then the plan after a run
- [ ] `test_committed_matches_generated` green (openapi.json includes `/api/v1/plan`)
- [ ] `/action/*`, HA publish, and `opt_res_latest.csv` behaviour unchanged

## Summary by Sourcery

Add persistent storage and an API endpoint to expose the latest successful optimization plan as structured JSON, aligned with existing last-run metadata and OpenAPI documentation.

New Features:
- Expose the latest optimization plan via a new read-only GET /api/v1/plan endpoint returning a structured JSON envelope and plan payload.
- Persist the latest optimization plan snapshot to disk and memory using a new plan_store module backed by plan_latest.json.

Enhancements:
- Return the stamped timestamp from last_run.record so other components can reuse it when recording related artifacts like plans.
- Record the optimization plan only for successful (Optimal) runs, keeping the plan data consistent with last-run status semantics.
- Extend OpenAPI generation and static spec to document the new /api/v1/plan endpoint and its schema.
- Update the optimization snapshot recording flow to emit a structured plan snapshot alongside last-run metadata while preserving existing behavior for failed runs.

Build:
- Update prek configuration so OpenAPI regeneration is triggered when the new plan schema or related API docs change.

Documentation:
- Introduce a JSON Schema document defining the /api/v1/plan response shape and wire it into the documented API surface.

Tests:
- Add integration tests for GET /api/v1/plan covering cold no-run state and post-record behavior.
- Add unit tests for the plan_store persistence layer, including DataFrame serialization, disk write-through, and read roundtrips.
- Add tests verifying last_run.record returns the stamped timestamp and that _record_optim_snapshot writes or skips plans appropriately based on optimization status.