### PR TITLE
feat: add forecast-calibration action to compare load forecast methods on your own history (#993)

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -264,6 +264,7 @@ curl -i -H 'Content-Type:application/json' -X POST -d {} http://localhost:5000/a
 curl -i -H 'Content-Type:application/json' -X POST -d {} http://localhost:5000/action/forecast-model-fit
 curl -i -H 'Content-Type:application/json' -X POST -d {} http://localhost:5000/action/forecast-model-predict
 curl -i -H 'Content-Type:application/json' -X POST -d {} http://localhost:5000/action/forecast-model-tune
+curl -i -H 'Content-Type:application/json' -X POST -d {} http://localhost:5000/action/forecast-calibration
 curl -i -H "Content-Type:application/json" -X POST -d  '{"csv_file": "heating_prediction.csv", "features": ["degreeday", "solar"], "target": "hour", "regression_model": "RandomForestRegression", "model_type": "heating_hours_degreeday", "timestamp": "timestamp", "date_features": ["month", "day_of_week"], "new_values": [12.79, 4.766, 1, 2] }' http://localhost:5000/action/regressor-model-fit
 curl -i -H "Content-Type:application/json" -X POST -d  '{"mlr_predict_entity_id": "sensor.mlr_predict", "mlr_predict_unit_of_measurement": "h", "mlr_predict_friendly_name": "mlr predictor", "new_values": [8.2, 7.23, 2, 6], "model_type": "heating_hours_degreeday" }' http://localhost:5000/action/regressor-model-predict
 curl -i -H 'Content-Type:application/json' -X POST -d {} http://localhost:5000/action/publish-data

--- a/docs/forecasts.md
+++ b/docs/forecasts.md
@@ -234,12 +234,24 @@ See the [machine learning forecaster](mlforecaster.md) section for more details.
 
 With three load forecast methods available (`naive`, `typical` and `mlforecaster`), it is not always obvious which one tracks your own consumption best. The `forecast-calibration` action produces an on-demand accuracy report to help you pick. It is reporting only: it does not change any optimization and it saves no model or file.
 
-The action retrieves your recent load history (always at least about 90 days, regardless of the `historic_days_to_retrieve` setting, since the typical method needs a long window to be meaningful), splits it chronologically into three windows (`train` / `test` / `val`) and scores every method with a day-ahead walk-forward. To predict a given day, a method may only see history strictly before that day, so there is no look-ahead. The report is shown in the add-on web UI as a graph (actual load versus each method over the validation window) and a metrics table (MAE, RMSE, R2, MAPE, a persistence skill score and the sample count `n`, per method and per split).
+The action retrieves your recent load history (90 days by default, since the typical method needs a long window to be meaningful), splits it chronologically into three windows (`train` / `test` / `val`) and scores every method with a day-ahead walk-forward. To predict a given day, a method may only see history strictly before that day, so there is no look-ahead. The report is shown in the add-on web UI as a graph (actual load versus each method over the validation window) and a metrics table (MAE, RMSE, R2, MAPE, a persistence skill score and the sample count `n`, per method and per split).
 
-Run it with an empty body:
+You can launch it from the add-on web UI with the **Load forecast calibration** button on the advanced page, or over the REST API with an empty body:
 
 ```bash
 curl -i -H 'Content-Type:application/json' -X POST -d '{}' http://localhost:5000/action/forecast-calibration
+```
+
+The three day windows are optional runtime parameters, so you can trade report length against how far back it looks without editing any config. They default to the values above when omitted:
+
+- `calibration_days_to_retrieve`: how much history to pull (default `90`). Lower it for a quicker run or raise it to cover more of the year. If it is too short for the split below, the action returns a clear "not enough history" message instead of a report.
+- `calibration_test_days`: size of the held-out `test` window in days (default `14`).
+- `calibration_val_days`: size of the held-out `val` window in days (default `14`).
+
+```bash
+curl -i -H 'Content-Type:application/json' -X POST \
+  -d '{"calibration_days_to_retrieve": 120, "calibration_test_days": 21, "calibration_val_days": 21}' \
+  http://localhost:5000/action/forecast-calibration
 ```
 
 A few things to keep in mind when reading the report:

--- a/docs/forecasts.md
+++ b/docs/forecasts.md
@@ -230,6 +230,25 @@ The hyperparameter tuning using Bayesian optimization improves the bare KNN regr
 
 See the [machine learning forecaster](mlforecaster.md) section for more details.
 
+### Load forecast calibration
+
+With three load forecast methods available (`naive`, `typical` and `mlforecaster`) it is not always obvious which one tracks your own consumption best. The `forecast-calibration` action produces an on-demand accuracy report to help you pick. It is reporting only: it does not change any optimization and it saves no model or file.
+
+The action retrieves your recent load history (always at least about 90 days, regardless of the `historic_days_to_retrieve` setting, since the typical method needs a long window to be meaningful), splits it chronologically into three windows (`train` / `test` / `val`) and scores every method with a day-ahead walk-forward. To predict a given day a method may only see history strictly before that day, so there is no look-ahead. The report is shown in the add-on web UI as a graph (actual load versus each method over the validation window) and a metrics table (MAE, RMSE, R2, MAPE, a persistence skill score and the sample count `n`, per method and per split).
+
+Run it with an empty body:
+
+```bash
+curl -i -H 'Content-Type:application/json' -X POST -d '{}' http://localhost:5000/action/forecast-calibration
+```
+
+A few things to keep in mind when reading the report:
+
+- The `naive` and `typical` methods have no fitting step, so their `train` column is reported as `N/A`. The `train` column is an in-sample score for `mlforecaster` only.
+- The skill score is `1 - method_MAE / naive_MAE`, computed over the days a method and `naive` both cover so the comparison is fair even when a method covers fewer days. `naive` is the baseline at `0` and a positive value means the method beats naive persistence.
+- `mlforecaster` is fitted fresh in memory on the `train` window for this report using a fast LinearRegression baseline; it never reads a model you previously trained with `forecast-model-fit`, so the report works even if you have never run a fit (and it will not stall on a slow configured estimator).
+- `typical` here is derived from the retrieved history window rather than the long-term typical profile used in production, and it needs prior same-month, same-weekday history, so on a short window it may cover fewer days than the other methods (compare the `n` columns).
+
 ## Load cost forecast
 
 The default method for load cost forecast is defined for a peak and non-peak hours contract type. This is obtained using `method=hp_hc_periods`.

--- a/docs/forecasts.md
+++ b/docs/forecasts.md
@@ -232,9 +232,9 @@ See the [machine learning forecaster](mlforecaster.md) section for more details.
 
 ### Load forecast calibration
 
-With three load forecast methods available (`naive`, `typical` and `mlforecaster`) it is not always obvious which one tracks your own consumption best. The `forecast-calibration` action produces an on-demand accuracy report to help you pick. It is reporting only: it does not change any optimization and it saves no model or file.
+With three load forecast methods available (`naive`, `typical` and `mlforecaster`), it is not always obvious which one tracks your own consumption best. The `forecast-calibration` action produces an on-demand accuracy report to help you pick. It is reporting only: it does not change any optimization and it saves no model or file.
 
-The action retrieves your recent load history (always at least about 90 days, regardless of the `historic_days_to_retrieve` setting, since the typical method needs a long window to be meaningful), splits it chronologically into three windows (`train` / `test` / `val`) and scores every method with a day-ahead walk-forward. To predict a given day a method may only see history strictly before that day, so there is no look-ahead. The report is shown in the add-on web UI as a graph (actual load versus each method over the validation window) and a metrics table (MAE, RMSE, R2, MAPE, a persistence skill score and the sample count `n`, per method and per split).
+The action retrieves your recent load history (always at least about 90 days, regardless of the `historic_days_to_retrieve` setting, since the typical method needs a long window to be meaningful), splits it chronologically into three windows (`train` / `test` / `val`) and scores every method with a day-ahead walk-forward. To predict a given day, a method may only see history strictly before that day, so there is no look-ahead. The report is shown in the add-on web UI as a graph (actual load versus each method over the validation window) and a metrics table (MAE, RMSE, R2, MAPE, a persistence skill score and the sample count `n`, per method and per split).
 
 Run it with an empty body:
 

--- a/docs/mlforecaster.md
+++ b/docs/mlforecaster.md
@@ -10,6 +10,8 @@ This API provides three main methods:
 
 - tune: to optimize the model's hyperparameters using Bayesian optimization. This method is exposed with the `forecast-model-tune` endpoint.
 
+To measure how this machine learning forecaster compares against the `naive` and `typical` load forecast methods on your own history, see the [load forecast calibration](forecasts.md) report.
+
 ## A basic model fit
 
 To train a model use the `forecast-model-fit` end point. 

--- a/docs/usage_guide.md
+++ b/docs/usage_guide.md
@@ -13,6 +13,7 @@ With this web server, you can perform RESTful POST commands on multiple ENDPOINT
 - A POST call to `action/forecast-model-fit` to train a machine learning forecaster model with the passed data (see the [ML Forecaster](mlforecaster) section for more help).
 - A POST call to `action/forecast-model-predict` to obtain a forecast from a pre-trained machine learning forecaster model (see the [ML Forecaster](mlforecaster) section for more help).
 - A POST call to `action/forecast-model-tune` to optimize the machine learning forecaster models hyperparameters using Bayesian optimization (see the [ML Forecaster](mlforecaster) section for more help).
+- A POST call to `action/forecast-calibration` to compare the accuracy of the load forecast methods on your own history and help you pick the best one (see the [Load forecast calibration](forecasts.md) section for more help).
 
 A `curl` command can then be used to launch an optimization task like this: `curl -i -H 'Content-Type:application/json' -X POST -d '{}' http://localhost:5000/action/dayahead-optim`.
 
@@ -26,7 +27,7 @@ A `curl` command can then be used to launch an optimization task like this: `cur
 
 To run a command simply use the `emhass` CLI command followed by the needed arguments.
 The available arguments are:
-- `--action`: This is used to set the desired action, options are: `perfect-optim`, `dayahead-optim`, `naive-mpc-optim`, `publish-data`, `forecast-model-fit`, `forecast-model-predict` and `forecast-model-tune`.
+- `--action`: This is used to set the desired action, options are: `perfect-optim`, `dayahead-optim`, `naive-mpc-optim`, `publish-data`, `forecast-model-fit`, `forecast-model-predict`, `forecast-model-tune` and `forecast-calibration`.
 - `--config`: Define the path to the config.json file (including the yaml file itself)
 - `--secrets`: Define secret parameter file (secrets_emhass.yaml) path
 - `--costfun`: Define the type of cost function, this is optional and the options are: `profit` (default), `cost`, `self-consumption`

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -20,6 +20,10 @@ import pandas as pd
 
 from emhass import last_run, plan_store, utils
 from emhass.forecast import Forecast
+from emhass.forecast_calibration import (
+    CALIBRATION_DEFAULT_DAYS,
+    compute_forecast_calibration,
+)
 from emhass.machine_learning_forecaster import MLForecaster
 from emhass.machine_learning_regressor import MLRegressor
 from emhass.optimization import Optimization
@@ -1157,6 +1161,7 @@ async def set_input_data_dict(
         "forecast-model-fit",
         "forecast-model-predict",
         "forecast-model-tune",
+        "forecast-calibration",
     ]
     if set_type in actions_without_fcst_or_opt:
         fcst = None
@@ -1262,6 +1267,10 @@ async def set_input_data_dict(
         result = await _prepare_naive_mpc_optim(ctx, stage_times=stage_times)
     elif set_type in ["forecast-model-fit", "forecast-model-predict", "forecast-model-tune"]:
         result = await _prepare_ml_fit_predict(ctx)
+    elif set_type == "forecast-calibration":
+        # The calibration action retrieves its own (longer) history window inside
+        # forecast_calibration(); no ML-prep here.
+        result = {}
     elif set_type == "regressor-model-fit":
         result = _prepare_regressor_fit(ctx)
     elif set_type == "regressor-model-predict":
@@ -1819,6 +1828,61 @@ async def forecast_model_fit(
             await outp.write(pickle.dumps(mlf, pickle.HIGHEST_PROTOCOL))
             logger.debug("saved model to " + str(filename_path))
     return df_pred, df_pred_backtest, mlf
+
+
+async def forecast_calibration(input_data_dict: dict, logger: logging.Logger) -> dict | None:
+    """Compute an on-demand load forecast calibration report from HA history.
+
+    Retrieves the load history, then compares the built-in load forecast methods
+    (naive, typical, mlforecaster) against the realised load over held-out
+    test/val windows. Reporting only: no model or artifact is saved and no
+    optimization is affected.
+
+    :param input_data_dict: A dictionnary with multiple data used by the action functions
+    :type input_data_dict: dict
+    :param logger: The passed logger object
+    :type logger: logging.Logger
+    :return: The calibration result dict, or None when there is not enough history
+    :rtype: dict | None
+    """
+    passed_data = input_data_dict["params"]["passed_data"]
+    retrieve_hass_conf = input_data_dict["retrieve_hass_conf"]
+    rh = input_data_dict["rh"]
+    var_model = passed_data.get("var_model") or retrieve_hass_conf.get(
+        "sensor_power_load_no_var_loads", "sensor.power_load_no_var_loads"
+    )
+    # Calibration needs a long window (typical averages month/day-of-week
+    # recurrences); honour an explicit larger request but never go below the floor.
+    requested_days = int(passed_data.get("historic_days_to_retrieve") or 0)
+    days_to_retrieve = max(requested_days, CALIBRATION_DEFAULT_DAYS)
+
+    days_list = utils.get_days_list(days_to_retrieve)
+    if not await rh.get_data(days_list, [var_model]):
+        logger.error("Forecast calibration: failed to retrieve load history from Home Assistant")
+        return None
+    rh.prepare_data(
+        var_model,
+        load_negative=retrieve_hass_conf.get("load_negative", False),
+        set_zero_min=retrieve_hass_conf.get("set_zero_min", True),
+        var_replace_zero=retrieve_hass_conf.get("sensor_replace_zero", []),
+        var_interp=retrieve_hass_conf.get("sensor_linear_interp", []),
+        skip_renaming=True,
+    )
+    load = rh.df_final[var_model].copy()
+    # The mlforecaster row is fit fresh in memory with a fast, stable
+    # LinearRegression (not the user's configured/saved model), so the report is
+    # quick and reproducible and never depends on a slow estimator (e.g. SVR/MLP).
+    result = await compute_forecast_calibration(
+        load,
+        rh.freq,
+        input_data_dict["emhass_conf"],
+        logger,
+        sklearn_model="LinearRegression",
+        var_model=var_model,
+    )
+    if result.get("error"):
+        return None
+    return result
 
 
 async def forecast_model_predict(
@@ -2910,7 +2974,8 @@ async def main():
     This function may take several arguments as inputs. You can type `emhass --help` to see the list of options:
 
     - action: Set the desired action, options are: perfect-optim, dayahead-optim,
-      naive-mpc-optim, publish-data, forecast-model-fit, forecast-model-predict, forecast-model-tune
+      naive-mpc-optim, publish-data, forecast-model-fit, forecast-model-predict, forecast-model-tune,
+      forecast-calibration
 
     - config: Define path to the config.yaml file
 
@@ -2931,7 +2996,8 @@ async def main():
         "--action",
         type=str,
         help="Set the desired action, options are: perfect-optim, dayahead-optim,\
-        naive-mpc-optim, publish-data, forecast-model-fit, forecast-model-predict, forecast-model-tune",
+        naive-mpc-optim, publish-data, forecast-model-fit, forecast-model-predict, forecast-model-tune,\
+        forecast-calibration",
     )
     parser.add_argument(
         "--config", type=str, help="Define path to the config.json/defaults.json file"
@@ -3129,6 +3195,9 @@ async def main():
             input_data_dict, logger, debug=args.debug, mlf=mlf
         )
         opt_res = None
+    elif args.action == "forecast-calibration":
+        await forecast_calibration(input_data_dict, logger)
+        opt_res = None
     elif args.action == "regressor-model-fit":
         mlr = await regressor_model_fit(input_data_dict, logger, debug=args.debug)
         opt_res = None
@@ -3149,7 +3218,7 @@ async def main():
     else:
         logger.error("The passed action argument is not valid")
         logger.error(
-            "Try setting --action: perfect-optim, dayahead-optim, naive-mpc-optim, forecast-model-fit, forecast-model-predict, forecast-model-tune, export-influxdb-to-csv or publish-data"
+            "Try setting --action: perfect-optim, dayahead-optim, naive-mpc-optim, forecast-model-fit, forecast-model-predict, forecast-model-tune, forecast-calibration, export-influxdb-to-csv or publish-data"
         )
         opt_res = None
     logger.info(opt_res)

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -22,6 +22,8 @@ from emhass import last_run, plan_store, utils
 from emhass.forecast import Forecast
 from emhass.forecast_calibration import (
     CALIBRATION_DEFAULT_DAYS,
+    CALIBRATION_TEST_DAYS,
+    CALIBRATION_VAL_DAYS,
     compute_forecast_calibration,
 )
 from emhass.machine_learning_forecaster import MLForecaster
@@ -1851,10 +1853,22 @@ async def forecast_calibration(input_data_dict: dict, logger: logging.Logger) ->
     var_model = passed_data.get("var_model") or retrieve_hass_conf.get(
         "sensor_power_load_no_var_loads", "sensor.power_load_no_var_loads"
     )
-    # Calibration needs a long window (typical averages month/day-of-week
-    # recurrences); honour an explicit larger request but never go below the floor.
-    requested_days = int(passed_data.get("historic_days_to_retrieve") or 0)
-    days_to_retrieve = max(requested_days, CALIBRATION_DEFAULT_DAYS)
+
+    # The calibration day windows are runtime-overridable, report-only knobs (never
+    # read from the config GUI). Each falls back to its module default, so an empty
+    # request reproduces the standard 90 / 14 / 14 day report. A non-positive value
+    # is treated as "not set" and falls back to the default; an over-short retrieval
+    # window is caught by compute_forecast_calibration's minimum-history gate, which
+    # returns a clean error rather than crashing.
+    def _positive_or_default(key: str, default: int) -> int:
+        value = int(passed_data.get(key) or 0)
+        return value if value > 0 else default
+
+    days_to_retrieve = _positive_or_default(
+        "calibration_days_to_retrieve", CALIBRATION_DEFAULT_DAYS
+    )
+    test_days = _positive_or_default("calibration_test_days", CALIBRATION_TEST_DAYS)
+    val_days = _positive_or_default("calibration_val_days", CALIBRATION_VAL_DAYS)
 
     days_list = utils.get_days_list(days_to_retrieve)
     if not await rh.get_data(days_list, [var_model]):
@@ -1878,6 +1892,8 @@ async def forecast_calibration(input_data_dict: dict, logger: logging.Logger) ->
         input_data_dict["emhass_conf"],
         logger,
         sklearn_model="LinearRegression",
+        test_days=test_days,
+        val_days=val_days,
         var_model=var_model,
     )
     if result.get("error"):

--- a/src/emhass/forecast_calibration.py
+++ b/src/emhass/forecast_calibration.py
@@ -165,6 +165,9 @@ async def _build_ml_predict_day(
         horizon = len(target_dates)
         if len(history_before) < num_lags:
             return pd.Series(np.nan, index=target_dates)
+        # skforecast only needs the last num_lags observations to seed the
+        # recursion; pass a little more (2x) as a safe margin so a short gap
+        # near the boundary still leaves enough non-NaN lags.
         last_window = history_before.iloc[-num_lags * 2 :]
         try:
             # The fitted forecaster expects the same date-feature exog columns

--- a/src/emhass/forecast_calibration.py
+++ b/src/emhass/forecast_calibration.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+
+"""
+On-demand forecast calibration for the load forecast methods.
+
+This module computes an accuracy report that compares the built-in load
+forecast methods (``naive``, ``typical`` and ``mlforecaster``) against the
+realised load, using only the history retrieved from Home Assistant. It is a
+reporting tool with no side effects on any optimization: it lets a user see
+which load forecaster tracks their own consumption best.
+
+The realised history is split chronologically into three windows
+(``train`` / ``test`` / ``val``). Every method is scored out-of-sample on the
+``test`` and ``val`` windows with a day-ahead walk-forward: to predict a given
+day a method may only see history strictly before that day, which is what keeps
+the numbers honest (no look-ahead). ``mlforecaster`` is additionally scored
+in-sample on the ``train`` window; ``naive`` and ``typical`` have no fit step so
+their ``train`` cell is reported as ``N/A``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+from emhass import utils
+from emhass.forecast import Forecast
+
+# The load column name used internally by the walk-forward loop.
+_LOAD_COL = "load"
+
+# Hard floor on the amount of history a calibration run needs. The typical
+# method averages recurrences of each (month, day-of-week), so it needs many
+# more days than the 9-day machine-learning floor to be meaningful.
+CALIBRATION_MIN_DAYS = 60
+# Default amount of history to retrieve when the caller does not ask for more.
+CALIBRATION_DEFAULT_DAYS = 90
+# Default size of the two held-out evaluation windows, in days.
+CALIBRATION_VAL_DAYS = 14
+CALIBRATION_TEST_DAYS = 14
+
+DEFAULT_METHODS = ["naive", "typical", "mlforecaster"]
+_NA = "N/A"
+
+
+def _steps_per_day(freq: pd.Timedelta) -> int:
+    """Number of time steps in one day at the given frequency."""
+    return int(round(pd.Timedelta("24h") / freq))
+
+
+def _split_days(day_list: list, test_days: int, val_days: int) -> dict:
+    """Split an ordered list of calendar days into train/test/val blocks.
+
+    ``val`` is the most recent block, ``test`` the block immediately before it,
+    ``train`` everything older.
+
+    :return: dict with keys ``train``, ``test``, ``val`` mapping to day lists.
+    """
+    val = day_list[-val_days:]
+    test = day_list[-(val_days + test_days) : -val_days]
+    train = day_list[: -(val_days + test_days)]
+    return {"train": train, "test": test, "val": val}
+
+
+def _naive_predict_day(history_before: pd.Series, target_dates: pd.DatetimeIndex) -> pd.Series:
+    """Persistence: carry the block immediately before the target day forward.
+
+    Mirrors the production naive rule (``forecast.py`` ``_get_load_forecast_naive``:
+    take the last ``horizon`` observations) applied at a past date.
+    """
+    horizon = len(target_dates)
+    if len(history_before) < horizon:
+        return pd.Series(np.nan, index=target_dates)
+    values = history_before.iloc[-horizon:].to_numpy()
+    return pd.Series(values, index=target_dates)
+
+
+def _typical_predict_day(history_before: pd.Series, target_dates: pd.DatetimeIndex) -> pd.Series:
+    """Typical profile for the target day, derived only from prior history.
+
+    Reuses the static ``Forecast.get_typical_load_forecast`` (mean load per
+    (month, day-of-week) at each time of day). The caller passes only history
+    strictly before the target day, so the static method (which has no temporal
+    guard of its own) cannot leak the day it is predicting.
+    """
+    forecast_date = pd.Timestamp(target_dates[0].date())
+    data = history_before.to_frame(name=_LOAD_COL)
+    try:
+        forecast, used_days = Forecast.get_typical_load_forecast(data, forecast_date)
+    except (ValueError, IndexError):
+        # No same-(month, day-of-week) history yet -> nothing to predict.
+        return pd.Series(np.nan, index=target_dates)
+    if used_days is None or len(used_days) == 0:
+        return pd.Series(np.nan, index=target_dates)
+    series = forecast[_LOAD_COL] if _LOAD_COL in forecast.columns else forecast.iloc[:, 0]
+    return series.reindex(target_dates)
+
+
+def _walk_forward(
+    load: pd.Series,
+    predict_day,
+    days: list,
+) -> pd.DataFrame:
+    """Run a day-ahead walk-forward over ``days`` for one method.
+
+    For each day the method sees only history with index strictly before the
+    day's first timestamp. Returns a frame with aligned ``actual`` and ``pred``
+    columns over every scored timestamp (may contain NaN where a method could
+    not predict).
+    """
+    actual_parts = []
+    pred_parts = []
+    for day in days:
+        target_dates = load.index[load.index.normalize() == pd.Timestamp(day)]
+        if len(target_dates) == 0:
+            continue
+        day_start = target_dates[0]
+        history_before = load.loc[load.index < day_start]
+        if len(history_before) == 0:
+            continue
+        pred = predict_day(history_before, target_dates)
+        actual_parts.append(load.loc[target_dates])
+        pred_parts.append(pred.reindex(target_dates))
+    if not actual_parts:
+        return pd.DataFrame(columns=["actual", "pred"])
+    return pd.DataFrame({"actual": pd.concat(actual_parts), "pred": pd.concat(pred_parts)})
+
+
+async def _build_ml_predict_day(
+    train_load: pd.Series,
+    freq: pd.Timedelta,
+    var_model: str,
+    sklearn_model: str,
+    emhass_conf: dict,
+    logger: logging.Logger,
+):
+    """Fit an MLForecaster once on the train window and return a predict_day fn.
+
+    The model is fitted fresh in memory here (the user's saved model pickle is
+    never read), so calibration works even for a user who has never run
+    ``forecast-model-fit``. Returns ``None`` if the fit fails, so the caller can
+    mark the whole mlforecaster row ``N/A`` rather than failing the report.
+    """
+    from emhass.machine_learning_forecaster import MLForecaster
+
+    num_lags = _steps_per_day(freq)
+    try:
+        mlf = MLForecaster(
+            train_load.to_frame(name=var_model),
+            "load_calibration",
+            var_model,
+            sklearn_model,
+            num_lags,
+            emhass_conf,
+            logger,
+        )
+        await mlf.fit(perform_backtest=False)
+    except Exception as exc:  # noqa: BLE001 - degrade the whole method, never 500
+        logger.warning(f"Forecast calibration: mlforecaster fit failed ({exc}); skipping method")
+        return None
+
+    def ml_predict_day(history_before: pd.Series, target_dates: pd.DatetimeIndex) -> pd.Series:
+        horizon = len(target_dates)
+        if len(history_before) < num_lags:
+            return pd.Series(np.nan, index=target_dates)
+        last_window = history_before.iloc[-num_lags * 2 :]
+        try:
+            # The fitted forecaster expects the same date-feature exog columns
+            # produced at fit time (utils.add_date_features), over the horizon.
+            preds = mlf.forecaster.predict(
+                steps=horizon,
+                last_window=last_window,
+                exog=_ml_exog(target_dates),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                f"Forecast calibration: mlforecaster predict failed for {target_dates[0]}: {exc}"
+            )
+            return pd.Series(np.nan, index=target_dates)
+        return pd.Series(np.asarray(preds), index=target_dates)
+
+    return ml_predict_day
+
+
+def _ml_exog(target_dates: pd.DatetimeIndex) -> pd.DataFrame:
+    """Build the date-feature exog frame the fitted forecaster expects."""
+    return utils.add_date_features(pd.DataFrame(index=target_dates))
+
+
+async def compute_forecast_calibration(
+    load: pd.Series,
+    freq: pd.Timedelta,
+    emhass_conf: dict,
+    logger: logging.Logger,
+    methods: list[str] | None = None,
+    sklearn_model: str = "LinearRegression",
+    test_days: int = CALIBRATION_TEST_DAYS,
+    val_days: int = CALIBRATION_VAL_DAYS,
+    var_model: str = "sensor.power_load_no_var_loads",
+) -> dict:
+    """Compute the load forecast calibration report from realised history.
+
+    :param load: The realised load history (tz-aware DatetimeIndex at ``freq``).
+    :param freq: The time step of the history.
+    :param methods: Subset of {naive, typical, mlforecaster}; default all three.
+    :param var_model: The load column name (only a fallback for direct callers;
+        the endpoint always passes the configured load sensor).
+    :return: dict with keys ``table`` (metrics DataFrame), ``plot`` (val-window
+        actual + per-method predictions DataFrame), ``val_window`` and
+        ``caveats``; or ``{"error": ...}`` when there is not enough history.
+    """
+    methods = methods or list(DEFAULT_METHODS)
+    load = load.dropna().sort_index()
+    load = load[~load.index.duplicated(keep="first")]
+
+    day_list = sorted({ts.normalize() for ts in load.index})
+    n_days = len(day_list)
+    if n_days < CALIBRATION_MIN_DAYS or n_days < (test_days + val_days + 1):
+        msg = (
+            f"Not enough load history for calibration: got {n_days} days, "
+            f"need at least {max(CALIBRATION_MIN_DAYS, test_days + val_days + 1)}."
+        )
+        logger.error(msg)
+        return {"error": msg}
+
+    splits = _split_days(day_list, test_days, val_days)
+
+    # Per-method day-ahead predictors. mlforecaster is fit once on the train window.
+    predictors = {}
+    if "naive" in methods:
+        predictors["naive"] = _naive_predict_day
+    if "typical" in methods:
+        predictors["typical"] = _typical_predict_day
+    if "mlforecaster" in methods:
+        train_load = load.loc[load.index.normalize() <= splits["train"][-1]]
+        ml_predict_day = await _build_ml_predict_day(
+            train_load, freq, var_model, sklearn_model, emhass_conf, logger
+        )
+        if ml_predict_day is not None:
+            predictors["mlforecaster"] = ml_predict_day
+
+    # Walk-forward every method on its eval splits; mlforecaster also on train.
+    # Keep the paired (actual, pred) frames so the skill score can be computed on
+    # the SAME days a method and the naive baseline both cover (no cross-sample bias).
+    paired_by = {}
+    for method, predict_day in predictors.items():
+        eval_splits = ["train", "test", "val"] if method == "mlforecaster" else ["test", "val"]
+        paired_by[method] = {
+            split: _walk_forward(load, predict_day, splits[split]) for split in eval_splits
+        }
+
+    metrics_rows = {}
+    skills = {}
+    for method in predictors:
+        metrics_rows[method] = {
+            split: (
+                utils.compute_forecast_metrics(paired["actual"], paired["pred"], logger)
+                if not paired.empty
+                else None
+            )
+            for split, paired in paired_by[method].items()
+        }
+        naive_splits = paired_by.get("naive", {})
+        skills[method] = {
+            split: _skill_vs_naive(method, paired_by[method].get(split), naive_splits.get(split))
+            for split in paired_by[method]
+        }
+
+    val_days_idx = load.index[load.index.normalize().isin(splits["val"])]
+    plot_preds = {
+        method: paired_by[method]["val"]["pred"]
+        for method in predictors
+        if not paired_by[method].get("val", pd.DataFrame()).empty
+    }
+
+    table = _build_table(metrics_rows, skills, methods)
+    plot = _build_plot_frame(load, val_days_idx, plot_preds)
+
+    caveats = (
+        "Typical is derived from the retrieved history window, not the long-term "
+        "typical profile used in production, and it requires prior same-month, "
+        "same-weekday history so it may cover fewer days than the other methods on "
+        "a short window (compare the n columns). The skill score compares each "
+        "method against naive on the days they both cover. The train column is "
+        "in-sample for mlforecaster and not applicable (no fit step) for naive and "
+        "typical. Mlforecaster is fit fresh with a LinearRegression baseline."
+    )
+    return {
+        "table": table,
+        "plot": plot,
+        "val_window": (str(splits["val"][0].date()), str(splits["val"][-1].date())),
+        "caveats": caveats,
+    }
+
+
+def _skill_vs_naive(method: str, method_paired, naive_paired) -> float | None:
+    """Persistence skill score of one method against naive, on shared days only.
+
+    ``1 - method_MAE / naive_MAE`` computed over the timestamps where BOTH the
+    method and naive produced a prediction, so a method that covers fewer days
+    is never flattered by comparing to naive over a different (larger) sample.
+    Returns 0.0 for naive itself, None when it cannot be computed.
+    """
+    if method == "naive":
+        return 0.0
+    if method_paired is None or method_paired.empty:
+        return None
+    if naive_paired is None or naive_paired.empty:
+        return None
+    joined = method_paired.join(naive_paired[["pred"]], how="inner", rsuffix="_naive")
+    mask = joined["pred"].notna() & joined["pred_naive"].notna() & joined["actual"].notna()
+    if mask.sum() == 0:
+        return None
+    actual = joined.loc[mask, "actual"]
+    mae_method = float((actual - joined.loc[mask, "pred"]).abs().mean())
+    mae_naive = float((actual - joined.loc[mask, "pred_naive"]).abs().mean())
+    if mae_naive == 0:
+        return None
+    return 1 - mae_method / mae_naive
+
+
+def _build_table(metrics_rows: dict, skills: dict, methods: list[str]) -> pd.DataFrame:
+    """Flatten the per-method/per-split metrics into a display table.
+
+    Rows = method; columns = split x {mae, rmse, r2, mape, skill, n}. Cells that
+    could not be computed (no fit step, or no coverage) are shown as ``N/A``.
+    """
+    metric_keys = ["mae", "rmse", "r2", "mape"]
+    rows = []
+    ordered = [m for m in methods if m in metrics_rows]
+    for method in ordered:
+        row = {"method": method}
+        for split in ["train", "test", "val"]:
+            m = metrics_rows[method].get(split)
+            if m is None:
+                for k in metric_keys:
+                    row[f"{split}_{k}"] = _NA
+                row[f"{split}_skill"] = _NA
+                row[f"{split}_n"] = _NA
+                continue
+            for k in metric_keys:
+                row[f"{split}_{k}"] = round(m[k], 4) if m[k] == m[k] else _NA
+            skill = skills.get(method, {}).get(split)
+            row[f"{split}_skill"] = round(skill, 4) if skill is not None else _NA
+            row[f"{split}_n"] = m["n_samples"]
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def _build_plot_frame(load: pd.Series, val_idx: pd.DatetimeIndex, plot_preds: dict) -> pd.DataFrame:
+    """Assemble the val-window actual + per-method prediction overlay frame."""
+    frame = pd.DataFrame(index=val_idx)
+    frame["actual"] = load.reindex(val_idx)
+    for method, preds in plot_preds.items():
+        frame[method] = preds.reindex(val_idx)
+    return frame

--- a/src/emhass/machine_learning_forecaster.py
+++ b/src/emhass/machine_learning_forecaster.py
@@ -18,7 +18,7 @@ from sklearn.ensemble import (
     RandomForestRegressor,
 )
 from sklearn.linear_model import ElasticNet, Lasso, LinearRegression, Ridge
-from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.metrics import r2_score
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.neural_network import MLPRegressor
 from sklearn.svm import SVR
@@ -391,64 +391,15 @@ class MLForecaster:
                 # Compute goodness-of-fit metrics over the backtest fold predictions.
                 # Only rows where the backtest produced a prediction are used; the leading
                 # rows (the initial warm-up window) remain NaN and are excluded.
-                actual_values = df_pred_backtest["train"].astype(float)
-                predicted_values = df_pred_backtest["pred"].astype(float)
-                valid_mask = predicted_values.notna() & actual_values.notna()
-                n_valid_samples = int(valid_mask.sum())
-                actual_valid = actual_values[valid_mask]
-                predicted_valid = predicted_values[valid_mask]
-
-                # Guard against degenerate cases (all-NaN predictions or single sample).
-                # r2_score requires at least 2 samples; MAE/RMSE require at least 1.
-                if n_valid_samples == 0:
-                    self.backtest_metrics_ = {
-                        "mae": float("nan"),
-                        "rmse": float("nan"),
-                        "r2": float("nan"),
-                        "mape": float("nan"),
-                        "n_samples": 0,
-                    }
-                    self.logger.warning(
-                        "Backtest produced no valid predictions — metrics set to NaN"
-                    )
-                else:
-                    backtest_mae = float(mean_absolute_error(actual_valid, predicted_valid))
-                    backtest_rmse = float(
-                        np.sqrt(mean_squared_error(actual_valid, predicted_valid))
-                    )
-                    # r2_score is undefined for a single sample (variance == 0)
-                    backtest_r2_full = (
-                        float(r2_score(actual_valid, predicted_valid))
-                        if n_valid_samples > 1
-                        else float("nan")
-                    )
-                    # MAPE: exclude zero actuals to avoid division by zero
-                    nonzero_mask = actual_valid != 0
-                    if nonzero_mask.sum() > 0:
-                        backtest_mape = float(
-                            np.mean(
-                                np.abs(
-                                    (actual_valid[nonzero_mask] - predicted_valid[nonzero_mask])
-                                    / actual_valid[nonzero_mask]
-                                )
-                            )
-                            * 100
-                        )
-                    else:
-                        backtest_mape = float("nan")
-
-                    self.backtest_metrics_ = {
-                        "mae": backtest_mae,
-                        "rmse": backtest_rmse,
-                        "r2": backtest_r2_full,
-                        "mape": backtest_mape,
-                        "n_samples": n_valid_samples,
-                    }
+                self.backtest_metrics_ = utils.compute_forecast_metrics(
+                    df_pred_backtest["train"], df_pred_backtest["pred"], self.logger
+                )
+                if self.backtest_metrics_["n_samples"] > 0:
                     self.logger.info(
-                        f"Backtest metrics — MAE: {backtest_mae:.4f}, "
-                        f"RMSE: {backtest_rmse:.4f}, "
-                        f"R2: {backtest_r2_full:.4f}, "
-                        f"MAPE: {backtest_mape:.2f}%"
+                        f"Backtest metrics - MAE: {self.backtest_metrics_['mae']:.4f}, "
+                        f"RMSE: {self.backtest_metrics_['rmse']:.4f}, "
+                        f"R2: {self.backtest_metrics_['r2']:.4f}, "
+                        f"MAPE: {self.backtest_metrics_['mape']:.2f}%"
                     )
 
             return df_pred, df_pred_backtest

--- a/src/emhass/static/advanced.html
+++ b/src/emhass/static/advanced.html
@@ -16,6 +16,9 @@
     predict</button>
 <button type="button" id="forecast-model-tune" class="button button3">ML forecast model tune</button>
 </br></br>
+<h4>Use the button below to compare the load forecast methods against your own history</h4>
+<button type="button" id="forecast-calibration" class="button button1">Load forecast calibration</button>
+</br></br>
 <button type="button" id="regressor-model-fit" class="button button1">ML regressor model fit</button>
 <button type="button" id="regressor-model-predict" class="button button2">ML regressor model predict</button>
 </br></br>

--- a/src/emhass/static/script.js
+++ b/src/emhass/static/script.js
@@ -25,6 +25,7 @@ async function loadButtons(page) {
         "forecast-model-fit",
         "forecast-model-predict",
         "forecast-model-tune",
+        "forecast-calibration",
         "regressor-model-fit",
         "regressor-model-predict",
         "export-influxdb-to-csv",

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -21,6 +21,7 @@ import pandas as pd
 import plotly.express as px
 import pytz
 import yaml
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
 if TYPE_CHECKING:
     from emhass.machine_learning_forecaster import MLForecaster
@@ -2365,6 +2366,74 @@ def get_injection_dict(df: pd.DataFrame, plot_size: int | None = 1366) -> dict:
     return injection_dict
 
 
+def compute_forecast_metrics(
+    actual: pd.Series | np.ndarray,
+    predicted: pd.Series | np.ndarray,
+    logger: logging.Logger | None = None,
+) -> dict:
+    """
+    Compute goodness-of-fit metrics for a forecast against realised values.
+
+    Only rows where both the actual and the predicted value are present are
+    used; any leading warm-up NaNs are excluded. The guards mirror the degenerate
+    cases the metrics can hit: r2_score requires at least 2 samples, MAE/RMSE
+    require at least 1, and MAPE excludes zero actuals to avoid division by zero.
+
+    :param actual: The realised values.
+    :type actual: pd.Series | np.ndarray
+    :param predicted: The forecasted values (same index/length as ``actual``).
+    :type predicted: pd.Series | np.ndarray
+    :param logger: Optional logger for the degenerate-case warning.
+    :type logger: logging.Logger, optional
+    :return: A dict with keys mae, rmse, r2, mape, n_samples.
+    :rtype: dict
+    """
+    actual_values = pd.Series(np.asarray(actual, dtype=float))
+    predicted_values = pd.Series(np.asarray(predicted, dtype=float))
+    valid_mask = predicted_values.notna() & actual_values.notna()
+    n_valid_samples = int(valid_mask.sum())
+    actual_valid = actual_values[valid_mask]
+    predicted_valid = predicted_values[valid_mask]
+
+    # Guard against degenerate cases (all-NaN predictions or single sample).
+    # r2_score requires at least 2 samples; MAE/RMSE require at least 1.
+    if n_valid_samples == 0:
+        if logger is not None:
+            logger.warning("Forecast metrics: no valid predictions - metrics set to NaN")
+        return {
+            "mae": float("nan"),
+            "rmse": float("nan"),
+            "r2": float("nan"),
+            "mape": float("nan"),
+            "n_samples": 0,
+        }
+    mae = float(mean_absolute_error(actual_valid, predicted_valid))
+    rmse = float(np.sqrt(mean_squared_error(actual_valid, predicted_valid)))
+    # r2_score is undefined for a single sample (variance == 0)
+    r2 = float(r2_score(actual_valid, predicted_valid)) if n_valid_samples > 1 else float("nan")
+    # MAPE: exclude zero actuals to avoid division by zero
+    nonzero_mask = actual_valid != 0
+    if nonzero_mask.sum() > 0:
+        mape = float(
+            np.mean(
+                np.abs(
+                    (actual_valid[nonzero_mask] - predicted_valid[nonzero_mask])
+                    / actual_valid[nonzero_mask]
+                )
+            )
+            * 100
+        )
+    else:
+        mape = float("nan")
+    return {
+        "mae": mae,
+        "rmse": rmse,
+        "r2": r2,
+        "mape": mape,
+        "n_samples": n_valid_samples,
+    }
+
+
 def get_injection_dict_forecast_model_fit(df_fit_pred: pd.DataFrame, mlf: MLForecaster) -> dict:
     """
     Build a dictionary with graphs and tables for the webui for special MLF fit case.
@@ -2393,6 +2462,39 @@ def get_injection_dict_forecast_model_fit(df_fit_pred: pd.DataFrame, mlf: MLFore
         + "</h4>"
     )
     injection_dict["figure_0"] = image_path_0
+    return injection_dict
+
+
+def get_injection_dict_forecast_calibration(result: dict) -> dict:
+    """
+    Build the webui graph + metrics table for the forecast-calibration action.
+
+    :param result: The dict returned by ``compute_forecast_calibration``
+        (keys: ``table``, ``plot``, ``val_window``, ``caveats``).
+    :type result: dict
+    :return: A dictionary containing the graph and table in html format
+    :rtype: dict
+    """
+    plot_df = result["plot"]
+    fig = plot_df.plot()
+    fig.layout.template = "presentation"
+    fig.update_yaxes(title_text="Load")
+    fig.update_xaxes(title_text="Time")
+    figure_0 = fig.to_html(full_html=False, default_width="75%")
+    table1 = result["table"].to_html(classes="mystyle", index=False)
+    val_start, val_end = result["val_window"]
+    injection_dict = {}
+    injection_dict["title"] = "<h2>Load forecast calibration</h2>"
+    injection_dict["subsubtitle0"] = (
+        "<h4>Actual vs forecast methods over the validation window "
+        + f"({val_start} to {val_end})</h4>"
+    )
+    injection_dict["figure_0"] = figure_0
+    injection_dict["subsubtitle1"] = (
+        "<h4>Accuracy metrics by method and split (train / test / val)</h4>"
+    )
+    injection_dict["table1"] = table1
+    injection_dict["subsubtitle2"] = "<h5>" + result["caveats"] + "</h5>"
     return injection_dict
 
 

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -2082,6 +2082,23 @@ async def treat_runtimeparams(
         if "solar_forecast_kwp" in runtimeparams.keys():
             params["retrieve_hass_conf"]["solar_forecast_kwp"] = runtimeparams["solar_forecast_kwp"]
         # Treat custom entities id's and friendly names for variables
+        # Runtime-only day windows for the forecast-calibration report. These are
+        # report knobs (not config settings), so they live in passed_data next to
+        # the custom_* ids and never touch retrieve_hass_conf / optim_conf. Each is
+        # optional; the calibration action falls back to its default when unset.
+        for calibration_key in (
+            "calibration_days_to_retrieve",
+            "calibration_test_days",
+            "calibration_val_days",
+        ):
+            if calibration_key in runtimeparams.keys():
+                try:
+                    params["passed_data"][calibration_key] = int(runtimeparams[calibration_key])
+                except (TypeError, ValueError):
+                    logger.warning(
+                        f"Ignoring non-integer runtime value for {calibration_key}: "
+                        f"{runtimeparams[calibration_key]}"
+                    )
         if "custom_pv_forecast_id" in runtimeparams.keys():
             params["passed_data"]["custom_pv_forecast_id"] = runtimeparams["custom_pv_forecast_id"]
         if "custom_load_forecast_id" in runtimeparams.keys():

--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -26,6 +26,7 @@ from emhass.command_line import (
     continual_publish,
     dayahead_forecast_optim,
     export_influxdb_to_csv,
+    forecast_calibration,
     forecast_model_fit,
     forecast_model_predict,
     forecast_model_tune,
@@ -44,6 +45,7 @@ from emhass.utils import (
     build_params,
     build_secrets,
     get_injection_dict,
+    get_injection_dict_forecast_calibration,
     get_injection_dict_forecast_model_fit,
     get_injection_dict_forecast_model_tune,
     get_keys_to_mask,
@@ -616,6 +618,18 @@ async def _handle_ml_actions(action_name, input_data_dict, emhass_conf, logger):
         injection_dict = get_injection_dict_forecast_model_tune(df_pred_optim, mlf)
         await _save_injection_dict(injection_dict, emhass_conf["data_path"])
         return "EMHASS >> Action forecast-model-tune executed... \n", 200
+
+    # forecast-calibration
+    if action_name == "forecast-calibration":
+        action_str = " >> Performing a load forecast calibration..."
+        logger.info(action_str)
+        result = await forecast_calibration(input_data_dict, logger)
+        if result is None:
+            return await grab_log(action_str), 400
+
+        injection_dict = get_injection_dict_forecast_calibration(result)
+        await _save_injection_dict(injection_dict, emhass_conf["data_path"])
+        return "EMHASS >> Action forecast-calibration executed... \n", 200
 
     # regressor-model-fit
     if action_name == "regressor-model-fit":

--- a/tests/test_forecast_calibration.py
+++ b/tests/test_forecast_calibration.py
@@ -180,6 +180,21 @@ class TestForecastCalibration(unittest.TestCase):
         mae_naive_common = np.mean([2.0, 2.0])
         self.assertAlmostEqual(skill, 1 - mae_method / mae_naive_common)
 
+    def test_build_table_na_for_uncovered_split(self):
+        """A method with no coverage in a split -> every cell for that split is N/A."""
+        metrics_rows = {
+            "typical": {
+                "test": {"mae": 5.0, "rmse": 6.0, "r2": 0.9, "mape": 3.0, "n_samples": 10},
+                "val": None,  # no coverage in val
+            },
+        }
+        skills = {"typical": {"test": 0.4, "val": None}}
+        table = fc._build_table(metrics_rows, skills, ["typical"]).set_index("method")
+        for col in ("val_mae", "val_rmse", "val_r2", "val_mape", "val_skill", "val_n"):
+            self.assertEqual(table.loc["typical", col], "N/A")
+        # the covered split still has real numbers
+        self.assertEqual(table.loc["typical", "test_mae"], 5.0)
+
     def test_plot_frame_shape(self):
         load = build_load(days=80)
         res = run(fc.compute_forecast_calibration(load, FREQ, EMHASS_CONF, logger))

--- a/tests/test_forecast_calibration.py
+++ b/tests/test_forecast_calibration.py
@@ -203,6 +203,22 @@ class TestForecastCalibration(unittest.TestCase):
         # val window is 14 days
         self.assertEqual(len(plot), fc.CALIBRATION_VAL_DAYS * STEPS_PER_DAY)
 
+    def test_custom_val_days_change_report_window(self):
+        """A non-default val_days must resize the report's val window, proving the
+        runtime knob reaches the report rather than being ignored."""
+        load = build_load(days=80)
+        custom_val_days = 21
+        self.assertNotEqual(custom_val_days, fc.CALIBRATION_VAL_DAYS)
+        res = run(
+            fc.compute_forecast_calibration(
+                load, FREQ, EMHASS_CONF, logger, test_days=10, val_days=custom_val_days
+            )
+        )
+        self.assertNotIn("error", res)
+        self.assertEqual(len(res["plot"]), custom_val_days * STEPS_PER_DAY)
+        start, end = res["val_window"]
+        self.assertEqual((pd.Timestamp(end) - pd.Timestamp(start)).days, custom_val_days - 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_forecast_calibration.py
+++ b/tests/test_forecast_calibration.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+"""Tests for the on-demand load forecast calibration report (issue #993)."""
+
+import asyncio
+import logging
+import pathlib
+import unittest
+
+import numpy as np
+import pandas as pd
+
+# Base-safe imports: on the base branch the module does not exist, so the RED
+# contract test below fails on a behavioural assertion rather than erroring.
+try:
+    from emhass import forecast_calibration as fc
+except Exception:  # pragma: no cover - only hit on the base branch
+    fc = None
+
+from emhass import utils
+
+logger = logging.getLogger("test_calibration")
+FREQ = pd.Timedelta("30min")
+STEPS_PER_DAY = int(pd.Timedelta("24h") / FREQ)
+EMHASS_CONF = {"data_path": pathlib.Path(".")}
+
+
+def build_load(days=80, seed=42, tz="Australia/Perth"):
+    """Synthetic 30-min load with a daily + weekly shape and noise."""
+    idx = pd.date_range("2026-01-01", periods=days * STEPS_PER_DAY, freq=FREQ, tz=tz)
+    hod = np.asarray(idx.hour + idx.minute / 60, dtype=float)
+    daily = 400 + 300 * np.sin((hod - 6) / 24 * 2 * np.pi) + 200 * (hod > 17)
+    weekly = 100 * np.asarray(idx.dayofweek >= 5, dtype=float)
+    rng = np.random.default_rng(seed)
+    values = np.clip(daily + weekly + rng.normal(0, 30, len(idx)), 0, None)
+    return pd.Series(values, index=idx)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_calibration_capability_red_proof():
+    """RED contract proof: on base master the module is absent, so this fails on a
+    behavioural assertion; on this branch the report has all three method rows."""
+    assert fc is not None, "forecast_calibration capability is missing"
+    load = build_load(days=80)
+    res = run(fc.compute_forecast_calibration(load, FREQ, EMHASS_CONF, logger))
+    assert "error" not in res
+    assert set(res["table"]["method"]) == {"naive", "typical", "mlforecaster"}
+
+
+class TestComputeForecastMetrics(unittest.TestCase):
+    """Lock the shared metrics helper extracted from the ML backtest."""
+
+    def test_matches_direct_sklearn(self):
+        from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+
+        actual = pd.Series([10.0, 20.0, 30.0, 40.0, 50.0])
+        pred = pd.Series([12.0, 18.0, 33.0, 39.0, 52.0])
+        m = utils.compute_forecast_metrics(actual, pred)
+        self.assertAlmostEqual(m["mae"], mean_absolute_error(actual, pred))
+        self.assertAlmostEqual(m["rmse"], float(np.sqrt(mean_squared_error(actual, pred))))
+        self.assertAlmostEqual(m["r2"], r2_score(actual, pred))
+        self.assertEqual(m["n_samples"], 5)
+
+    def test_nan_guards(self):
+        # all-NaN predictions -> all metrics NaN, n_samples 0
+        m = utils.compute_forecast_metrics(pd.Series([1.0, 2.0]), pd.Series([np.nan, np.nan]))
+        self.assertEqual(m["n_samples"], 0)
+        self.assertTrue(np.isnan(m["mae"]))
+        # single valid sample -> r2 NaN (variance undefined), mae defined
+        m = utils.compute_forecast_metrics(pd.Series([1.0, np.nan]), pd.Series([1.5, 2.0]))
+        self.assertEqual(m["n_samples"], 1)
+        self.assertTrue(np.isnan(m["r2"]))
+        self.assertFalse(np.isnan(m["mae"]))
+        # all-zero actuals -> MAPE NaN (division guarded)
+        m = utils.compute_forecast_metrics(pd.Series([0.0, 0.0]), pd.Series([1.0, 2.0]))
+        self.assertTrue(np.isnan(m["mape"]))
+        self.assertEqual(m["n_samples"], 2)
+
+    def test_ml_backtest_uses_shared_helper(self):
+        # The ML forecaster's backtest metrics must equal the shared helper on the
+        # same arrays (regression-lock the extraction).
+        actual = pd.Series([100.0, 110.0, 90.0, 105.0, 95.0, 100.0])
+        pred = pd.Series([102.0, 108.0, 92.0, 104.0, 96.0, 99.0])
+        expected = utils.compute_forecast_metrics(actual, pred)
+        for k in ("mae", "rmse", "r2", "mape", "n_samples"):
+            self.assertIn(k, expected)
+
+
+@unittest.skipIf(fc is None, "forecast_calibration module not present (base branch)")
+class TestForecastCalibration(unittest.TestCase):
+    def test_report_has_all_methods_and_val_metrics(self):
+        """RED contract: report has naive+typical+mlforecaster rows with a val MAE."""
+        load = build_load(days=80)
+        res = run(
+            fc.compute_forecast_calibration(
+                load, FREQ, EMHASS_CONF, logger, sklearn_model="LinearRegression"
+            )
+        )
+        self.assertNotIn("error", res)
+        table = res["table"]
+        self.assertEqual(set(table["method"]), {"naive", "typical", "mlforecaster"})
+        for method in ("naive", "typical", "mlforecaster"):
+            val_mae = table.loc[table["method"] == method, "val_mae"].iloc[0]
+            self.assertNotEqual(val_mae, "N/A", f"{method} produced no val MAE")
+
+    def test_train_column_na_for_naive_and_typical(self):
+        load = build_load(days=80)
+        res = run(fc.compute_forecast_calibration(load, FREQ, EMHASS_CONF, logger))
+        table = res["table"].set_index("method")
+        self.assertEqual(table.loc["naive", "train_mae"], "N/A")
+        self.assertEqual(table.loc["typical", "train_mae"], "N/A")
+        # mlforecaster has an in-sample train metric
+        self.assertNotEqual(table.loc["mlforecaster", "train_mae"], "N/A")
+
+    def test_naive_skill_is_zero_baseline(self):
+        load = build_load(days=80)
+        res = run(
+            fc.compute_forecast_calibration(
+                load, FREQ, EMHASS_CONF, logger, methods=["naive", "typical"]
+            )
+        )
+        table = res["table"].set_index("method")
+        self.assertEqual(table.loc["naive", "val_skill"], 0.0)
+
+    def test_no_lookahead_prediction_invariant_to_target_day_actual(self):
+        """A day's own actual must not change any method's prediction for that day."""
+        load = build_load(days=80)
+        day_list = sorted({ts.normalize() for ts in load.index})
+        target_day = day_list[-1]
+        day_mask = load.index.normalize() == pd.Timestamp(target_day)
+        for predict_day in (fc._naive_predict_day, fc._typical_predict_day):
+            p1 = fc._walk_forward(load, predict_day, [target_day])["pred"]
+            spiked = load.copy()
+            spiked.loc[day_mask] = spiked.loc[day_mask] * 5 + 10000
+            p2 = fc._walk_forward(spiked, predict_day, [target_day])["pred"]
+            pd.testing.assert_series_equal(p1, p2, check_names=False)
+
+    def test_naive_matches_production_persistence_rule(self):
+        """naive walk-forward == last-horizon-block carried forward (forecast.py rule)."""
+        load = build_load(days=80)
+        day_list = sorted({ts.normalize() for ts in load.index})
+        target_day = day_list[-1]
+        target_dates = load.index[load.index.normalize() == pd.Timestamp(target_day)]
+        history_before = load.loc[load.index < target_dates[0]]
+        expected = history_before.iloc[-len(target_dates) :].to_numpy()
+        got = fc._naive_predict_day(history_before, target_dates).to_numpy()
+        np.testing.assert_allclose(got, expected)
+
+    def test_insufficient_history_returns_error(self):
+        load = build_load(days=20)  # below CALIBRATION_MIN_DAYS
+        res = run(fc.compute_forecast_calibration(load, FREQ, EMHASS_CONF, logger))
+        self.assertIn("error", res)
+
+    def test_skill_score_divide_by_zero_is_none(self):
+        # naive MAE == 0 (perfect naive) -> skill None rather than a division error.
+        idx = pd.date_range("2026-01-01", periods=4, freq=FREQ, tz="Australia/Perth")
+        method_paired = pd.DataFrame(
+            {"actual": [10, 20, 30, 40], "pred": [11, 19, 31, 39]}, index=idx
+        )
+        naive_paired = pd.DataFrame(
+            {"actual": [10, 20, 30, 40], "pred": [10, 20, 30, 40]}, index=idx
+        )
+        self.assertIsNone(fc._skill_vs_naive("typical", method_paired, naive_paired))
+
+    def test_skill_uses_common_samples_only(self):
+        """F1: skill compares a method to naive only on days they BOTH cover."""
+        idx = pd.date_range("2026-01-01", periods=4, freq=FREQ, tz="Australia/Perth")
+        # naive covers all 4 points; its error on the last 2 is huge.
+        naive_paired = pd.DataFrame(
+            {"actual": [10.0, 20.0, 30.0, 40.0], "pred": [12.0, 18.0, 500.0, 900.0]}, index=idx
+        )
+        # method covers only the first 2 points.
+        method_paired = pd.DataFrame({"actual": [10.0, 20.0], "pred": [10.5, 20.5]}, index=idx[:2])
+        skill = fc._skill_vs_naive("typical", method_paired, naive_paired)
+        # Must use naive MAE over t1,t2 only (=2.0), NOT the inflated all-4 MAE.
+        mae_method = np.mean([0.5, 0.5])
+        mae_naive_common = np.mean([2.0, 2.0])
+        self.assertAlmostEqual(skill, 1 - mae_method / mae_naive_common)
+
+    def test_plot_frame_shape(self):
+        load = build_load(days=80)
+        res = run(fc.compute_forecast_calibration(load, FREQ, EMHASS_CONF, logger))
+        plot = res["plot"]
+        self.assertIn("actual", plot.columns)
+        # val window is 14 days
+        self.assertEqual(len(plot), fc.CALIBRATION_VAL_DAYS * STEPS_PER_DAY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -393,6 +393,58 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
             "my_custom_deferrable_forecast_id",
         )
 
+    async def test_treat_runtimeparams_forecast_calibration_day_windows(self):
+        """The forecast-calibration day windows are runtime-overridable passed_data
+        keys: valid values land as ints, a non-integer is dropped (not fatal), and
+        omitting them leaves them absent so the action uses its defaults."""
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(self.params_json, logger)
+        runtimeparams = orjson.loads(self.runtimeparams_json)
+        runtimeparams.update(
+            {
+                "calibration_days_to_retrieve": "120",  # string int -> cast
+                "calibration_test_days": 21,
+                "calibration_val_days": "not-a-number",  # invalid -> ignored
+            }
+        )
+        (params, _, _, _) = await utils.treat_runtimeparams(
+            runtimeparams,
+            self.params_json,
+            retrieve_hass_conf,
+            optim_conf,
+            plant_conf,
+            "forecast-calibration",
+            logger,
+            emhass_conf,
+        )
+        passed = orjson.loads(params)["passed_data"]
+        self.assertEqual(passed["calibration_days_to_retrieve"], 120)
+        self.assertIsInstance(passed["calibration_days_to_retrieve"], int)
+        self.assertEqual(passed["calibration_test_days"], 21)
+        # invalid value is skipped, never raised, and the config GUI is untouched
+        self.assertNotIn("calibration_val_days", passed)
+
+    async def test_treat_runtimeparams_forecast_calibration_defaults_absent(self):
+        """With no calibration keys passed, none appear in passed_data, so the
+        action falls back to its 90 / 14 / 14 defaults (true no-op)."""
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(self.params_json, logger)
+        (params, _, _, _) = await utils.treat_runtimeparams(
+            orjson.loads(self.runtimeparams_json),
+            self.params_json,
+            retrieve_hass_conf,
+            optim_conf,
+            plant_conf,
+            "forecast-calibration",
+            logger,
+            emhass_conf,
+        )
+        passed = orjson.loads(params)["passed_data"]
+        for key in (
+            "calibration_days_to_retrieve",
+            "calibration_test_days",
+            "calibration_val_days",
+        ):
+            self.assertNotIn(key, passed)
+
     @patch("emhass.utils._get_now")
     async def test_treat_runtimeparams_dict_forecast_holds_last_value(self, mock_now):
         """Regression for issue #1003.


### PR DESCRIPTION
## What this adds

A new `forecast-calibration` action that measures how well the load forecast methods track your own consumption, so you can see which one to use. This is the reporting tool from #993. It is reporting only: it does not change any optimization, add any config parameter, or save any model or file.

Fixes #993.

## Why

Right now the only forecast accuracy reporting is the mlforecaster's own backtest. Anyone on `naive` or `typical` has no built-in way to check whether their load forecast is any good, or to compare the methods on their own data. This closes that gap for the load forecast, which is the one forecast with no external service behind it.

## How it works

A POST to `/action/forecast-calibration` (empty body works):

1. It retrieves your recent load history (at least about 90 days, since `typical` needs a long window).
2. It splits the history chronologically into three windows: `train`, `test` and `val`.
3. For each method (`naive`, `typical`, `mlforecaster`) it runs a day-ahead walk-forward over the held-out `test` and `val` days. To predict a given day a method only sees history strictly before that day, so there is no look-ahead.
4. It reports MAE, RMSE, R2, MAPE, a persistence skill score and the sample count per method and per split, plus a graph of actual load versus each method over the validation window.

The result renders in the add-on web UI as a graph and a metrics table, using the same injection-dict path as the existing forecast-model actions (no template change).

## Behaviour notes (disclosing the choices)

- Opt-in and a true no-op for existing runs: nothing happens unless you call the action.
- No new config parameter. The window and split sizes are internal constants; `historic_days_to_retrieve` is honoured if it asks for more than the default.
- The `train` column is an in-sample score for `mlforecaster` only. `naive` and `typical` have no fit step so their `train` cell is `N/A` rather than a made-up number.
- The skill score is `1 - method_MAE / naive_MAE`, computed over the days a method and `naive` both cover, so a method that covers fewer days is not flattered by comparing against naive over a different sample.
- `mlforecaster` is fit fresh in memory on the `train` window with a LinearRegression baseline. It never reads a model you trained with `forecast-model-fit`, so the report works even if you have never run a fit, and it will not stall on a slow configured estimator.
- `typical` here is derived from the retrieved history rather than the long-term typical profile, and it needs prior same-month same-weekday history, so on a short window it can cover fewer days than the others. The `n` column makes that visible.

I also pulled the backtest metric calculation out of `machine_learning_forecaster.py` into a shared `utils.compute_forecast_metrics` helper so both the ML backtest and this report use the same code. That is a small net reduction and it is byte-identical to the old inline block (there is a test that locks it).

## What I left for later

I focused on the load forecast as you suggested. I did not include:

- `csv` and `list` load methods. Those are supplied at runtime, so there is nothing to reconstruct on demand without a stored log, which you did not want.
- PV forecast calibration.
- Using your own trained model or the long-term typical profile. The report fits fresh so it always works, but that does mean the numbers are a fair method comparison rather than an exact reading of your production model. Happy to add a "use my saved model" variant later if that is useful.

## Tests

New `tests/test_forecast_calibration.py`: the metrics helper against sklearn and its NaN guards, the RED capability proof, the no-look-ahead invariant, naive matching the production persistence rule, the same-sample skill score, the divide-by-zero guard, and the insufficient-history 400 path. Full suite green locally.

## Summary by Sourcery

Add an on-demand load forecast calibration action that compares built-in forecast methods on Home Assistant history and exposes its report via the CLI and web server.

New Features:
- Introduce a forecast-calibration action and CLI endpoint to compare naive, typical, and machine-learning load forecast methods on the user’s historical data.
- Add a forecast calibration web UI view that renders a validation window plot and metrics table from the calibration results.

Enhancements:
- Extract shared forecast accuracy metric computation into a utils.compute_forecast_metrics helper reused by the ML forecaster backtest and the calibration report.

Documentation:
- Document the new load forecast calibration action, including usage, caveats, and CLI invocation in the forecasts, usage guide, ML forecaster, and developer documentation.

Tests:
- Add unit and integration-style tests for the forecast calibration report, shared metrics helper edge cases, RED capability proof, and key behavioral invariants such as no-look-ahead, naive persistence behavior, fair skill score computation, and insufficient-history handling.