### PR TITLE
fix: hold-last fill for dict forecasts with pre-horizon points (#1003)

### DIFF
--- a/docs/passing_data.md
+++ b/docs/passing_data.md
@@ -55,6 +55,20 @@ The possible dictionary keys to pass data are:
 
 - `prod_price_forecast` for the PV production selling price forecast.
 
+#### Passing a forecast as timestamped values
+
+Instead of a plain list, any of these forecast keys can be passed as an object that maps ISO 8601 timestamps to values. EMHASS aggregates the points to the optimization time step and then holds each value until the next provided point (step interpolation), so you only need to supply a point where the value changes. A point whose timestamp falls before the start of the optimization window is used to anchor the first values of the horizon.
+
+```json
+{
+  "load_cost_forecast": {
+    "2024-01-01T00:00:00+01:00": 0.20,
+    "2024-01-01T06:00:00+01:00": 0.15,
+    "2024-01-01T18:00:00+01:00": 0.30
+  }
+}
+```
+
 ### Passing other data at runtime
 
 It is possible to also pass other data during runtime to automate energy management. For example, it could be useful to dynamically update the total number of hours for each deferrable load (`operating_hours_of_each_deferrable_load`) using for instance a correlation with the outdoor temperature (useful for water heater for example). 

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1728,19 +1728,27 @@ async def treat_runtimeparams(
                     ).dt.tz_convert(time_zone)
 
                     # Aggregate any sub-step points to the optimization time step.
+                    # Resample in the local time_zone so the buckets line up with the
+                    # forecast grid, which get_forecast_dates floors in local time
+                    # (this matters for sub-hour UTC offsets such as +05:30).
                     forecast_data_df = forecast_data_df.resample(
                         pd.to_timedelta(optimization_time_step, "minutes"),
                         on="time",
                     ).aggregate({"value": "mean"})
-                    # Align with forecast_dates using hold-last (step) semantics: each
-                    # value holds until the next provided point. Union the two indexes
-                    # first so points defined before forecast_dates[0] still anchor the
-                    # forward-fill; reindexing straight onto forecast_dates with
-                    # method="nearest" dropped that anchor and let the trailing bfill
-                    # fill the leading slots with the NEXT value instead (issue #1003).
-                    # forecast_dates is a list of ISO strings; parse to a tz-aware
-                    # (UTC) index so the union aligns by instant across DST edges.
+                    # Now move to UTC so the union/reindex below align by instant
+                    # across DST edges without mixing two differently-localized
+                    # indexes. forecast_dates is a list of ISO strings; parse it to
+                    # the same UTC index. tz_convert only relabels, the instants are
+                    # unchanged, so the local-time aggregation above is preserved.
+                    forecast_data_df.index = forecast_data_df.index.tz_convert("UTC")
                     target_dates = pd.to_datetime(forecast_dates, utc=True)
+                    # Align with forecast_dates using hold-last (step) semantics: each
+                    # value holds until the next provided point. Union the provided
+                    # index with the horizon first so points defined before
+                    # forecast_dates[0] still anchor the forward-fill; reindexing
+                    # straight onto forecast_dates with method="nearest" dropped that
+                    # anchor and let the trailing bfill fill the leading slots with the
+                    # NEXT value instead (issue #1003).
                     combined_index = forecast_data_df.index.union(target_dates)
                     forecast_data_df = forecast_data_df.reindex(combined_index)
                     # ffill applies the hold-last; bfill then covers any slots before

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1727,16 +1727,27 @@ async def treat_runtimeparams(
                         forecast_data_df["time"], format="ISO8601", utc=True
                     ).dt.tz_convert(time_zone)
 
-                    # align index with forecast_dates
-                    forecast_data_df = (
-                        forecast_data_df.resample(
-                            pd.to_timedelta(optimization_time_step, "minutes"),
-                            on="time",
-                        )
-                        .aggregate({"value": "mean"})
-                        .reindex(forecast_dates, method="nearest")
-                    )
+                    # Aggregate any sub-step points to the optimization time step.
+                    forecast_data_df = forecast_data_df.resample(
+                        pd.to_timedelta(optimization_time_step, "minutes"),
+                        on="time",
+                    ).aggregate({"value": "mean"})
+                    # Align with forecast_dates using hold-last (step) semantics: each
+                    # value holds until the next provided point. Union the two indexes
+                    # first so points defined before forecast_dates[0] still anchor the
+                    # forward-fill; reindexing straight onto forecast_dates with
+                    # method="nearest" dropped that anchor and let the trailing bfill
+                    # fill the leading slots with the NEXT value instead (issue #1003).
+                    # forecast_dates is a list of ISO strings; parse to a tz-aware
+                    # (UTC) index so the union aligns by instant across DST edges.
+                    target_dates = pd.to_datetime(forecast_dates, utc=True)
+                    combined_index = forecast_data_df.index.union(target_dates)
+                    forecast_data_df = forecast_data_df.reindex(combined_index)
+                    # ffill applies the hold-last; bfill then covers any slots before
+                    # the first provided point (a dict that starts after the window
+                    # start) by extending that first value back over them.
                     forecast_data_df["value"] = forecast_data_df["value"].ffill().bfill()
+                    forecast_data_df = forecast_data_df.reindex(target_dates)
                     forecast_input = forecast_data_df["value"].tolist()
                 if isinstance(forecast_input, list) and len(forecast_input) >= len(forecast_dates):
                     params["passed_data"][forecast_key] = forecast_input

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -393,6 +393,76 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
             "my_custom_deferrable_forecast_id",
         )
 
+    @patch("emhass.utils._get_now")
+    async def test_treat_runtimeparams_dict_forecast_holds_last_value(self, mock_now):
+        """Regression for issue #1003.
+
+        A dict forecast (load_cost_forecast / prod_price_forecast) must hold each
+        value until the next provided point (step semantics). A point defined
+        BEFORE the forecast horizon start must anchor the leading slots; it must
+        not be discarded so that the trailing back-fill paints those slots with
+        the NEXT value. Before the fix, reindex(method="nearest") dropped the
+        pre-horizon anchor and the bfill filled the leading slots with the next
+        value, so the load price before the first in-horizon point read 0 and the
+        production price before its first point read the later peak value.
+        """
+        params = await TestUtils.get_test_params()
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(
+            orjson.dumps(params).decode("utf-8"), logger
+        )
+        time_zone = retrieve_hass_conf["time_zone"]
+
+        # Pin "now" to 09:00 local so the 30 min forecast grid starts there.
+        mock_local = pd.Timestamp("2026-06-26T09:00:00", tz=time_zone)
+        mock_now.return_value = mock_local.tz_convert(UTC)
+
+        def iso(hour, minute=0):
+            return pd.Timestamp(f"2026-06-26T{hour:02d}:{minute:02d}:00", tz=time_zone).isoformat()
+
+        horizon = 12  # 12 x 30 min = 09:00 .. 14:30
+        runtimeparams = {
+            "prediction_horizon": horizon,
+            # First point (08:00) is one hour before the horizon start (09:00).
+            "load_cost_forecast": {iso(8): 0.308, iso(11): 0.0, iso(14): 0.308},
+            "prod_price_forecast": {iso(8): 0.0, iso(13): 0.1, iso(21): 0.0},
+        }
+        set_type = "naive-mpc-optim"
+        params_out, _, _, _ = await utils.treat_runtimeparams(
+            runtimeparams,
+            orjson.dumps(params).decode("utf-8"),
+            retrieve_hass_conf,
+            optim_conf,
+            plant_conf,
+            set_type,
+            logger,
+            emhass_conf,
+        )
+        passed = orjson.loads(params_out)["passed_data"]
+        load_cost = passed["load_cost_forecast"]
+        prod_price = passed["prod_price_forecast"]
+
+        self.assertEqual(len(load_cost), horizon)
+        self.assertEqual(len(prod_price), horizon)
+
+        # Leading slots hold the pre-horizon anchor (the bug back-filled the next
+        # value here: load_cost[0] -> 0.0 and prod_price[0] -> 0.1).
+        self.assertAlmostEqual(load_cost[0], 0.308)
+        self.assertAlmostEqual(prod_price[0], 0.0)
+
+        # Full step profile across the horizon.
+        # load_cost: 0.308 until 11:00 (idx 4), 0.0 until 14:00 (idx 10), then 0.308.
+        for idx in range(0, 4):
+            self.assertAlmostEqual(load_cost[idx], 0.308)
+        for idx in range(4, 10):
+            self.assertAlmostEqual(load_cost[idx], 0.0)
+        for idx in range(10, 12):
+            self.assertAlmostEqual(load_cost[idx], 0.308)
+        # prod_price: 0.0 until 13:00 (idx 8), then 0.1 to the end of the horizon.
+        for idx in range(0, 8):
+            self.assertAlmostEqual(prod_price[idx], 0.0)
+        for idx in range(8, 12):
+            self.assertAlmostEqual(prod_price[idx], 0.1)
+
     async def test_treat_runtimeparams_failed(self):
         # Test treatment of nan values
         params = await TestUtils.get_test_params()


### PR DESCRIPTION
Fixes #1003.

When you pass `load_cost_forecast` or `prod_price_forecast` as a timestamp-to-value dict, EMHASS filled the horizon wrong whenever a point was defined before the start of the optimization window. The price before the first in-window change came out as the *next* value instead of the one that should have been held.

The reporter's case: a production price of 0 before 18:00 showed up as the 0.10 peak, and a load price that should have been 0.308 before 11:00 showed up as 0.

The cause is in `treat_runtimeparams` (the dict branch). It did:

```python
resample(step).aggregate({"value": "mean"}).reindex(forecast_dates, method="nearest")
# then .ffill().bfill()
```

`method="nearest"` snaps each horizon slot to the nearest provided timestamp rather than holding the last value, and it drops any point that sits before `forecast_dates[0]`. With that anchor gone, the trailing `bfill()` fills the leading slots with the next value.

The fix keeps the resample-mean aggregation (still correct for sub-step inputs) but aligns with hold-last semantics: union the provided index with the horizon, forward-fill, then reindex onto the horizon. The union keeps a pre-horizon point alive as a fill anchor, so each value holds until the next change. I parse `forecast_dates` (a list of ISO strings) to a UTC index so the union lines up by instant across DST edges.

Behaviour change to disclose: dict forecasts now use step / hold-last interpolation instead of nearest-point snapping. List forecasts are untouched. For a dict whose first point is already at or after the window start the output is unchanged, so the only thing that moves is the previously-wrong leading region.

Tests: added `test_treat_runtimeparams_dict_forecast_holds_last_value`. It pins the clock, passes a dict with a point one step before the horizon start, and checks that the leading slots hold the anchor value and the full step profile holds across the horizon. The test fails on master (the leading load slot reads 0 instead of 0.308) and passes with the fix. Full suite is green.

I also added a short note to `docs/passing_data.md` covering the timestamped-dict form, since only the list form was documented before.

## Summary by Sourcery

Fix handling of dict-based load and production price forecasts so values are held until the next change, including when an initial point lies before the optimization window, and document and test the corrected behaviour.

Bug Fixes:
- Ensure dict-based load_cost_forecast and prod_price_forecast correctly use hold-last semantics across the optimization horizon, including when an initial point occurs before the horizon start.

Documentation:
- Document how to pass forecasts as timestamp-to-value dictionaries and clarify that EMHASS uses step interpolation, holding each value until the next change.

Tests:
- Add a regression test verifying that dict-based forecasts hold the last value across the horizon and correctly anchor leading slots with pre-horizon points.