### PR TITLE
feat: carry over completed operating timesteps for must-run deferrables (closes #983)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -161,6 +161,19 @@ Example:
   **Single-constant, sequence and thermal loads** ignore `def_current_power` (it is a no-op for those load types). A single-constant load runs as one fixed block, so its currently-running state is handled by `def_current_state` (which pins the remaining required timesteps); pinning a below-nominal power there would fight the required-energy target. Use `def_current_state` for a currently-running single-constant load.
 
   **Typical MPC use:** read the load's power sensor at the start of each optimization tick and pass the reading in watts via the runtime API so the optimizer knows the load is running and at what level.
+- `def_current_operating_timesteps`: Per-load integer list: how many operating timesteps each must-run deferrable load has already completed today at the start of this optimization horizon. The optimizer schedules only the REMAINDER: `required_timesteps` and `target_energy` are each decremented by the elapsed amount, clamped at 0. **Default `null` (absent key) or `[0, 0]` is an exact no-op** -- today's plan is unchanged. One non-negative integer per deferrable load, in the same order as `nominal_power_of_deferrable_loads`.
+
+  Unit: timesteps. Convert from time: `elapsed_hours / optimization_time_step`. With the default 30-minute step, 2 elapsed hours = 4 timesteps.
+
+  Applies to **both standard and single_constant must-run loads** (unlike `def_current_on_timesteps` which is gated on `def_minimum_on_time > 0` and excluded for single_constant loads). If a load has no required operating hours configured (`operating_hours_of_each_deferrable_load[k] == 0`), the elapsed value is ignored.
+
+  When the elapsed count equals or exceeds the total required timesteps, the remainder clamps to 0 and the constraint is fully relaxed -- the load is no longer forced to run in this tick, and the solve stays Optimal.
+
+  **Interaction with `def_current_state`:** if you also pass `def_current_state[k]=true` for a single_constant load, the optimizer uses both signals: the currently-running pin (block A) uses the *decremented* `required_timesteps`, so the running-block anchor also shrinks automatically.
+
+  **Daily reset boundary:** EMHASS does not track wall-clock day rollover. The caller (supervisor / automation) is responsible for resetting the elapsed count to 0 at the start of each day, exactly as with `def_current_on_timesteps` and `def_current_power`.
+
+  **Typical MPC use:** at each optimization tick, read the load's run-time counter (e.g. from a Home Assistant energy meter or runtime helper) and pass the elapsed timesteps so the optimizer schedules only the outstanding run.
 - `deferrable_load_max_cost`: Make a deferrable load *optional* by capping how much it may cost to run. This is a list of floats, one value per deferrable load, in the same currency units as your load cost forecast. The default `0` keeps a load **mandatory**: the optimizer must deliver its full `operating_hours_of_each_deferrable_load` of energy within the horizon, as it always has. A value above `0` makes the load **optional**: the optimizer schedules it only when its complete run can be done for less than that amount (the cost of the energy it consumes plus any `set_deferrable_startup_penalty`), otherwise the load is left off for the whole horizon. This suits a "nice to have" load that is only worth running when energy is cheap enough, for example a heat pump boosting hot water above its normal setpoint, or an immersion heater that should only soak up surplus when prices are very low. The cap is an all-or-nothing budget for the load's entire run, not a per-timestep price limit. It applies to every deferrable load type (standard, semi-continuous, single-constant and sequence loads) except thermal loads configured with a `thermal_config` or `thermal_battery`, which follow their own temperature targets instead. For example:
 	```json
 	"deferrable_load_max_cost": [0, 0.65]

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -275,6 +275,9 @@ class OptimizationCache:
             "def_current_off_timesteps",
             # Per-call current power in watts (issue #605); pin value is a cp.Parameter.
             "def_current_power",
+            # Per-call completed operating timesteps today (issue #983); decrements
+            # required_timesteps + target_energy via cp.Parameter (no rebuild on cache hit).
+            "def_current_operating_timesteps",
             "minimum_power_of_deferrable_loads",
             "cost_forecast_per_deferrable_load",
             # shared_thermal_tanks has its own structural hash field above

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -414,6 +414,16 @@ class Optimization:
             active.value = 0.0
             self.param_def_current_power_active.append(active)
 
+        # Completed operating-timesteps parameters (issue #983).
+        # param_current_operating_timesteps[k]: how many operating timesteps load k has
+        # already run today. Used to decrement required_timesteps and target_energy in the
+        # per-solve param-update block, clamped at 0. Absent key -> no decrement (no-op).
+        self.param_current_operating_timesteps = []
+        for k in range(num_def_loads):
+            cotp = cp.Parameter(nonneg=True, name=f"current_operating_timesteps_{k}")
+            cotp.value = 0.0
+            self.param_current_operating_timesteps.append(cotp)
+
         # Load active parameters: allows deactivating non-thermal loads with 0 operating
         # timesteps without rebuilding the problem. When param_load_active[k] = 0, all
         # binary variables for load k are forced to 0 by constraints, letting the solver
@@ -844,6 +854,44 @@ class Optimization:
                 self.param_def_current_state[k].value = max(
                     self.param_def_current_state[k].value, 1.0
                 )
+
+    def _update_def_current_operating_timesteps_params(self, num_def_loads: int) -> None:
+        """Update def_current_operating_timesteps CVXPY Parameters from optim_conf (issue #983).
+
+        Reads ``optim_conf["def_current_operating_timesteps"]`` (a per-load list of
+        non-negative integers representing how many operating timesteps each must-run load
+        has already completed today) and writes the values into
+        ``self.param_current_operating_timesteps``.
+
+        When the key is absent from optim_conf all parameters reset to 0.0, which is an
+        exact no-op (no decrement applied). The actual decrement of ``required_timesteps``
+        and ``target_energy`` is applied in the per-solve param-update loop using the
+        parameter values set here.
+
+        A length mismatch is warned and handled gracefully: extra entries are ignored,
+        missing ones are assumed 0 (no decrement for that load).
+        """
+        if "def_current_operating_timesteps" not in self.optim_conf:
+            for k in range(min(num_def_loads, len(self.param_current_operating_timesteps))):
+                self.param_current_operating_timesteps[k].value = 0.0
+            return
+
+        cots_conf = self.optim_conf["def_current_operating_timesteps"]
+        n_conf = len(cots_conf)
+        if n_conf != num_def_loads:
+            self.logger.warning(
+                "def_current_operating_timesteps length mismatch: "
+                "num_deferrable_loads=%d, len(def_current_operating_timesteps)=%d; "
+                "extra entries will be ignored or missing ones assumed 0",
+                num_def_loads,
+                n_conf,
+            )
+
+        for k in range(num_def_loads):
+            val = cots_conf[k] if k < n_conf else 0
+            elapsed = self._coerce_nonneg_timesteps(val, k, "def_current_operating_timesteps")
+            if k < len(self.param_current_operating_timesteps):
+                self.param_current_operating_timesteps[k].value = float(elapsed)
 
     def update_battery_power_limits(self, plant_conf: dict) -> None:
         """
@@ -3906,10 +3954,23 @@ class Optimization:
         # Update def_current_power (issue #605): runs AFTER _update_def_current_state_params
         # so it can bump param_def_current_state to suppress the phantom t=0 startup.
         self._update_def_current_power_params(num_deferrable_loads)
+        # Update def_current_operating_timesteps (issue #983): stores the elapsed completed
+        # operating timesteps so the per-load loop below can decrement required_timesteps
+        # and target_energy accordingly.
+        self._update_def_current_operating_timesteps_params(num_deferrable_loads)
 
         # Shared-tank members are temperature-driven; used below to exempt them
         # from the operating-timestep deactivation in the param_load_active loop.
         shared_tank_membership = self._load_shared_tank_membership()
+
+        # Loads whose must-run requirement is fully satisfied by the COTS decrement
+        # (issue #983): elapsed completed timesteps >= required, so remaining clamps
+        # to 0. Such a load MUST be released (treated as a load with no operating
+        # requirement) -- otherwise the param_load_active loop keeps it active
+        # (has_operating_requirement is True from def_total_hours/timestep) and the
+        # single-constant startup constraint forces a phantom extra block. Populated
+        # in the decrement branch below; consumed by the param_load_active loop.
+        cots_satisfied_loads = set()
 
         # Update Energy Constraint Parameters for Deferrable Loads
         # These control the Big-M relaxation of energy/timestep constraints
@@ -3939,6 +4000,57 @@ class Optimization:
                 required_timesteps = 0
                 target_energy = 0.0
                 constraint_active = False
+
+            # Apply completed-operating-timesteps decrement (issue #983).
+            # If the caller signals that the load has already run for some timesteps
+            # today, reduce the remaining required run and energy proportionally.
+            # Clamped at 0 so an elapsed >= required never produces negative values
+            # or an infeasible model.  Applies to both standard and single_constant
+            # must-run loads (no is_single_const gate -- that is the whole point of
+            # this param vs def_current_on_timesteps which is gated not is_single_const).
+            if (
+                k < len(self.param_current_operating_timesteps)
+                and self.param_current_operating_timesteps[k].value > 0
+                and constraint_active
+            ):
+                elapsed_steps = int(self.param_current_operating_timesteps[k].value)
+                required_timesteps = max(0, required_timesteps - elapsed_steps)
+                # target_energy units: W * h  (nominal_power in W, time_step in h)
+                target_energy = max(
+                    0.0, target_energy - elapsed_steps * nominal_power * self.time_step
+                )
+                # If the decrement reduces required to 0, fully relax the constraint
+                # so the load is not forced to run.
+                if required_timesteps == 0:
+                    constraint_active = False
+                    # The must-run requirement is now MET. Record the load so the
+                    # param_load_active loop deactivates it (param_load_active=0),
+                    # the same as a load with no operating requirement -- otherwise
+                    # the single-constant startup constraint
+                    # (sum(p_def_start) == param_load_active - already_running)
+                    # would still force a phantom startup block. This branch only
+                    # runs when constraint_active was True, which already excludes
+                    # thermal / shared-tank / sequence loads (their energy/timestep
+                    # constraints are skipped), but the param_load_active loop guards
+                    # those cases again for safety.
+                    cots_satisfied_loads.add(k)
+                    # CRITICAL INTERACTION with def_current_power (issue #982/#605):
+                    # a currently-running load may also have def_current_power[k] > 0,
+                    # which (for pin-eligible loads) PINS p_deferrable[k][0] to that
+                    # wattage and force-ON's bin2[k][0] via _def_current_power_affected.
+                    # With param_load_active=0 the load is bounded to 0 W for the whole
+                    # horizon (p_def_bin2 <= 0 and p_deferrable <= M*0), so the t=0
+                    # force-on / pin would conflict and make the model INFEASIBLE.
+                    # A target-MET load must be allowed to turn off, so release the
+                    # current-power pin and force-on for it (the t0 pin is treated as
+                    # released for COTS-satisfied loads). Single_const loads are never
+                    # affected by def_current_power anyway (excluded in
+                    # _update_def_current_power_params), so this is a no-op for them and
+                    # only matters for a standard (semi_cont) COTS-satisfied load.
+                    if k < len(self._def_current_power_affected):
+                        self._def_current_power_affected[k] = False
+                    if k < len(self.param_def_current_power_active):
+                        self.param_def_current_power_active[k].value = 0.0
 
             # Set energy constraint parameters. Force-relax the constraint if
             # the load's configured window is entirely outside the horizon
@@ -4041,10 +4153,19 @@ class Optimization:
                 )
                 # Only fire when load is ON, N > 0, NOT single-constant (those use
                 # their own currently-running pin), and elapsed is explicitly supplied.
+                # COTS-satisfied loads (issue #983) are RELEASED from every force-on
+                # mechanism: the param_load_active loop deactivates them
+                # (param_load_active=0 => bin2<=0), so a min-on force-on here
+                # (param_running_lb => bin2>=1) would conflict and make the MILP
+                # INFEASIBLE (rescued only by the global relaxed-LP fallback, which
+                # degrades the whole solve). A target-MET load must be free to turn
+                # off, so skip Block B for it (mirrors Block A's required_timesteps>0
+                # gate and the def_current_power release above).
                 if (
                     current_state
                     and min_on_n > 0
                     and not is_single_const
+                    and k not in cots_satisfied_loads
                     and "def_current_on_timesteps" in self.optim_conf
                     and k < len(self.optim_conf["def_current_on_timesteps"])
                 ):
@@ -4227,6 +4348,19 @@ class Optimization:
                         "constraints drive this load).",
                         k,
                     )
+            elif k in cots_satisfied_loads and not is_sequence:
+                # COTS decrement fully satisfied this must-run load (issue #983):
+                # remaining required clamped to 0. Deactivate it exactly like a load
+                # with no operating requirement so the single-constant startup
+                # constraint does not force a phantom block. is_thermal is already
+                # handled above; guard is_sequence here too (sequence loads never
+                # enter the decrement branch -- their energy constraint is exempt --
+                # so cots_satisfied_loads can't contain one, but stay defensive).
+                self.param_load_active[k].value = 0.0
+                self.logger.debug(
+                    f"Deferrable load {k}: deactivated (operating requirement met "
+                    "by def_current_operating_timesteps, issue #983)"
+                )
             elif (has_operating_requirement or is_sequence) and not window_outside_horizon:
                 self.param_load_active[k].value = 1.0
             else:

--- a/src/emhass/static/data/runtime_params.json
+++ b/src/emhass/static/data/runtime_params.json
@@ -111,6 +111,13 @@
       "default_value": null,
       "unit": "W"
     },
+    "def_current_operating_timesteps": {
+      "friendly_name": "Completed operating timesteps of deferrable loads",
+      "Description": "Per-load integer list: how many operating timesteps each must-run deferrable load has already completed today at the start of this optimization horizon. The optimizer schedules only the REMAINDER: required_timesteps and target_energy are each decremented by the elapsed amount, clamped at 0. Applies to both standard and single_constant must-run loads. Default null (absent key) is an exact no-op -- today's plan is unchanged. Example: if a load requires 6 timesteps total and has already run for 2, only 4 remain for this solve. One non-negative integer per deferrable load, in the same order as nominal_power_of_deferrable_loads. The daily reset boundary is the caller's responsibility (EMHASS does not track wall-clock day rollover). Runtime-overridable on every optimization tick without a cache rebuild. Related to issue #983.",
+      "input": "array.int",
+      "default_value": null,
+      "unit": "timesteps"
+    },
     "def_load_config": {
       "friendly_name": "Deferrable load special config",
       "Description": "Per-deferrable-load special configuration carrying the thermal_config / thermal_battery models. Deep, evolving nested schema; not inlined here. See the linked documentation for the full structure.",

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1979,6 +1979,24 @@ async def treat_runtimeparams(
             else:
                 params["optim_conf"]["def_current_power"] = [float(dcp)] * n_loads
 
+        # def_current_operating_timesteps: per-load completed operating timesteps today (issue #983).
+        # Absent key -> no decrement (NOT assumed zero). Mirrors def_current_on_timesteps.
+        if "def_current_operating_timesteps" in runtimeparams:
+            dcots = runtimeparams["def_current_operating_timesteps"]
+            # String -> parse JSON list
+            if isinstance(dcots, str):
+                try:
+                    dcots = orjson.loads(dcots)
+                except Exception:
+                    logger.warning(
+                        f"Could not parse def_current_operating_timesteps string: {dcots}"
+                    )
+            n_loads = len(params["optim_conf"]["nominal_power_of_deferrable_loads"])
+            if isinstance(dcots, list):
+                params["optim_conf"]["def_current_operating_timesteps"] = [int(v) for v in dcots]
+            else:
+                params["optim_conf"]["def_current_operating_timesteps"] = [int(dcots)] * n_loads
+
         # set_deferrable_load_single_constant arrives via the generic associations.csv
         # path as-is (may be a list of strings from runtimeparams JSON).  Apply the
         # same _cast_bool coercion so 'False' → False, not True (#873, mirrors #876).

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -8144,6 +8144,444 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             err_msg="def_current_power changed a single_const load (must be ignored)",
         )
 
+    # ---------------------------------------------------------------------------
+    # Tests for def_current_operating_timesteps (issue #983)
+    # Runtime-only, per-load "completed operating timesteps today" signal that
+    # DECREMENTS the remaining required run (required_timesteps + target_energy).
+    # Applies to both standard and single_constant must-run loads.
+    # All tests are base-safe: they read the new config key via optim_conf dict
+    # so no AttributeError on base code. RED tests fail on the BEHAVIOURAL
+    # assertion (full block scheduled instead of remainder), not on an exception.
+    # ---------------------------------------------------------------------------
+
+    def _make_cots_overrides(self, is_single_const=True, operating_hours=3.0, **extra):
+        """Return a base optim_conf override dict for def_current_operating_timesteps tests.
+
+        Default: single_constant load with 3 h required (= 6 timesteps at 30 min).
+        Pass is_single_const=False for a standard (semi_cont) load test.
+        """
+        base = {
+            "costfun": "cost",
+            "number_of_deferrable_loads": 2,
+            "nominal_power_of_deferrable_loads": [3000.0, 750.0],
+            "minimum_power_of_deferrable_loads": [0.0, 0.0],
+            "operating_hours_of_each_deferrable_load": [operating_hours, 0.0],
+            "treat_deferrable_load_as_semi_cont": [not is_single_const, True],
+            "set_deferrable_load_single_constant": [is_single_const, False],
+            "set_deferrable_startup_penalty": [0.0, 0.0],
+            "set_deferrable_max_startups": [0, 0],
+            "start_timesteps_of_each_deferrable_load": [0, 0],
+            "end_timesteps_of_each_deferrable_load": [0, 0],
+            "def_load_config": [],
+            "deferrable_load_groups": [],
+            "set_use_battery": False,
+        }
+        base.update(extra)
+        return base
+
+    def test_current_operating_timesteps_single_const_red(self):
+        """RED (issue #983): single_constant load with elapsed > 0 schedules only remainder.
+
+        A must-run single_constant load requires 6 timesteps (3 h at 30 min). When
+        def_current_operating_timesteps=[2, 0], only 4 timesteps remain. The optimizer
+        must schedule exactly 4 timesteps (sum(bin2_0) == 4).
+
+        Base code: ignores def_current_operating_timesteps -> schedules the full 6
+        timesteps (sum(bin2_0) == 6). This test FAILS on the assertEqual on base code
+        (gets 6, not 4), NOT on an Attribute/KeyError, so it is RED-on-base-safe.
+        """
+        n = 10
+        # Flat prices so the optimizer is indifferent and schedules the full block.
+        prices = [0.2] * n
+        df = self._make_min_on_scenario(n=n, prices=prices)
+
+        # Counterfactual: without elapsed, full 6 timesteps scheduled.
+        base = self._make_cots_overrides(
+            is_single_const=True,
+            operating_hours=3.0,
+        )
+        _opt_base, res_base = self._run_min_on_optim(base, df, n)
+        self.assertIn(
+            _opt_base.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"Counterfactual solve non-optimal: {_opt_base.optim_status}",
+        )
+        # Counterfactual: confirm base schedules the full 6 timesteps.
+        bin2_base = res_base["P_def_bin2_0"].values
+        total_base = int(round(bin2_base.sum()))
+        self.assertEqual(
+            total_base,
+            6,
+            f"Counterfactual FAILED: expected 6 timesteps scheduled, got {total_base}. "
+            f"bin2={bin2_base}",
+        )
+
+        # With elapsed=2: only 4 timesteps should be scheduled.
+        with_elapsed = self._make_cots_overrides(
+            is_single_const=True,
+            operating_hours=3.0,
+            def_current_operating_timesteps=[2, 0],
+        )
+        _opt_rem, res_rem = self._run_min_on_optim(with_elapsed, df, n)
+        self.assertIn(
+            _opt_rem.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"Remainder solve non-optimal: {_opt_rem.optim_status}",
+        )
+        # BEHAVIOURAL assertion -- this line fails on base code (schedules 6, not 4).
+        bin2_rem = res_rem["P_def_bin2_0"].values
+        total_rem = int(round(bin2_rem.sum()))
+        self.assertEqual(
+            total_rem,
+            4,
+            f"def_current_operating_timesteps decrement failed: expected 4 timesteps "
+            f"remaining, got {total_rem}. bin2={bin2_rem}. Base code returns 6 here "
+            "-- this is the RED assertion.",
+        )
+
+    def test_current_operating_timesteps_noop_no_key(self):
+        """def_current_operating_timesteps absent = identical plan to all-zeros (no-op).
+
+        Run the same single_constant scenario twice (without the key, then with all
+        zeros) and verify the results are equal. Also confirm the full block is
+        scheduled in both cases so the test cannot false-green.
+        """
+        n = 10
+        prices = [0.2] * n
+        df = self._make_min_on_scenario(n=n, prices=prices)
+
+        overrides_no_key = self._make_cots_overrides(is_single_const=True, operating_hours=3.0)
+        overrides_zeros = self._make_cots_overrides(
+            is_single_const=True,
+            operating_hours=3.0,
+            def_current_operating_timesteps=[0, 0],
+        )
+
+        _opt_a, res_a = self._run_min_on_optim(overrides_no_key, df, n)
+        _opt_b, res_b = self._run_min_on_optim(overrides_zeros, df, n)
+
+        self.assertIn(_opt_a.optim_status, VALID_OPTIMAL_STATUSES)
+        self.assertIn(_opt_b.optim_status, VALID_OPTIMAL_STATUSES)
+
+        np.testing.assert_allclose(
+            res_a["P_deferrable0"].values,
+            res_b["P_deferrable0"].values,
+            atol=1e-6,
+            err_msg="def_current_operating_timesteps=[0,0] changed the result vs absent key (no-op broken)",
+        )
+
+        # Anti-green: full 6 timesteps should be scheduled in the no-op path.
+        bin2_a = res_a["P_def_bin2_0"].values
+        total_a = int(round(bin2_a.sum()))
+        self.assertEqual(
+            total_a,
+            6,
+            f"No-op anti-green FAILED: expected full 6 timesteps, got {total_a}.",
+        )
+
+    def test_current_operating_timesteps_standard_load(self):
+        """Standard (non-single_const) load decrement via def_current_operating_timesteps.
+
+        A semi_cont load requires 3 h = 6 timesteps. With elapsed=3, only 3 timesteps
+        of energy should be scheduled (total power sum / nominal ~= 3 timesteps).
+        """
+        n = 10
+        prices = [0.2] * n
+        df = self._make_min_on_scenario(n=n, prices=prices)
+
+        # Counterfactual: full 6-timestep run (3 h).
+        base = self._make_cots_overrides(is_single_const=False, operating_hours=3.0)
+        _opt_base, res_base = self._run_min_on_optim(base, df, n)
+        self.assertIn(_opt_base.optim_status, VALID_OPTIMAL_STATUSES)
+        p0_base = res_base["P_deferrable0"].values
+        # Energy delivered (Wh): sum(P) * time_step (0.5 h per step)
+        energy_base = p0_base.sum() * 0.5
+        self.assertAlmostEqual(
+            energy_base,
+            3000.0 * 3.0,  # 3000 W * 3 h = 9000 Wh
+            delta=100.0,
+            msg=f"Counterfactual energy wrong: expected ~9000 Wh, got {energy_base:.0f}",
+        )
+
+        # With elapsed=3: only 3 timesteps (1.5 h) of energy should remain.
+        with_elapsed = self._make_cots_overrides(
+            is_single_const=False,
+            operating_hours=3.0,
+            def_current_operating_timesteps=[3, 0],
+        )
+        _opt_rem, res_rem = self._run_min_on_optim(with_elapsed, df, n)
+        self.assertIn(_opt_rem.optim_status, VALID_OPTIMAL_STATUSES)
+        p0_rem = res_rem["P_deferrable0"].values
+        energy_rem = p0_rem.sum() * 0.5
+        self.assertAlmostEqual(
+            energy_rem,
+            3000.0 * 1.5,  # 3 remaining timesteps * 0.5 h * 3000 W = 4500 Wh
+            delta=100.0,
+            msg=(
+                f"Standard-load decrement failed: expected ~4500 Wh remaining, "
+                f"got {energy_rem:.0f}. Base code schedules ~9000 Wh (full block)."
+            ),
+        )
+
+    def test_current_operating_timesteps_clamp_elapsed_ge_required(self):
+        """Elapsed >= required: required becomes 0, model feasible, load not forced.
+
+        When elapsed >= total required timesteps the decrement clamps at 0. The load
+        is no longer forced (constraint_active=False), so the optimizer may schedule 0
+        timesteps. The solve must remain Optimal.
+        """
+        n = 10
+        # High prices everywhere so optimizer wants the load off.
+        prices = [0.9] * n
+        df = self._make_min_on_scenario(n=n, prices=prices)
+
+        # elapsed=6 >= required=6 (3 h at 30 min) -> remainder = 0
+        overrides = self._make_cots_overrides(
+            is_single_const=True,
+            operating_hours=3.0,
+            def_current_operating_timesteps=[6, 0],
+        )
+        _opt, res = self._run_min_on_optim(overrides, df, n)
+        self.assertIn(
+            _opt.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"Clamp test: solve non-optimal after elapsed>=required: {_opt.optim_status}",
+        )
+        # Load should not be forced on (remainder == 0 -> constraint fully relaxed).
+        bin2 = res["P_def_bin2_0"].values
+        total = int(round(bin2.sum()))
+        self.assertEqual(
+            total,
+            0,
+            f"Clamp test: expected 0 timesteps scheduled (remainder=0), got {total}. bin2={bin2}",
+        )
+
+    def test_current_operating_timesteps_over_elapsed_clamp(self):
+        """Elapsed > required: clamped to 0, model remains feasible.
+
+        elapsed=10 > required=6 must not produce negative required/energy or an
+        infeasible solve. Clamp ensures required_timesteps = max(0, 6-10) = 0.
+        """
+        n = 10
+        prices = [0.9] * n
+        df = self._make_min_on_scenario(n=n, prices=prices)
+
+        overrides = self._make_cots_overrides(
+            is_single_const=True,
+            operating_hours=3.0,
+            def_current_operating_timesteps=[10, 0],
+        )
+        _opt, res = self._run_min_on_optim(overrides, df, n)
+        self.assertIn(
+            _opt.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"Over-elapsed clamp test: solve non-optimal: {_opt.optim_status}",
+        )
+        bin2 = res["P_def_bin2_0"].values
+        self.assertEqual(
+            int(round(bin2.sum())),
+            0,
+            f"Over-elapsed clamp: expected 0 timesteps scheduled, got {bin2.sum():.1f}",
+        )
+
+    def test_current_operating_timesteps_length_mismatch_warns(self):
+        """Length mismatch (len != num_def_loads) must log a WARNING and not crash.
+
+        Mirrors test_current_power_length_mismatch_warns. Passes a
+        def_current_operating_timesteps list of length 1 against a 2-load scenario
+        (num_deferrable_loads=2). The optimizer must:
+          1. Log a WARNING containing "def_current_operating_timesteps length mismatch"
+          2. Still complete the solve and return an Optimal status.
+        """
+        n = 10
+        prices = [0.2] * n
+        df = self._make_min_on_scenario(n=n, prices=prices)
+
+        # len=1, num_loads=2 -> length mismatch
+        overrides = self._make_cots_overrides(
+            is_single_const=True,
+            operating_hours=3.0,
+            def_current_operating_timesteps=[2],  # only 1 entry for 2 loads
+        )
+        with self.assertLogs(level="WARNING") as logs:
+            _opt, _res = self._run_min_on_optim(overrides, df, n)
+
+        self.assertIn(
+            _opt.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"Length-mismatch must not crash the solve. Got: {_opt.optim_status}",
+        )
+        self.assertTrue(
+            any("def_current_operating_timesteps length mismatch" in line for line in logs.output),
+            f"Expected WARNING containing 'def_current_operating_timesteps length mismatch'; "
+            f"got: {logs.output}",
+        )
+
+    def test_current_operating_timesteps_running_singleconst_clamp(self):
+        """Running single_const load with elapsed >= required stays feasible (clamp-to-zero).
+
+        A single_constant must-run load requiring 2 timesteps (1 h at 30 min) is
+        currently running (def_current_state=True, def_current_on_timesteps=2 to pin
+        it at t=0). def_current_operating_timesteps=[2, 0] means it has already
+        completed all 2 required timesteps today.
+
+        The decrement must clamp remaining_required to 0. The model must:
+          1. Solve Optimal -- NOT become infeasible.
+          2. Schedule 0 additional full-block timesteps for load 0 (requirement
+             satisfied; load is not forced to run a phantom extra block).
+
+        This is the adversarial coverage gap: a currently-running single_const load
+        whose elapsed >= required should be fully released (constraint_active=False),
+        not stranded in an infeasible over-constrained state.
+        """
+        n = 10
+        # Expensive prices so the optimizer avoids running the load if it is free to.
+        prices = [0.9] * n
+        df = self._make_min_on_scenario(n=n, prices=prices)
+
+        # operating_hours=1.0 -> 2 timesteps at 30 min. elapsed=2 -> clamps to 0.
+        overrides = self._make_cots_overrides(
+            is_single_const=True,
+            operating_hours=1.0,
+            def_current_operating_timesteps=[2, 0],
+        )
+        # Pin the load as currently running at t=0 (single_const running-pin pattern).
+        overrides["def_current_state"] = [True, False]
+        overrides["def_current_on_timesteps"] = [2, 0]
+
+        _opt, res = self._run_min_on_optim(overrides, df, n)
+
+        self.assertIn(
+            _opt.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"Running single_const + elapsed>=required must stay Optimal (clamp-to-zero). "
+            f"Got: {_opt.optim_status}. A non-Optimal result means the load was stranded "
+            "in an infeasible over-constrained state instead of being released.",
+        )
+        # With remaining_required=0 and high prices, the optimizer must not schedule
+        # any additional full block (bin2 sum should be 0).
+        bin2 = res["P_def_bin2_0"].values
+        self.assertEqual(
+            int(round(bin2.sum())),
+            0,
+            f"Running single_const clamp-to-zero: expected 0 additional timesteps "
+            f"(requirement already satisfied), got {bin2.sum():.1f}. bin2={bin2}",
+        )
+
+    def test_current_operating_timesteps_satisfied_with_current_power_feasible(self):
+        """COTS-satisfied currently-running load + def_current_power set stays FEASIBLE.
+
+        Critical interaction guard (issues #983 x #982/#605): a currently-running
+        single_const load whose elapsed >= required (remaining clamps to 0) is
+        deactivated (param_load_active=0). If a non-zero def_current_power t=0
+        force-on / power-pin were left active for that load, it would conflict with
+        the load being bounded to 0 W for the whole horizon and make the model
+        INFEASIBLE. The fix releases the current-power pin/force-on for COTS-satisfied
+        loads, so the solve must remain Optimal and schedule no extra block.
+        """
+        n = 10
+        prices = [0.9] * n
+        df = self._make_min_on_scenario(n=n, prices=prices)
+
+        # operating_hours=1.0 -> 2 timesteps; elapsed=2 -> clamps to 0.
+        overrides = self._make_cots_overrides(
+            is_single_const=True,
+            operating_hours=1.0,
+            def_current_operating_timesteps=[2, 0],
+        )
+        overrides["def_current_state"] = [True, False]
+        overrides["def_current_on_timesteps"] = [2, 0]
+        # def_current_power set for the running load: this is the adversarial leg.
+        # (For single_const it is excluded from the pin upstream, but exercise the
+        # path explicitly so a regression in that exclusion is caught here as an
+        # infeasibility rather than slipping through.)
+        overrides["def_current_power"] = [3000.0, 0.0]
+
+        _opt, res = self._run_min_on_optim(overrides, df, n)
+
+        self.assertIn(
+            _opt.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"COTS-satisfied running load WITH def_current_power must stay feasible "
+            f"(pin/force-on released). Got: {_opt.optim_status}.",
+        )
+        bin2 = res["P_def_bin2_0"].values
+        self.assertEqual(
+            int(round(bin2.sum())),
+            0,
+            f"COTS-satisfied + def_current_power: expected 0 timesteps scheduled, "
+            f"got {bin2.sum():.1f}. bin2={bin2}",
+        )
+
+    def test_current_operating_timesteps_satisfied_standard_min_on_feasible(self):
+        """COTS-satisfied STANDARD (semi_cont) load with a min-on remainder stays
+        plain Optimal and is released (issues #983 x #952/#980).
+
+        The reproduced HIGH-severity bug: a currently-running STANDARD (semi_cont,
+        NOT single_const) load that ALSO has an in-progress min-on window
+        (def_minimum_on_time set, def_current_on_timesteps mid-window) AND whose
+        must-run requirement is already satisfied by def_current_operating_timesteps
+        (elapsed >= required, remaining clamps to 0).
+
+        Without the fix, the COTS decrement deactivates the load
+        (param_load_active=0 => bin2 <= 0) while min-on Block B force-ON's it via
+        param_running_lb (bin2 >= 1). The two constraints conflict => the MILP is
+        INFEASIBLE and is rescued only by the GLOBAL relaxed-LP fallback, which
+        returns status "Optimal (Relaxed)" and degrades the entire solve. (Single_const
+        is safe only because Block B is gated `not is_single_const`.)
+
+        The fix gates Block B on `k not in cots_satisfied_loads`, so a COTS-satisfied
+        load is FREE (optimizer may run it if economical) but never FORCED. The solve
+        must therefore return PLAIN "Optimal" (NOT the relaxed fallback), and the load
+        must be RELEASED -- not pinned ON for the whole min-on tail.
+
+        This asserts the EXACT status string "Optimal" (not VALID_OPTIMAL_STATUSES)
+        precisely to distinguish a healthy MILP solve from the relaxed-LP rescue.
+        """
+        n = 10
+        # Expensive prices everywhere so a released load wants to be OFF; if Block B
+        # were still forcing it ON, that force (not economics) would drive bin2 high.
+        prices = [0.9] * n
+        df = self._make_min_on_scenario(n=n, prices=prices)
+
+        # STANDARD (semi_cont) load 0. operating_hours=1.0 -> 2 required timesteps at
+        # 30 min; def_current_operating_timesteps=[2, 0] -> elapsed 2 >= required 2,
+        # remaining clamps to 0 -> COTS-satisfied.
+        overrides = self._make_cots_overrides(
+            is_single_const=False,
+            operating_hours=1.0,
+            def_current_operating_timesteps=[2, 0],
+        )
+        # Currently running, mid min-on window: min_on=6 timesteps, elapsed on-time=2
+        # so remaining=4 -> Block B would force 4 ON steps (the infeasibility leg).
+        overrides["def_minimum_on_time"] = [6, 0]
+        overrides["def_current_state"] = [True, False]
+        overrides["def_current_on_timesteps"] = [2, 0]
+
+        _opt, res = self._run_min_on_optim(overrides, df, n)
+
+        # PLAIN Optimal (not "Optimal (Relaxed)") proves the MILP itself is feasible
+        # and the relaxed-LP fallback was NOT triggered.
+        self.assertEqual(
+            _opt.optim_status,
+            "Optimal",
+            f"COTS-satisfied STANDARD load with min-on remainder must solve plain "
+            f"'Optimal', NOT the relaxed-LP fallback. Got: {_opt.optim_status}. A "
+            f"'(Relaxed)' status means min-on Block B force-ON conflicted with the "
+            "param_load_active=0 deactivation and the MILP went infeasible.",
+        )
+        # Released: with the requirement met and high prices, the load must NOT be
+        # pinned ON for the min-on tail. (If Block B still fired it would be forced ON
+        # for 4 steps; release => optimizer keeps it off, bin2 sum == 0.)
+        bin2 = res["P_def_bin2_0"].values
+        self.assertEqual(
+            int(round(bin2.sum())),
+            0,
+            f"COTS-satisfied STANDARD load with min-on remainder must be released "
+            f"(not forced ON for the min-on tail), expected 0 timesteps, got "
+            f"{bin2.sum():.1f}. bin2={bin2}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime_params.py
+++ b/tests/test_runtime_params.py
@@ -59,6 +59,7 @@ EXPECTED_KEYS = {
     "weather_forecast_cache_only",
     "def_current_state",
     "def_current_power",
+    "def_current_operating_timesteps",
     "def_load_config",
 }
 


### PR DESCRIPTION
## What this is

This is the concrete version of the carryover proposal in #983. I built it because the constraint handling and the state handoff are much easier to discuss against real code than in the abstract, and it slots in alongside #980 and #982. It is entirely opt-in and a no-op by default, so it costs nothing for anyone not using it. Whether it belongs in core is your call, I am happy to reshape it or drop it.

Closes #983 if you want it.

## The problem

In naive-MPC the optimiser re-plans every cycle and rebuilds the required run for each deferrable from `operating_hours` on every solve, with no memory of how much the load has already run today. For a flexible load that can fragment this is harmless. For a must-run load pinned to a daily window it is not: as the day advances and the full block no longer fits the remaining window, the optimiser pushes it later and eventually rolls the whole block to tomorrow, so the load under-runs its daily target.

Real example from my own setup: a pool pump as a must-run `set_deferrable_load_single_constant` load, about 4 hours/day, pinned to a 09:00 to 15:00 window, 15-minute MPC. Once the clock passed the point where 4 hours still fit before 15:00, each solve moved the block later and then rolled it to the next day. The pump ran a couple of short fragments instead of its 4 hours.

#980 (`def_current_on_timesteps`) only carries the min-on-time tail, and is gated `not is_single_const`. #982 (`def_current_power`) only pins t0. Neither decrements the remaining required run, so nothing tells the optimiser that part of today's hours is already done.

## The change

A new runtime-only, per-load signal `def_current_operating_timesteps`: a list of integers, one per deferrable load, saying how many operating timesteps each load has already completed today at the start of the horizon. Each solve then decrements that load's `required_timesteps` and `target_energy` by the elapsed amount, clamped at 0, so it schedules only the remainder. It applies to standard and single_constant must-run loads.

On the design question I raised in the issue (extend `def_current_on_timesteps` vs a sibling): I went with a sibling. `def_current_on_timesteps` is deliberately gated `not is_single_const` and only fires when `def_minimum_on_time > 0`, so overloading it would have changed its existing behaviour and still needed a separate single-constant path. A sibling mirrors the #982 runtime-only measurement pattern exactly and keeps both features clean. Easy to change if you would rather it were one parameter.

The supervisor still owns the elapsed tracking and the daily reset boundary (which, as @scruysberghs rightly noted, is not always midnight), exactly the same split as #980 and #982. It just feeds the number.

## Behaviour change disclosure

- Default unset, or an all-zero list, is a byte-exact no-op. There is a test that pins this.
- When a load's elapsed reaches its required run, that load is treated as satisfied for the day: it is released, not forced. It is dropped from the must-run forcing (the single-constant pin, the min-on-time tail, and the `def_current_power` t0 pin are all released for that load), so it is free to run if it is economical but is never forced to start a fresh block. This only affects a load you are actively feeding the new signal for.
- This is a fed, trusted signal. If you tell EMHASS a load has done 3 hours, it believes you, the same as the existing current-state inputs.

## Non-goals

- EMHASS does not track wall-clock day rollover or decide when "today" resets. The supervisor feeds the elapsed count, same as #980/#982.
- No automatic elapsed tracking inside EMHASS.
- Flexible (fragmentable) loads are unchanged beyond the remainder decrement.

## Tests

In `tests/test_optimization.py`:
- `test_current_operating_timesteps_single_const_red` red/green proof: a must-run single-constant load with elapsed > 0 schedules only the remainder (fails on master).
- `test_current_operating_timesteps_noop_no_key`: absent key reproduces today's plan.
- `test_current_operating_timesteps_standard_load`: standard load decrement.
- `test_current_operating_timesteps_clamp_elapsed_ge_required` and `_over_elapsed_clamp`: elapsed >= required clamps to 0, model stays feasible, load not forced.
- `test_current_operating_timesteps_length_mismatch_warns`: a length mismatch logs a warning and still solves.
- `test_current_operating_timesteps_running_singleconst_clamp`: a currently-running single-constant load at/over its target solves cleanly with no phantom block.
- `test_current_operating_timesteps_satisfied_with_current_power_feasible`: a satisfied load that is also reporting current power stays feasible.
- `test_current_operating_timesteps_satisfied_standard_min_on_feasible`: a satisfied standard load that also has a min-on-time remainder solves to plain Optimal (not the relaxed fallback).

`tests/test_runtime_params.py` covers the runtime-key plumbing (it stays disjoint from the config schema, like `def_current_power`). Full suite green locally (629 passed, 28 xfailed).

Documented in `docs/config.md` next to the other `def_current_*` runtime signals.

## Summary by Sourcery

Introduce a runtime-only signal to decrement completed operating timesteps for must-run deferrable loads so MPC only schedules remaining required run and releases loads whose daily requirement is already satisfied.

Bug Fixes:
- Prevent infeasible or relaxed fallback solutions caused by conflicts between must-run requirements, minimum-on-time constraints, and current-power pins when loads have already met their operating-hour targets.
- Ensure single-constant and standard must-run loads are not forced to run phantom extra blocks once their daily operating requirement is fully satisfied.

Enhancements:
- Add CVXPY parameters and optimization logic to apply completed-operating-timestep decrements across standard and single-constant deferrable loads, including safe clamping and interaction with load-activation flags.
- Extend runtime parameter handling and config hashing to support the new completed-operating-timesteps signal without affecting cached problem structures.

Documentation:
- Document the new def_current_operating_timesteps runtime parameter, its units, interaction with other deferrable load signals, and typical MPC usage in the configuration guide.

Tests:
- Add optimization tests verifying decrement behavior, clamping when elapsed time meets or exceeds requirements, length-mismatch handling, and interactions with current power and minimum-on-time constraints for both standard and single-constant loads.
- Add runtime-parameter tests to cover plumbing for the new def_current_operating_timesteps key.