### PR TITLE
fix: atomic entity-file writes so continual_publish survives a partial read

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -2762,6 +2762,11 @@ async def continual_publish(
         # on the next interval, otherwise published sensors freeze until restart.
         try:
             freq = await _publish_and_update_freq(input_data_dict, entity_path, logger, freq)
+        except asyncio.CancelledError:
+            # Task cancellation (e.g. shutdown) must propagate, never be retried.
+            # CancelledError is a BaseException so the broad except below would
+            # not catch it anyway; this makes that intent explicit.
+            raise
         except Exception:
             logger.exception("continual_publish cycle failed; retrying next interval")
     return False

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -2756,8 +2756,14 @@ async def continual_publish(
         timestamp_diff = freq.total_seconds() - (datetime.now(time_zone).timestamp() % 60)
         sleep_seconds = max(0.0, min(timestamp_diff, 60.0))
         await asyncio.sleep(sleep_seconds)
-        # Delegate processing to helper function to reduce complexity
-        freq = await _publish_and_update_freq(input_data_dict, entity_path, logger, freq)
+        # Delegate processing to helper function to reduce complexity. A
+        # transient failure in a single cycle (e.g. a half-written entity file
+        # read mid-publish) must not kill the background task: log it and retry
+        # on the next interval, otherwise published sensors freeze until restart.
+        try:
+            freq = await _publish_and_update_freq(input_data_dict, entity_path, logger, freq)
+        except Exception:
+            logger.exception("continual_publish cycle failed; retrying next interval")
     return False
 
 
@@ -2775,7 +2781,10 @@ async def _publish_and_update_freq(input_data_dict, entity_path, logger, current
         return current_freq
     # Loop through all saved entity files
     for entity in entity_path_contents:
-        if entity != default_metadata_json:
+        # Skip metadata and any in-flight atomic-write temp files: entity and
+        # metadata files are committed via a "<name>.<...>.tmp" + os.replace, and
+        # that temp file can be momentarily visible to this directory listing.
+        if entity != default_metadata_json and not entity.endswith(".tmp"):
             await publish_json(
                 entity,
                 input_data_dict,

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import re
 import time
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Self
 
@@ -1645,8 +1646,19 @@ class RetrieveHass:
                     index="timestamp", orient="index", date_unit="s", date_format="iso"
                 )
                 parsed = orjson.loads(result)
-                async with aiofiles.open(entities_path / (entity_id + ".json"), "w") as file:
+                # Atomic commit: write to a unique temp file then os.replace, so
+                # a concurrent reader (the continual_publish background task)
+                # always sees a complete document, never the zero-byte window an
+                # in-place truncating write would expose. The uuid suffix keeps
+                # the temp name unique even if the same entity is published
+                # concurrently (this write is not under _metadata_lock).
+                entity_file = entities_path / (entity_id + ".json")
+                tmp_entity_path = entity_file.with_name(
+                    f"{entity_id}.json.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+                )
+                async with aiofiles.open(tmp_entity_path, "w") as file:
                     await file.write(orjson.dumps(parsed, option=orjson.OPT_INDENT_2).decode())
+                os.replace(tmp_entity_path, entity_file)
 
                 # Save the required metadata to json file. The whole
                 # read-modify-write is serialized with a process-wide lock and

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import asyncio
 import copy
 import json
 import os
@@ -7,7 +8,7 @@ import pathlib
 import pickle
 import tempfile
 import unittest
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import aiofiles
@@ -25,6 +26,7 @@ from emhass.command_line import (
     _prepare_dayahead_optim,
     _publish_and_update_freq,
     adjust_pv_forecast,
+    continual_publish,
     dayahead_forecast_optim,
     export_influxdb_to_csv,
     forecast_model_fit,
@@ -1904,15 +1906,23 @@ class TestCommandLineAsyncUtils(unittest.IsolatedAsyncioTestCase):
         mock_listdir.return_value = []
         res = await _publish_and_update_freq(input_data_dict, entity_path, logger, current_freq)
         self.assertEqual(res, current_freq)
-        # Test 3: Directory has files, metadata exists, new frequency returned
-        mock_listdir.return_value = ["sensor1.json", "metadata.json"]
+        # Test 3: Directory has files, metadata exists, new frequency returned.
+        # The listing also contains an in-flight atomic-write temp file, which
+        # must be skipped (publishing it would derive a bogus entity_id and
+        # KeyError in publish_json).
+        mock_listdir.return_value = [
+            "sensor1.json",
+            "metadata.json",
+            "sensor1.json.1234.deadbeef.tmp",
+        ]
         mock_isfile.return_value = True
         # Mock reading the metadata.json file
         mock_file_handle = AsyncMock()
         mock_file_handle.read.return_value = orjson.dumps({"lowest_time_step": 15})
         mock_aio_open.return_value.__aenter__.return_value = mock_file_handle
         res = await _publish_and_update_freq(input_data_dict, entity_path, logger, current_freq)
-        # publish_json should only be called for "sensor1.json", NOT "metadata.json"
+        # publish_json should only be called for "sensor1.json", NOT
+        # "metadata.json" nor the ".tmp" temp file.
         mock_publish_json.assert_called_once_with(
             "sensor1.json", input_data_dict, entity_path, logger, "continual_publish"
         )
@@ -1990,6 +2000,46 @@ class TestCommandLineAsyncUtils(unittest.IsolatedAsyncioTestCase):
         mock_rh.reset_mock()
         await publish_json(entity_file, input_data_dict, entity_path, logger)
         self.assertEqual(mock_rh.post_data.call_args[1]["idx"], 1)
+
+    @patch("emhass.command_line.asyncio.sleep", new_callable=AsyncMock)
+    @patch("emhass.command_line._publish_and_update_freq")
+    async def test_continual_publish_survives_cycle_exception(self, mock_update, _mock_sleep):
+        """A transient failure in a single publish cycle (e.g. issue #1000's
+        empty-file read raising ValueError) must not kill the background task:
+        the loop logs it and continues on the next interval. RED on base, where
+        the exception propagates out of continual_publish and publishing stops
+        until restart."""
+        input_data_dict = {
+            "retrieve_hass_conf": {
+                "time_zone": UTC,
+                "optimization_time_step": pd.Timedelta(minutes=5),
+            }
+        }
+        entity_path = pathlib.Path("/mock/entities")
+        logger = MagicMock()
+
+        count = 0
+
+        async def fake_update(*args, **kwargs):
+            nonlocal count
+            count += 1
+            if count == 1:
+                # The exact failure reported in issue #1000.
+                raise ValueError("Expected object or value")
+            # Break out of the otherwise-infinite loop on the second iteration.
+            # CancelledError is a BaseException, so a correct ``except Exception``
+            # guard does not swallow it.
+            raise asyncio.CancelledError
+
+        mock_update.side_effect = fake_update
+
+        with self.assertRaises(asyncio.CancelledError):
+            await continual_publish(input_data_dict, entity_path, logger)
+
+        # Reaching a second iteration proves the first exception was swallowed
+        # and the loop kept running.
+        self.assertEqual(count, 2)
+        logger.exception.assert_called_once()
 
 
 class TestCommandLineTimezoneLogic(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -2039,7 +2039,13 @@ class TestCommandLineAsyncUtils(unittest.IsolatedAsyncioTestCase):
         # Reaching a second iteration proves the first exception was swallowed
         # and the loop kept running.
         self.assertEqual(count, 2)
+        # The transient failure is logged (with traceback) exactly once, and the
+        # message is pinned so a future refactor cannot silently drop it.
         logger.exception.assert_called_once()
+        self.assertIn(
+            "continual_publish cycle failed; retrying next interval",
+            logger.exception.call_args[0][0],
+        )
 
 
 class TestCommandLineTimezoneLogic(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -1096,12 +1096,17 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
                         save_entities=True,
                         dont_post=True,
                     )
-                    # The metadata is committed atomically: a temp file is
-                    # os.replace'd into metadata.json (never an in-place write).
-                    mock_replace.assert_called_once()
-                    tmp_src, dest = mock_replace.call_args.args
-                    self.assertTrue(str(tmp_src).endswith(".tmp"))
-                    self.assertEqual(pathlib.Path(dest).name, "metadata.json")
+                    # Both the entity data file and metadata.json are committed
+                    # atomically: a temp file is os.replace'd into place (never
+                    # an in-place write). Two replaces: entity then metadata.
+                    self.assertEqual(mock_replace.call_count, 2)
+                    replaced = {}
+                    for call in mock_replace.call_args_list:
+                        tmp_src, dest = call.args
+                        self.assertTrue(str(tmp_src).endswith(".tmp"))
+                        replaced[pathlib.Path(dest).name] = str(tmp_src)
+                    self.assertIn("metadata.json", replaced)
+                    self.assertIn(entity_id + ".json", replaced)
         finally:
             # Restore path to prevent polluting other tests
             self.rh.emhass_conf["data_path"] = original_path
@@ -1270,6 +1275,59 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
             with open(metadata_path, "rb") as f:
                 metadata = orjson.loads(f.read())
             self.assertIn("sensor.x", metadata)
+
+    async def test_entity_data_file_written_atomically(self):
+        """The per-entity data file must be committed via a temp file + os.replace,
+        not an in-place truncating write, so the continual_publish reader never
+        observes the zero-byte window that raises ``ValueError: Expected object or
+        value`` in pd.read_json. Regression for issue #1000."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.rh.emhass_conf["data_path"] = pathlib.Path(tmpdir)
+            # get_data_from_file=True skips the network POST but still reaches
+            # the save_entities block (response_ok is forced True).
+            self.rh.get_data_from_file = True
+
+            data_df = pd.Series(
+                [100.0, 200.0],
+                index=pd.date_range("2024-01-01", periods=2, freq="30min"),
+            )
+            data_df.name = "test_data"
+            entity_id = "sensor.atomic_test"
+
+            replaced_names = []
+            real_replace = os.replace
+
+            def spy_replace(src, dst):
+                replaced_names.append(pathlib.Path(dst).name)
+                return real_replace(src, dst)
+
+            with patch("os.replace", side_effect=spy_replace):
+                response, _ = await self.rh.post_data(
+                    data_df,
+                    0,
+                    entity_id,
+                    "power",
+                    "W",
+                    entity_id,
+                    "power",
+                    save_entities=True,
+                    dont_post=True,
+                )
+
+            self.assertTrue(response.ok)
+            entities_path = pathlib.Path(tmpdir) / "entities"
+            entity_file = entities_path / (entity_id + ".json")
+            # The entity data file is committed through os.replace, exactly like
+            # metadata.json (RED on base: base only os.replace's metadata.json).
+            # Exactly two atomic commits: the entity file and metadata.json.
+            self.assertEqual(len(replaced_names), 2)
+            self.assertIn(entity_id + ".json", replaced_names)
+            # The final file exists and parses cleanly.
+            self.assertTrue(entity_file.is_file())
+            with open(entity_file, "rb") as f:
+                orjson.loads(f.read())
+            # The atomic commit must not leave temp files behind.
+            self.assertEqual(list(entities_path.glob("*.tmp")), [])
 
     async def test_session_lazy_initialization(self):
         """Test that session is lazily initialized on first use."""

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -1097,8 +1097,9 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
                         dont_post=True,
                     )
                     # Both the entity data file and metadata.json are committed
-                    # atomically: a temp file is os.replace'd into place (never
-                    # an in-place write). Two replaces: entity then metadata.
+                    # atomically: each is os.replace'd from a temp file into
+                    # place (never an in-place write). Exactly two replaces, one
+                    # per file; the relative order is not significant.
                     self.assertEqual(mock_replace.call_count, 2)
                     replaced = {}
                     for call in mock_replace.call_args_list:


### PR DESCRIPTION
## The bug

On a `continual_publish` setup, an automation calling `/action/naive-mpc-optim`
starts returning 400 and the result sensors in Home Assistant stop updating.
Later optimization runs log fine, but the sensors stay frozen at the timestamp
of the first failure until both EMHASS and HA are restarted. Reported in #1000
on 0.17.7, reproduces on master.

The traceback:

```
ERROR in app: Exception on request POST /action/naive-mpc-optim
  File "command_line.py", in continual_publish
    freq = await _publish_and_update_freq(...)
  File "command_line.py", in _publish_and_update_freq
    await publish_json(...)
  File "command_line.py", in publish_json
    entity_data = pd.read_json(entity_path / entity, orient="index")
ValueError: Expected object or value
```

## Root cause

`post_data(save_entities=True)` writes each `data/entities/<id>.json` in place
with a truncating `open(..., "w")`. The `continual_publish` background task reads
those same files on its own schedule, in the same event loop. When a read lands
in the window between truncate and write it sees a zero-byte file, and
`pd.read_json` raises `ValueError: Expected object or value`.

That is the visible error, but the reason a restart is needed is the second part:
`continual_publish` is a bare `while True:` with no exception handling, so that
one read error propagates out and the background task dies. After that, optim
runs still write fresh entity files but nothing republishes them on the continual
cadence, so the sensors stay frozen until the task is respawned at startup. Quart
logs the dead task against the request that started it, and that ERROR line is
what turns the next action response into a 400.

The `metadata.json` write directly below the entity write was already hardened
with a temp file plus `os.replace` in e749da98. The per-entity data file was the
remaining in-place write.

## The fix

- Write each entity file to a unique temp file then `os.replace` it into place,
  mirroring the existing `metadata.json` commit, so a concurrent reader always
  sees a complete document.
- `continual_publish` now catches a transient per-cycle exception, logs it, and
  retries on the next interval instead of exiting. `CancelledError` still
  propagates, so shutdown is unaffected.
- The reader skips in-flight `.tmp` files, since the atomic writes now place them
  briefly in the entities directory. This also covers the pre-existing
  `metadata.json` temp file.

## Behaviour change

No config or output change. On the happy path the published values, entity schema
and metadata format are identical. The only differences are that the entity write
is now atomic and the publisher loop no longer dies on a transient error.

## Tests

- `test_retrieve_hass.py`: new `test_entity_data_file_written_atomically` (entity
  file committed via `os.replace`, no temp file left behind); updated
  `test_post_data_extended` for the now-two atomic commits (entity + metadata).
- `test_command_line_utils.py`: new `test_continual_publish_survives_cycle_exception`
  (loop survives a cycle error and keeps running); extended
  `test_publish_and_update_freq` to confirm `.tmp` files are skipped.

All four are red on master and green with the fix. Full suite passes locally
(622 passed, 28 xfail).

Fixes #1000

## Summary by Sourcery

Ensure entity data files are written atomically and make the continual_publish loop robust against transient read errors.

Bug Fixes:
- Prevent continual_publish from crashing when encountering partially written or empty entity JSON files by catching per-cycle exceptions and continuing.
- Avoid reading in-flight temporary files during continual_publish to prevent bogus entity IDs and errors.

Enhancements:
- Write per-entity JSON files via a temporary file and atomic os.replace, mirroring metadata writes, so readers always see complete documents.

Tests:
- Add regression tests verifying atomic entity file writes, correct handling of temporary files during continual publishing, and that continual_publish survives a failing cycle and continues running.