### PR TITLE
fix: guard get_mix_forecast against a missing sensor column (#764)

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -1070,6 +1070,14 @@ class Forecast:
         if ignore_pv_feedback:
             return df_forecast
 
+        # The mix correction blends the latest real sensor value into the first
+        # forecast step. When the forecast was supplied as a runtime list rather
+        # than read from the sensor, df_now holds no column for that sensor, so
+        # there is no live value to blend. Skip the correction and return the
+        # forecast unchanged instead of raising a KeyError (issue #764).
+        if df_now is None or col not in df_now.columns or df_now.empty:
+            return df_forecast
+
         first_fcst = alpha * df_forecast.iloc[0] + beta * df_now[col].iloc[-1]
         df_forecast.iloc[0] = int(round(first_fcst))
         return df_forecast

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -2818,6 +2818,43 @@ class TestDstForecastDates(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(fcst_normal.forecast_dates), expected_slots)
 
 
+class TestGetMixForecast(unittest.TestCase):
+    """Unit tests for the static Forecast.get_mix_forecast mix-correction helper.
+
+    The callers pass the forecast as a pandas Series and the current real
+    values as a DataFrame keyed by sensor column (see get_power_from_weather /
+    get_load_forecast).
+    """
+
+    def test_missing_sensor_column_returns_forecast_unchanged(self):
+        # Issue #764: when the forecast is supplied as a runtime list, df_now has
+        # no column for the configured sensor, so there is no live value to blend.
+        # get_mix_forecast must skip the correction, not raise KeyError.
+        col = "sensor.pv_production_watts"
+        forecast = pd.Series([1000.0, 900.0, 800.0])
+        df_now = pd.DataFrame({"sensor.other": [42]})  # lacks `col`
+        out = Forecast.get_mix_forecast(df_now, forecast.copy(), 0.5, 0.5, col)
+        pd.testing.assert_series_equal(out, forecast)
+
+    def test_empty_df_now_returns_forecast_unchanged(self):
+        col = "sensor.pv_production_watts"
+        forecast = pd.Series([1000.0, 900.0, 800.0])
+        out = Forecast.get_mix_forecast(pd.DataFrame(), forecast.copy(), 0.5, 0.5, col)
+        pd.testing.assert_series_equal(out, forecast)
+
+    def test_present_sensor_column_still_blends_first_step(self):
+        # Counterfactual: when df_now HAS the column, the first step is still
+        # blended, so the guard does not disable the normal correction path.
+        col = "sensor.pv_production_watts"
+        forecast = pd.Series([1000.0, 900.0, 800.0])
+        df_now = pd.DataFrame({col: [600, 500]})  # latest real value = 500
+        out = Forecast.get_mix_forecast(df_now, forecast.copy(), 0.5, 0.5, col)
+        # first step = round(0.5*1000 + 0.5*500) = 750; the rest are unchanged
+        self.assertEqual(int(out.iloc[0]), 750)
+        self.assertEqual(int(out.iloc[1]), 900)
+        self.assertEqual(int(out.iloc[2]), 800)
+
+
 if __name__ == "__main__":
     unittest.main()
     ch.close()


### PR DESCRIPTION
### The bug

`naive-mpc-optim` crashes with `HTTP 500` / `KeyError: <pv sensor>` when `pv_power_forecast` is passed as a runtime list (reported in #764, hit again in #1011). The same crash happens for a runtime `load_power_forecast` list.

The mix correction in `Forecast.get_mix_forecast` blends the latest real sensor value into the first forecast step:

```python
first_fcst = alpha * df_forecast.iloc[0] + beta * df_now[col].iloc[-1]
```

When the forecast comes from a runtime list instead of the sensor, `df_now` has no column for the configured sensor, so `df_now[col]` raises `KeyError` and the whole optimisation aborts.

### The fix

If `df_now` is empty or does not contain the sensor column there is no live value to blend, so return the forecast unchanged and skip the correction. One guard in the shared static method covers both the PV and load callers. When the column is present the blend is unchanged, so there is no behaviour change for the normal sensor-backed path.

### Tests

`tests/test_forecast.py::TestGetMixForecast`:
- missing sensor column returns the forecast unchanged (was a KeyError)
- empty `df_now` returns the forecast unchanged
- present sensor column still blends the first step (guards the happy path)

The first two fail on master with the reported KeyError; all three pass with the fix. Full suite stays green.

## Summary by Sourcery

Guard mix forecast computation against missing or empty sensor data to prevent runtime crashes when forecasts are provided as lists.

Bug Fixes:
- Prevent KeyError in get_mix_forecast when df_now lacks the configured sensor column or is empty.

Tests:
- Add unit coverage for get_mix_forecast to ensure missing sensor columns and empty current-value frames return forecasts unchanged, and valid sensor data still triggers mix correction.