### PR TITLE
fix: plumb soc_final through dayahead-optim (#1002)

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -1902,7 +1902,10 @@ async def dayahead_forecast_optim(
     """
     _t0 = _time.monotonic()
     soc_init = input_data_dict["params"]["passed_data"].get("soc_init")
-    logger.info(f"Performing day-ahead forecast optimization with soc_init: {soc_init}")
+    soc_final = input_data_dict["params"]["passed_data"].get("soc_final")
+    logger.info(
+        f"Performing day-ahead forecast optimization with soc_init: {soc_init}, soc_final: {soc_final}"
+    )
     # Prepare forecast data with costs, prices, outdoor temp, and GHI
     with stage_timer(input_data_dict["stage_times"], "price_prep", logger):
         df_input_data_dayahead = prepare_forecast_and_weather_data(
@@ -1916,6 +1919,7 @@ async def dayahead_forecast_optim(
             input_data_dict["p_pv_forecast"],
             input_data_dict["p_load_forecast"],
             soc_init=soc_init,
+            soc_final=soc_final,
             stage_times=input_data_dict["stage_times"],
         )
     # Save CSV file for publish_data

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -3763,16 +3763,7 @@ class Optimization:
                 else:
                     soc_init = self.plant_conf["battery_target_state_of_charge"]
             if soc_final is None:
-                # With set_battery_first_priority enabled, defaulting
-                # soc_final = soc_init collides with the "import only when
-                # SoC <= SOC_min" gate whenever soc_init > SOC_min: the
-                # solver is forced to end at the initial (high) SoC without
-                # ever being allowed to recharge through import, which is
-                # structurally infeasible (#1002). Fall back to SOC_min so
-                # the battery is free to drain naturally under the flag.
-                if self.optim_conf.get("set_battery_first_priority", False):
-                    soc_final = self.plant_conf["battery_minimum_state_of_charge"]
-                elif soc_init is not None:
+                if soc_init is not None:
                     soc_final = soc_init
                 else:
                     soc_final = self.plant_conf["battery_target_state_of_charge"]

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -3763,7 +3763,16 @@ class Optimization:
                 else:
                     soc_init = self.plant_conf["battery_target_state_of_charge"]
             if soc_final is None:
-                if soc_init is not None:
+                # With set_battery_first_priority enabled, defaulting
+                # soc_final = soc_init collides with the "import only when
+                # SoC <= SOC_min" gate whenever soc_init > SOC_min: the
+                # solver is forced to end at the initial (high) SoC without
+                # ever being allowed to recharge through import, which is
+                # structurally infeasible (#1002). Fall back to SOC_min so
+                # the battery is free to drain naturally under the flag.
+                if self.optim_conf.get("set_battery_first_priority", False):
+                    soc_final = self.plant_conf["battery_minimum_state_of_charge"]
+                elif soc_init is not None:
                     soc_final = soc_init
                 else:
                     soc_final = self.plant_conf["battery_target_state_of_charge"]
@@ -4872,6 +4881,7 @@ class Optimization:
         p_pv: pd.Series,
         p_load: pd.Series,
         soc_init: float | None = None,
+        soc_final: float | None = None,
         stage_times: dict[str, float] | None = None,
     ) -> pd.DataFrame:
         r"""
@@ -4886,6 +4896,18 @@ class Optimization:
         :param p_load: The forecasted Load power consumption. This power should \
             not include the power from the deferrable load that we want to find.
         :type p_load: pandas.DataFrame
+        :param soc_init: Optional initial battery SOC for the optimization. \
+            When ``None`` (the default), falls back to ``soc_final`` if set, \
+            otherwise to ``battery_target_state_of_charge`` from the plant config.
+        :type soc_init: float, optional
+        :param soc_final: Optional final battery SOC for the optimization. \
+            When ``None`` (the default), falls back to ``soc_init`` if set, \
+            otherwise to ``battery_target_state_of_charge``. Passing an explicit \
+            ``soc_final`` distinct from ``soc_init`` is required to plan a \
+            net battery charge / discharge across the horizon — notably when \
+            ``set_battery_first_priority`` is enabled and the horizon starts \
+            at a high SOC.
+        :type soc_final: float, optional
         :param stage_times: Optional dict to record nested sub-stage timings
             (``optim_solve.build`` / ``optim_solve.solve`` / ``optim_solve.extract``).
         :type stage_times: dict, optional
@@ -4893,7 +4915,9 @@ class Optimization:
         :rtype: pandas.DataFrame
 
         """
-        self.logger.info(f"Perform optimization for the day-ahead with soc_init: {soc_init}")
+        self.logger.info(
+            f"Perform optimization for the day-ahead with soc_init: {soc_init}, soc_final: {soc_final}"
+        )
 
         # Extract cost arrays (ensure they are flat numpy arrays)
         unit_load_cost = df_input_data[self.var_load_cost].values
@@ -4908,6 +4932,7 @@ class Optimization:
             unit_load_cost,
             unit_prod_price,
             soc_init=soc_init,
+            soc_final=soc_final,
             stage_times=stage_times,
         )
         return self.opt_res

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1338,6 +1338,96 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         self.opt.perform_naive_mpc_optim(df, pv, load, 6, soc_init=0.5, soc_final=0.5)
         self.assertNotIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
 
+    def test_battery_first_priority_dayahead_default_soc_final_is_feasible(self):
+        """Issue #1002: ``set_battery_first_priority`` with dayahead-optim used to
+        be structurally infeasible whenever ``soc_init`` was above ``SOC_min``
+        and no explicit ``soc_final`` was passed. The default ``soc_final =
+        soc_init`` collided with the "import only when SoC <= SOC_min" gate:
+        the solver was forced to end at the initial (high) SoC while never
+        being allowed to recharge through import. The fix defaults
+        ``soc_final`` to ``SOC_min`` under the flag, letting the battery drain
+        naturally so the plan is feasible.
+        """
+        df = self.prepare_forecast_data()
+        df["p_pv_forecast"] = 0.0
+        df["p_load_forecast"] = 1000.0
+        df["unit_load_cost"] = 0.28
+        df["unit_prod_price"] = 0.08
+        pv = df["p_pv_forecast"].copy()
+        load = df["p_load_forecast"].copy()
+        self.optim_conf.update(
+            {
+                "set_use_battery": True,
+                "number_of_deferrable_loads": 0,
+                "set_battery_dynamic": False,
+                "set_nodischarge_to_grid": True,
+                "set_battery_first_priority": True,
+            }
+        )
+        self.plant_conf.update(
+            {
+                "battery_nominal_energy_capacity": 7700,
+                "battery_discharge_power_max": 20000,
+                "battery_charge_power_max": 20000,
+                "battery_minimum_state_of_charge": 0.1,
+                "battery_maximum_state_of_charge": 1.0,
+                "battery_discharge_efficiency": 1.0,
+                "battery_charge_efficiency": 1.0,
+            }
+        )
+        self.opt = self.create_optimization()
+        # soc_init=1.0, soc_final=None. Before #1002 the default soc_final=
+        # soc_init=1.0 made this infeasible. It must now solve to Optimal.
+        self.opt.perform_dayahead_forecast_optim(df, pv, load, soc_init=1.0)
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+
+    def test_dayahead_forecast_optim_honours_soc_final(self):
+        """Issue #1002: ``perform_dayahead_forecast_optim`` now accepts
+        ``soc_final`` and passes it through to ``perform_optimization``.
+        Setting an explicit ``soc_final`` different from ``soc_init`` must
+        change the final SoC in the resulting plan, proving the plumbing.
+        """
+        df = self.prepare_forecast_data()
+        df["p_pv_forecast"] = 0.0
+        df["p_load_forecast"] = 500.0
+        df["unit_load_cost"] = 0.28
+        df["unit_prod_price"] = 0.08
+        pv = df["p_pv_forecast"].copy()
+        load = df["p_load_forecast"].copy()
+        self.optim_conf.update(
+            {
+                "set_use_battery": True,
+                "number_of_deferrable_loads": 0,
+                "set_battery_dynamic": False,
+                "set_nodischarge_to_grid": False,
+            }
+        )
+        self.plant_conf.update(
+            {
+                "battery_nominal_energy_capacity": 10000,
+                "battery_discharge_power_max": 20000,
+                "battery_charge_power_max": 20000,
+                "battery_minimum_state_of_charge": 0.1,
+                "battery_maximum_state_of_charge": 1.0,
+                "battery_discharge_efficiency": 1.0,
+                "battery_charge_efficiency": 1.0,
+            }
+        )
+        self.opt = self.create_optimization()
+        res_hi = self.opt.perform_dayahead_forecast_optim(
+            df, pv, load, soc_init=0.9, soc_final=0.9
+        )
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+
+        self.opt = self.create_optimization()
+        res_lo = self.opt.perform_dayahead_forecast_optim(
+            df, pv, load, soc_init=0.9, soc_final=0.1
+        )
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+        # The lower target must end at a strictly lower SoC — proving the
+        # runtime soc_final actually reached the constraint.
+        self.assertLess(res_lo["SOC_opt"].iloc[-1], res_hi["SOC_opt"].iloc[-1] - 0.05)
+
     def test_sequence_load_runs_with_zero_operating_hours(self):
         """Issue #887: a sequence (list-valued power) deferrable load runs for
         the length of its sequence and ignores operating_hours, which is

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1338,49 +1338,6 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         self.opt.perform_naive_mpc_optim(df, pv, load, 6, soc_init=0.5, soc_final=0.5)
         self.assertNotIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
 
-    def test_battery_first_priority_dayahead_default_soc_final_is_feasible(self):
-        """Issue #1002: ``set_battery_first_priority`` with dayahead-optim used to
-        be structurally infeasible whenever ``soc_init`` was above ``SOC_min``
-        and no explicit ``soc_final`` was passed. The default ``soc_final =
-        soc_init`` collided with the "import only when SoC <= SOC_min" gate:
-        the solver was forced to end at the initial (high) SoC while never
-        being allowed to recharge through import. The fix defaults
-        ``soc_final`` to ``SOC_min`` under the flag, letting the battery drain
-        naturally so the plan is feasible.
-        """
-        df = self.prepare_forecast_data()
-        df["p_pv_forecast"] = 0.0
-        df["p_load_forecast"] = 1000.0
-        df["unit_load_cost"] = 0.28
-        df["unit_prod_price"] = 0.08
-        pv = df["p_pv_forecast"].copy()
-        load = df["p_load_forecast"].copy()
-        self.optim_conf.update(
-            {
-                "set_use_battery": True,
-                "number_of_deferrable_loads": 0,
-                "set_battery_dynamic": False,
-                "set_nodischarge_to_grid": True,
-                "set_battery_first_priority": True,
-            }
-        )
-        self.plant_conf.update(
-            {
-                "battery_nominal_energy_capacity": 7700,
-                "battery_discharge_power_max": 20000,
-                "battery_charge_power_max": 20000,
-                "battery_minimum_state_of_charge": 0.1,
-                "battery_maximum_state_of_charge": 1.0,
-                "battery_discharge_efficiency": 1.0,
-                "battery_charge_efficiency": 1.0,
-            }
-        )
-        self.opt = self.create_optimization()
-        # soc_init=1.0, soc_final=None. Before #1002 the default soc_final=
-        # soc_init=1.0 made this infeasible. It must now solve to Optimal.
-        self.opt.perform_dayahead_forecast_optim(df, pv, load, soc_init=1.0)
-        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
-
     def test_dayahead_forecast_optim_honours_soc_final(self):
         """Issue #1002: ``perform_dayahead_forecast_optim`` now accepts
         ``soc_final`` and passes it through to ``perform_optimization``.


### PR DESCRIPTION
## Summary

Scoped-down follow-up to #1002. Complementary to #1014, not a competitor
— I originally proposed both a plumbing change and a default-fallback
change; @LesIT1's #1014 addresses the infeasibility at its source (the
hard import-gate becomes a soft penalty), which is the better fix and
makes my default-fallback change unnecessary. I've reverted that part.

What stays: **plumb `soc_final` through the dayahead path.** ee56fdf
already routes runtime `soc_init` through
`dayahead_forecast_optim` → `perform_dayahead_forecast_optim` →
`perform_optimization`; this adds the symmetric `soc_final` step for the
same three functions. Currently the only way to pin a terminal SoC on
the dayahead path is to switch to `naive-mpc-optim`, which changes the
horizon and cadence semantics — this closes that gap.

Orthogonal to the constraint model, useful with or without
`set_battery_first_priority`.

## Regression test

`test_dayahead_forecast_optim_honours_soc_final` proves the runtime
`soc_final` actually reaches `perform_optimization` by contrasting two
runs with different targets (`soc_final=0.9` vs `soc_final=0.1`) and
asserting `SOC_opt.iloc[-1]` differs by more than the SoC-recovery
tolerance. No dependency on `set_battery_first_priority`.

## Order-of-merge

Either order works — the two PRs touch different concerns and don't
conflict:

- #1014 first, this after: nothing to do here; the plumb is independent.
- This first, #1014 after: same.

I've kept the two commits on the branch (the initial change + the
scope-down revert) so the reasoning is visible in history. Happy to
squash if you'd prefer a single-commit landing.

Related: #834, #957, #1014.
