### PR TITLE
fix: Catch UnicodeDecodeError on torn pickle cache reads in web_server

### DIFF
--- a/src/emhass/web_server.py
+++ b/src/emhass/web_server.py
@@ -211,7 +211,7 @@ async def index():
             content = await fid.read()
             try:
                 injection_dict = pickle.loads(content)
-            except (EOFError, pickle.UnpicklingError):
+            except (EOFError, pickle.UnpicklingError, UnicodeDecodeError):
                 app.logger.warning(
                     "The data container file is empty or incomplete (possible write race condition). "
                     "Please launch an optimization task."
@@ -290,7 +290,7 @@ async def configuration():
             content = await fid.read()
             try:
                 _, params = pickle.loads(content)  # Don't overwrite emhass_conf["config_path"]
-            except (EOFError, pickle.UnpicklingError):
+            except (EOFError, pickle.UnpicklingError, UnicodeDecodeError):
                 params = {}
     else:
         params = {}
@@ -312,7 +312,7 @@ async def template_action():
             content = await fid.read()
             try:
                 injection_dict = pickle.loads(content)
-            except (EOFError, pickle.UnpicklingError):
+            except (EOFError, pickle.UnpicklingError, UnicodeDecodeError):
                 app.logger.warning(
                     "The data container file is empty or incomplete (possible write race condition). "
                     "Please launch an optimization task."
@@ -490,7 +490,7 @@ async def _load_params_and_runtime(request, emhass_conf, logger):
             content = await fid.read()
             try:
                 _, params = pickle.loads(content)  # Don't overwrite emhass_conf["config_path"]
-            except (EOFError, pickle.UnpicklingError):
+            except (EOFError, pickle.UnpicklingError, UnicodeDecodeError):
                 logger.error(
                     "params.pkl is corrupted or truncated (race condition); cannot proceed"
                 )
@@ -934,7 +934,7 @@ async def _load_injection_dict() -> dict | None:
             content = await fid.read()
             try:
                 return pickle.loads(content)
-            except (EOFError, pickle.UnpicklingError):
+            except (EOFError, pickle.UnpicklingError, UnicodeDecodeError):
                 # File truncated due to write race condition; treat as not yet available
                 return None
     else:


### PR DESCRIPTION
All 5 spots in `web_server.py` that read a pickled cache file (`injection_dict`, `params.pkl`) already anticipate a write-race condition where the web server reads the file while an optimization task is mid-write, and handle it via `except (EOFError, pickle.UnpicklingError)`. But a torn read can also surface as a `UnicodeDecodeError` from inside `pickle.loads`, when the partial bytes happen to include a string opcode with a truncated/invalid UTF-8 payload — this isn't caught by the existing except clause and crashes the request with a 500 instead of falling back to the intended "race condition, please launch an optimization task" handling.

Reproduced in production: two optimization actions (`naive-mpc-optim` and `dayahead-optim`) landing back-to-back at the same cron tick, with a `GET /` request racing the `injection_dict` write in between:

```
[ERROR] Exception on request GET /
  File ".../emhass/web_server.py", line 213, in index
    injection_dict = pickle.loads(content)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x95 in position 4854088: invalid start byte
```

This widens the except tuple at all 5 call sites to also catch `UnicodeDecodeError`, so they degrade the same way the existing race-condition handling already does.

## Summary by Sourcery

Bug Fixes:
- Treat UnicodeDecodeError from pickle.loads on cache files as a recoverable race condition across all cache read sites.