### PR TITLE
fix(thermal): keep solar gains when pv_power_forecast is passed (#997)

### DIFF
--- a/docs/thermal_battery.md
+++ b/docs/thermal_battery.md
@@ -898,7 +898,7 @@ rest_command:
 Important notes:
 - `outdoor_temperature_forecast` is required for thermal battery optimization (building heating mode)
 - `start_temperature` should ideally come from a real sensor (floor temp for underfloor heating, tank sensor for hot water)
-- If using solar gains, ensure your forecast data includes `ghi` (global horizontal irradiance)
+- If using solar gains, the optimization data needs a `ghi` (global horizontal irradiance) column. This comes from the weather forecast automatically, including when you pass your own `pv_power_forecast` (see "Solar gains not working" in Troubleshooting)
 - Add `"thermal_inertia_time_constant": 2.0` to the `thermal_battery` dict to enable the thermal inertia filter
 - In MPC mode, `Q_input` auto-persists between solves; use `"q_input_initial": 0.5` to manually override
 - For hot water tanks, add `"density": 997, "heat_capacity": 4.184` and a `"draw_off_demand"` profile or `"specific_heating_demand": 0.0, "area":1.0`
@@ -1053,6 +1053,21 @@ Requirements for solar gains:
 3. Must use physics-based method (not HDD method)
 
 Check the logs for: "Using physics-based heating demand with solar gains"
+
+#### Passing your own `pv_power_forecast`
+
+Supplying `pv_power_forecast` as a runtime parameter switches the weather forecast
+method to `list`, which on its own only carries the PV power and no `ghi` or
+`temp_air`. To keep solar-gain modelling working in that case, EMHASS still fetches
+the open-meteo weather forecast for the `ghi` and outdoor-temperature columns
+whenever a thermal load is configured, while using your passed list for the PV
+power. So bringing your own PV forecast no longer silently disables solar gains.
+
+This extra weather fetch only happens when a `thermal_config` or `thermal_battery`
+load is present, so pure PV/battery setups that pass `pv_power_forecast` are
+unaffected and make no extra weather call. If open-meteo is unreachable the run
+falls back to no solar gains (a warning is logged) rather than failing. A passed
+`outdoor_temperature_forecast` still takes precedence over the fetched temperature.
 
 ### Hot water tank temperature drops too fast
 

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -764,6 +764,61 @@ class Forecast:
         data.set_index("ts", inplace=True)
         return data
 
+    def _list_method_needs_weather(self) -> bool:
+        """Whether a configured deferrable load consumes weather-derived data.
+
+        The ``list`` weather path only carries the passed PV power (``yhat``). A
+        thermal load's physics demand additionally needs ``ghi`` (solar gains) and
+        ``temp_air`` (the outdoor-temperature fallback), so when one is configured
+        we still fetch open-meteo to supply those columns (issue #997). Pure
+        PV/battery setups never trigger the extra fetch, keeping the list path a
+        no-op for them.
+        """
+        return any(
+            isinstance(cfg, dict)
+            and (
+                isinstance(cfg.get("thermal_config"), dict)
+                or isinstance(cfg.get("thermal_battery"), dict)
+            )
+            for cfg in self.optim_conf.get("def_load_config", []) or []
+        )
+
+    async def _augment_list_with_open_meteo(
+        self, data: pd.DataFrame, w_forecast_cache_path: str, use_legacy_pvlib: bool
+    ) -> pd.DataFrame:
+        """Graft open-meteo weather columns onto a list-method PV frame (issue #997).
+
+        The passed PV power (``yhat``) is preserved untouched; every weather-derived
+        column (``ghi``, ``temp_air`` and the rest) is copied over, reindexed onto the
+        list frame's index. Fail-soft: if the open-meteo fetch is unavailable the plain
+        list frame is returned unchanged, so an offline/air-gapped setup keeps
+        working exactly as before (just without solar gains).
+        """
+        try:
+            weather = await self._get_weather_open_meteo(w_forecast_cache_path, use_legacy_pvlib)
+        except Exception:
+            self.logger.warning(
+                "Could not fetch open-meteo weather to accompany the passed "
+                "pv_power_forecast; thermal solar gains and the outdoor-temperature "
+                "fallback are unavailable for this run (issue #997).",
+                exc_info=True,
+            )
+            return data
+        if weather is None:
+            self.logger.warning(
+                "open-meteo weather fetch returned no data while accompanying the "
+                "passed pv_power_forecast; thermal solar gains are unavailable this run."
+            )
+            return data
+        for col in weather.columns:
+            if col == "yhat":
+                continue
+            # Both frames are built on the same forecast horizon; "nearest"
+            # only absorbs sub-second index rounding between the list index
+            # (forecast_dates_tz) and the open-meteo index.
+            data[col] = weather[col].reindex(data.index, method="nearest")
+        return data
+
     async def get_weather_forecast(
         self,
         method: str | None = "open-meteo",
@@ -811,6 +866,14 @@ class Forecast:
             data = self._get_weather_csv(csv_path)
         elif method == "list":
             data = self._get_weather_list()
+            # When PV is supplied as a runtime list, weather_forecast_method is
+            # forced to "list" and only the PV power survives. If a thermal load
+            # needs weather-derived GHI/temperature, still fetch open-meteo for
+            # those columns so solar gains are not silently dropped (issue #997).
+            if data is not None and self._list_method_needs_weather():
+                data = await self._augment_list_with_open_meteo(
+                    data, w_forecast_cache_path, use_legacy_pvlib
+                )
         else:
             self.logger.error("Method %r is not valid", method)
             data = None
@@ -2167,9 +2230,13 @@ class Forecast:
             data = data.loc[self.forecast_dates[0] : self.forecast_dates[-1]]
             self.logger.info("Retrieved forecast data from the previously saved cache.")
         else:
-            if self.weather_forecast_method == "open-meteo":
+            if self.weather_forecast_method in ("open-meteo", "list"):
                 # Open-Meteo has no rate limits: delete the stale cache so
-                # the next call fetches fresh data directly from the API.
+                # the next call fetches fresh data directly from the API. The
+                # "list" method only reaches this cache via the open-meteo
+                # weather augmentation (issue #997), which is open-meteo-sourced
+                # too, so it gets the same refetch-fresh treatment rather than
+                # being served stale, zero-filled irradiance.
                 self.logger.warning(
                     "Cache does not fully cover the requested timeframe. "
                     "Removing stale Open-Meteo cache; fresh data will be fetched from the API."

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -794,9 +794,14 @@ class Forecast:
         list frame is returned unchanged, so an offline/air-gapped setup keeps
         working exactly as before (just without solar gains).
         """
+        # Only swallow the external failure modes the open-meteo path can raise
+        # (network, file/cache IO, malformed or incomplete response data). A
+        # programming error should still surface rather than be downgraded to a
+        # warning. This keeps the augmentation fail-soft for an offline setup
+        # without hiding real bugs.
         try:
             weather = await self._get_weather_open_meteo(w_forecast_cache_path, use_legacy_pvlib)
-        except Exception:
+        except (aiohttp.ClientError, OSError, ValueError, KeyError):
             self.logger.warning(
                 "Could not fetch open-meteo weather to accompany the passed "
                 "pv_power_forecast; thermal solar gains and the outdoor-temperature "

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1094,6 +1094,117 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(df_input_data["unit_prod_price"].values[0], 1)
         self.assertEqual(df_input_data["unit_prod_price"].values[-1], 48)
 
+    # --- issue #997: list weather method keeps GHI/temp_air for thermal loads ---
+    async def _build_list_fcst_pinned(self, with_thermal: bool):
+        """Build a pinned 1-day list-method Forecast, optionally with a thermal load."""
+        fcst, _, _ = await self._build_longer_list_forecast(48)
+        fcst.optim_conf["delta_forecast_daily"] = pd.Timedelta(days=1)
+        self._pin_forecast_to_date(fcst, "2024-06-15 00:00:00")
+        fcst.params["passed_data"]["prediction_horizon"] = None
+        fcst.optim_conf["def_load_config"] = (
+            [{"thermal_config": {"window_area": 2.0, "u_value": 1.0}}] if with_thermal else []
+        )
+        return fcst
+
+    def _fake_open_meteo_frame(self, fcst):
+        """An open-meteo-shaped weather frame on the forecast index (ghi + temp_air)."""
+        idx = fcst.forecast_dates_tz
+        return pd.DataFrame(
+            {
+                "ghi": np.linspace(0.0, 800.0, len(idx)),
+                "temp_air": np.linspace(10.0, 25.0, len(idx)),
+            },
+            index=idx,
+        )
+
+    async def test_get_weather_forecast_list_keeps_ghi_for_thermal(self):
+        """#997: a thermal load + passed PV list still gets GHI/temp from open-meteo."""
+        fcst = await self._build_list_fcst_pinned(with_thermal=True)
+        fake = self._fake_open_meteo_frame(fcst)
+        with unittest.mock.patch.object(
+            fcst,
+            "_get_weather_open_meteo",
+            new=unittest.mock.AsyncMock(return_value=fake),
+        ) as m:
+            data = await fcst.get_weather_forecast(method="list")
+        m.assert_awaited_once()
+        self.assertIn("ghi", data.columns)
+        self.assertIn("temp_air", data.columns)
+        self.assertFalse(data["ghi"].isnull().any())
+        # PV power (yhat) is exactly the passed list, untouched by the augmentation
+        self.assertEqual(data["yhat"].iloc[0], 1)
+        self.assertEqual(data["yhat"].iloc[-1], 48)
+        # weather method stays "list" so get_power_from_weather still returns yhat
+        self.assertEqual(fcst.weather_forecast_method, "list")
+
+    async def test_get_weather_forecast_list_no_thermal_is_noop(self):
+        """#997 no-op: with no thermal load, no open-meteo fetch fires, only yhat."""
+        fcst = await self._build_list_fcst_pinned(with_thermal=False)
+        with unittest.mock.patch.object(
+            fcst,
+            "_get_weather_open_meteo",
+            new=unittest.mock.AsyncMock(return_value=self._fake_open_meteo_frame(fcst)),
+        ) as m:
+            data = await fcst.get_weather_forecast(method="list")
+        m.assert_not_awaited()
+        self.assertEqual(list(data.columns), ["yhat"])
+        self.assertEqual(data["yhat"].iloc[0], 1)
+        self.assertEqual(data["yhat"].iloc[-1], 48)
+
+    async def test_get_weather_forecast_list_open_meteo_failure_is_soft(self):
+        """#997 fail-soft: an open-meteo error leaves the plain list frame and warns."""
+        fcst = await self._build_list_fcst_pinned(with_thermal=True)
+        with unittest.mock.patch.object(
+            fcst,
+            "_get_weather_open_meteo",
+            new=unittest.mock.AsyncMock(side_effect=aiohttp.ClientError("boom")),
+        ):
+            with self.assertLogs(logger, level="WARNING") as cm:
+                data = await fcst.get_weather_forecast(method="list")
+        self.assertEqual(list(data.columns), ["yhat"])
+        self.assertIn("issue #997", "\n".join(cm.output))
+
+    async def test_get_weather_forecast_list_open_meteo_none_is_soft(self):
+        """#997 fail-soft: open-meteo returning None leaves the plain list frame."""
+        fcst = await self._build_list_fcst_pinned(with_thermal=True)
+        with unittest.mock.patch.object(
+            fcst,
+            "_get_weather_open_meteo",
+            new=unittest.mock.AsyncMock(return_value=None),
+        ):
+            with self.assertLogs(logger, level="WARNING") as cm:
+                data = await fcst.get_weather_forecast(method="list")
+        self.assertEqual(list(data.columns), ["yhat"])
+        self.assertIn("no data", "\n".join(cm.output))
+
+    async def test_get_cached_forecast_data_list_method_refetches_stale(self):
+        """#997: under the open-meteo weather augmentation (method='list'), a cache
+        that does not cover the window is treated like open-meteo (deleted for a
+        fresh refetch) rather than served best-effort stale with zero-filled GHI."""
+        cache_path = emhass_conf["data_path"] / "weather_forecast_data.pkl"
+        temp_path = emhass_conf["data_path"] / "temp_weather_forecast_data.pkl"
+        if os.path.isfile(cache_path):
+            os.rename(cache_path, temp_path)
+        stale_index = pd.date_range(
+            start=self.fcst.forecast_dates[0] - pd.Timedelta(days=5),
+            periods=8,
+            freq=self.fcst.freq,
+        )
+        stale = pd.DataFrame({"ghi": 100.0, "temp_air": 20.0}, index=stale_index)
+        with open(cache_path, "wb") as f:
+            pickle.dump(stale, f)
+        self.fcst.weather_forecast_method = "list"
+        try:
+            result = await self.fcst.get_cached_forecast_data(str(cache_path))
+            removed = not os.path.isfile(cache_path)
+        finally:
+            if os.path.isfile(cache_path):
+                os.remove(cache_path)
+            if os.path.isfile(temp_path):
+                os.rename(temp_path, cache_path)
+        self.assertIsNone(result)
+        self.assertTrue(removed)
+
     # Test output weather forecast using longer passed runtime lists
     async def _build_longer_list_forecast(self, list_length: int):
         """Build a Forecast configured for 3-day list-based forecasts.


### PR DESCRIPTION
## What this fixes

Closes #997. If you pass your own `pv_power_forecast` as a runtime parameter, the thermal battery's physics demand silently stops accounting for solar gains, for heating and cooling.

The cause is that passing any list forecast (including `pv_power_forecast`) flips `weather_forecast_method` to `"list"` in `treat_runtimeparams`. The `"list"` weather path only carries the PV power, so the `ghi` column never gets built, the `if "ghi" in data_opt.columns` guards in the demand calculation skip the solar term, and the gains disappear with no warning. The same thing happens to the outdoor-temperature fallback: once you bring your own PV you also lose the open-meteo `temp_air` the thermal model would otherwise fall back on.

@mime24 spotted the original symptom while we were looking at #994, and we agreed on the approach in the issue thread: keep the weather/GHI fetch independent of the PV list rather than adding a new runtime key.

## The change

When the PV power is supplied as a list and a thermal load is actually configured, EMHASS now still fetches the open-meteo weather forecast and grafts its weather columns (`ghi`, `temp_air`, and the rest) onto the list frame. The PV power stays exactly the list you passed. With `ghi` and `temp_air` present again, the existing GHI merge and the temp-air fallback in `command_line` pick them up the way they already do for the open-meteo path, so solar gains and the outdoor-temperature fallback survive.

It is all in `forecast.py`. `command_line.py` is untouched because its merge already keys off whether the column exists.

## Behaviour change to be aware of

- The extra open-meteo fetch only happens when a `thermal_config` or `thermal_battery` load is present. A pure PV/battery setup that passes `pv_power_forecast` is unaffected and makes no extra weather call, so it is a no-op for everyone not using a thermal load.
- It is fail-soft. If open-meteo is unreachable the run logs a warning and carries on without solar gains, the same as today, rather than failing. So an offline or air-gapped setup keeps working.
- One small related change in the same path: when the weather cache is enabled, a stale cache that does not cover the requested window was being served best-effort (zero-filled GHI) under the `list` method. Since the only way `list` reaches that cache is through this open-meteo augmentation, and open-meteo has no rate limit, I let it refetch fresh instead, the same as the normal open-meteo path. This only affects the `list` + thermal + caching combination.

## The alternative I did not take

The other option in the issue was to accept `solar_irradiance_forecast` (GHI) as a new runtime forecast key. @mime24 and I both preferred keeping the weather fetch decoupled from the PV list because it means solar gains just keep working with no new key to learn. Happy to switch to the explicit-key shape instead if you would rather have that.

## Tests

In `tests/test_forecast.py`:

- a thermal load plus a passed PV list now gets `ghi` and `temp_air` from open-meteo while `yhat` stays the passed list (fails on master),
- the no-op case: no thermal load means no open-meteo fetch and the frame stays PV-only,
- two fail-soft cases (open-meteo raising and returning nothing) leave the plain list frame and warn,
- the stale-cache refetch under the `list` method.

Full suite passes locally (625 passed, 28 xfailed).

## Summary by Sourcery

Ensure thermal loads retain solar gains and outdoor temperature fallbacks when pv_power_forecast is provided as a runtime list by augmenting list-based forecasts with weather data.

Bug Fixes:
- Preserve GHI and outdoor temperature data for thermal loads when pv_power_forecast is supplied via the list weather method.
- Treat stale cached weather data for list-based forecasts like open-meteo data, forcing a refetch instead of serving zero-filled irradiance.

Enhancements:
- Add helper logic to detect thermal loads and augment list-based PV forecasts with open-meteo weather columns while leaving the passed PV list unchanged.

Documentation:
- Document how solar gains behave when passing pv_power_forecast and clarify that GHI is sourced automatically from the weather forecast in this case.

Tests:
- Add tests covering list-method weather augmentation for thermal loads, the no-op behavior for non-thermal setups, fail-soft handling of open-meteo failures, and stale cache refetching under the list method.