### PR TITLE
fix: weather-forecast-cache never refreshes a stale Solcast cache (#1016)

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -563,7 +563,21 @@ class Forecast:
 
     async def _get_weather_solcast(self, w_forecast_cache_path: str) -> pd.DataFrame:
         """Helper to retrieve weather data from Solcast or cache."""
-        cached_data = await self._get_cached_forecast_or_none(w_forecast_cache_path)
+        # The explicit `weather-forecast-cache` action sets weather_forecast_cache
+        # and is meant to refresh the cache from the Solcast API. Reading the cache
+        # first here would return a stale-but-present cache early (for Solcast,
+        # get_cached_forecast_data serves reindexed/zero-filled stale data instead
+        # of returning None), so the refresh action would never fetch and the cache
+        # would freeze permanently once it aged past its coverage window. Bypass the
+        # cache read for that action so it always fetches fresh; normal cache_only
+        # MPC runs still read the cache. The fetch stays quota-guarded by
+        # _solcast_rate_limit_ok.
+        force_refresh = self.params["passed_data"].get("weather_forecast_cache", False)
+        cached_data = (
+            None
+            if force_refresh
+            else await self._get_cached_forecast_or_none(w_forecast_cache_path)
+        )
         if cached_data is not None:
             return cached_data
         # Incompatible/stale cache was discarded (issue #932); fall through


### PR DESCRIPTION
## What

Make the `weather-forecast-cache` action always fetch a fresh Solcast forecast, instead of short-circuiting on an existing stale cache.

## Why

`_get_weather_solcast` reads the cache **before** deciding to fetch and returns early whenever a cache file exists:

```python
cached_data = await self._get_cached_forecast_or_none(w_forecast_cache_path)
if cached_data is not None:
    return cached_data
```

The `weather_forecast_cache` flag (set by the `weather-forecast-cache` action) only controls **saving after a fetch** — it does not bypass this early return. For Solcast, `get_cached_forecast_data` serves reindexed/zero-filled stale data (non-`None`) when the cache no longer covers the requested timeframe, so the dedicated refresh action can never fetch while any cache file is present.

Result: the Solcast cache is effectively **write-once then frozen**. The only fetch that ever happens is the first (when no file exists); after the cache ages past its coverage window (~1 day, given ~2× horizon is cached), every optimization silently runs on a flat/zero PV forecast. This is the Solcast counterpart of the Open-Meteo stale-cache regressions from v0.17.3 (#916/#917) — Open-Meteo got delete-on-stale, Solcast did not.

Full analysis, reproduction and evidence in #1016.

## Change

Bypass the cache read when `weather_forecast_cache` is set, so the explicit refresh action always fetches fresh. Normal `cache_only` MPC runs are unchanged, and the fetch is still quota-guarded by `_solcast_rate_limit_ok`.

## Testing

Verified on a live add-on (v0.17.7, behavior identical in `master`): with a stale cache present, the `weather-forecast-cache` action served stale and made zero API calls; after this change it fetches fresh and rewrites the cache, while `cache_only` MPC runs continue to read the cache.

Fixes #1016

## Summary by Sourcery

Bug Fixes:
- Prevent the weather-forecast-cache action from returning stale Solcast cache data by bypassing cache reads when a forced refresh is requested.