### PR TITLE
fix: bound set_nodischarge_to_grid export by PV surplus, not raw PV (#795 regression)

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -196,6 +196,16 @@ class Optimization:
         self.param_load_cost_pos = cp.Parameter(
             self.num_timesteps, nonneg=True, name="load_cost_pos"
         )
+        # Non-negative PV surplus, max(0, PV - load), used as the export ceiling for
+        # set_nodischarge_to_grid on AC-coupled systems. Bounding export by raw PV
+        # (pre-fix behaviour) lets the battery reach the grid indirectly: it covers
+        # the whole load so PV is freed for export (regression of #795, reintroduced
+        # by #981). Bounding by the surplus blocks battery-to-grid while still
+        # allowing battery-to-load. Dedicated Parameter (not max() baked in at build
+        # time) to stay correct across warm-started re-solves.
+        self.param_export_ceiling = cp.Parameter(
+            self.num_timesteps, nonneg=True, name="export_ceiling"
+        )
         self.param_prod_price = cp.Parameter(self.num_timesteps, name="prod_price")
 
         # Per-deferrable-load cost override parameters. When the user supplies a
@@ -1858,17 +1868,23 @@ class Optimization:
         # No discharge to grid: prevent battery energy from reaching the grid. Hybrid inverters
         # prioritise PV to the load, so the battery cannot discharge while PV exports (strict E<=D, #796).
         # AC-coupled systems can, so E<=D wrongly forbids battery-to-load during export and makes the
-        # solve infeasible when a large SoC must be shed (#936). For them bound grid export to the
-        # available PV instead (net of curtailment), blocking battery-to-grid while allowing battery-to-load.
+        # solve infeasible when a large SoC must be shed (#936). For them bound grid export to the PV
+        # *surplus* (max(0, PV - load), param_export_ceiling), not raw PV: bounding by raw PV lets the
+        # battery cover the entire load and free PV for export, i.e. battery-to-grid through a PV detour
+        # (#795, reintroduced by #981). Bounding by the surplus blocks battery-to-grid while still
+        # allowing battery-to-load. Curtailment further lowers the exportable surplus.
         if self.optim_conf["set_nodischarge_to_grid"]:
             if self.plant_conf["inverter_is_hybrid"]:
                 constraints.append(E <= D)
             elif self.plant_conf["compute_curtailment"]:
                 constraints.append(
-                    self.vars["p_grid_neg"] + p_pv - self.vars["p_pv_curtailment"] >= 0
+                    self.vars["p_grid_neg"]
+                    + self.param_export_ceiling
+                    - self.vars["p_pv_curtailment"]
+                    >= 0
                 )
             else:
-                constraints.append(self.vars["p_grid_neg"] + p_pv >= 0)
+                constraints.append(self.vars["p_grid_neg"] + self.param_export_ceiling >= 0)
 
         # Dynamic Power Limits (Ramp Rate)
         if self.optim_conf["set_battery_dynamic"]:
@@ -3783,6 +3799,7 @@ class Optimization:
             self.param_load_forecast = cp.Parameter(current_n, name="load_forecast")
             self.param_load_cost = cp.Parameter(current_n, name="load_cost")
             self.param_load_cost_pos = cp.Parameter(current_n, nonneg=True, name="load_cost_pos")
+            self.param_export_ceiling = cp.Parameter(current_n, nonneg=True, name="export_ceiling")
             self.param_prod_price = cp.Parameter(current_n, name="prod_price")
             self.param_cost_per_load = [
                 cp.Parameter(current_n, name=f"cost_per_load_{k}")
@@ -3958,6 +3975,9 @@ class Optimization:
         self.param_load_forecast.value = p_load
         self.param_load_cost.value = unit_load_cost
         self.param_load_cost_pos.value = np.maximum(np.asarray(unit_load_cost, dtype=float), 0.0)
+        self.param_export_ceiling.value = np.maximum(
+            np.asarray(p_pv, dtype=float) - np.asarray(p_load, dtype=float), 0.0
+        )
         self.param_prod_price.value = unit_prod_price
 
         # Per-load cost forecast overrides. Default each load's per-timestep cost

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -59,6 +59,17 @@ CURTAILMENT_TIEBREAK_EPS = 1e-7
 # penalty to genuinely avoidable import, so an aggressive factor is safe.
 BATTERY_FIRST_IMPORT_PENALTY_FACTOR = 100.0
 
+# Soft terminal-SoC target, the same treatment #1002 gave set_battery_first_priority.
+# A hard equality on the horizon's net energy change turns the solve infeasible
+# whenever the requested soc_final simply cannot be reached. That collides with
+# set_nodischarge_to_grid on AC-coupled systems: when PV already covers the load a
+# large SoC shed has no local deficit to discharge into, and export is (correctly)
+# closed off, so no schedule exists (#936 vs #795). Enforcing the target through
+# non-negative slacks priced far above any realistic tariff keeps it met exactly
+# whenever that is possible, while a contradictory target relaxes to the closest
+# reachable SoC instead of returning infeasible.
+SOC_FINAL_DEVIATION_PENALTY_FACTOR = 100.0
+
 
 class Optimization:
     r"""
@@ -206,6 +217,11 @@ class Optimization:
         self.param_export_ceiling = cp.Parameter(
             self.num_timesteps, nonneg=True, name="export_ceiling"
         )
+        # Currency per Wh charged for missing the terminal SoC target. Set per solve
+        # from the horizon's highest import tariff so the target stays dominant at any
+        # price scale; a Parameter (not a baked-in constant) keeps that correct across
+        # warm-started re-solves. See SOC_FINAL_DEVIATION_PENALTY_FACTOR.
+        self.param_soc_final_penalty = cp.Parameter(nonneg=True, name="soc_final_penalty")
         self.param_prod_price = cp.Parameter(self.num_timesteps, name="prod_price")
 
         # Per-deferrable-load cost override parameters. When the user supplies a
@@ -1367,6 +1383,12 @@ class Optimization:
             )
             vars_dict["soc_deficit_cost"] = cp.Variable(n, nonneg=True, name="soc_deficit_cost")
             vars_dict["soc_surplus_cost"] = cp.Variable(n, nonneg=True, name="soc_surplus_cost")
+            # Terminal-SoC slacks: the signed miss on the horizon's net energy change,
+            # split into two non-negative parts so the deviation stays linear. Priced in
+            # the objective rather than forbidden, so an unreachable soc_final degrades
+            # to "as close as allowed" instead of infeasible.
+            vars_dict["soc_final_under"] = cp.Variable(nonneg=True, name="soc_final_under")
+            vars_dict["soc_final_over"] = cp.Variable(nonneg=True, name="soc_final_over")
             # Battery-first priority gate (issue #834): binary per timestep,
             # 1 = grid import is "free" (unpenalized) in this slot. Only created
             # when the feature is enabled; otherwise it never enters self.vars.
@@ -1636,6 +1658,16 @@ class Optimization:
         # is clipped to non-negative (param_load_cost_pos): a negative-price slot
         # must not turn this penalty into an unbounded reward on the otherwise
         # upper-unbounded penalty variable.
+        # Terminal-SoC deviation penalty. param_soc_final_penalty is already in currency
+        # per Wh (it folds in the kWh conversion and the dominance factor), so the slacks
+        # enter the objective directly. Charging both directions keeps the target an
+        # equality rather than a one-sided bound.
+        soc_final_under = self.vars.get("soc_final_under")
+        if soc_final_under is not None:
+            objective_terms.append(
+                -self.param_soc_final_penalty * (soc_final_under + self.vars["soc_final_over"])
+            )
+
         battery_first_penalty = self.vars.get("battery_first_penalty")
         if battery_first_penalty is not None:
             objective_terms.append(
@@ -1872,19 +1904,22 @@ class Optimization:
         # *surplus* (max(0, PV - load), param_export_ceiling), not raw PV: bounding by raw PV lets the
         # battery cover the entire load and free PV for export, i.e. battery-to-grid through a PV detour
         # (#795, reintroduced by #981). Bounding by the surplus blocks battery-to-grid while still
-        # allowing battery-to-load. Curtailment further lowers the exportable surplus.
+        # allowing battery-to-load.
         if self.optim_conf["set_nodischarge_to_grid"]:
             if self.plant_conf["inverter_is_hybrid"]:
                 constraints.append(E <= D)
-            elif self.plant_conf["compute_curtailment"]:
-                constraints.append(
-                    self.vars["p_grid_neg"]
-                    + self.param_export_ceiling
-                    - self.vars["p_pv_curtailment"]
-                    >= 0
-                )
             else:
                 constraints.append(self.vars["p_grid_neg"] + self.param_export_ceiling >= 0)
+                if self.plant_conf["compute_curtailment"]:
+                    # Curtailed PV cannot be exported either. This stays a SEPARATE bound:
+                    # folding p_pv_curtailment into the surplus ceiling would additionally
+                    # cap curtailment itself at the surplus, an unrelated restriction that
+                    # removes legitimate curtailment freedom (it may exceed the surplus)
+                    # and breaks the #342 tie-break placement. Together the two bounds give
+                    # export <= min(surplus, PV - curtailment), which is what we want.
+                    constraints.append(
+                        self.vars["p_grid_neg"] + p_pv - self.vars["p_pv_curtailment"] >= 0
+                    )
 
         # Dynamic Power Limits (Ramp Rate)
         if self.optim_conf["set_battery_dynamic"]:
@@ -1970,10 +2005,18 @@ class Optimization:
         )
 
         # Final SOC Constraint
-        # The total energy change over the whole horizon must match init -> final
-        # Total Sum of power flow * dt == (Init - Final) * Capacity
+        # The total energy change over the whole horizon should match init -> final:
+        # Total Sum of power flow * dt == (Init - Final) * Capacity.
+        # Enforced softly (see SOC_FINAL_DEVIATION_PENALTY_FACTOR): the two non-negative
+        # slacks absorb any unreachable remainder and are charged in the objective, so
+        # the equality still holds exactly whenever a schedule exists for it.
         total_energy_change = cp.sum(energy_change)
-        constraints.append(total_energy_change == (soc_init - soc_final) * cap)
+        constraints.append(
+            total_energy_change
+            == (soc_init - soc_final) * cap
+            + self.vars["soc_final_under"]
+            - self.vars["soc_final_over"]
+        )
 
         # Intermediate SOC target (issue #553): require SoC >= target at the
         # requested timestep, leaving the battery free to discharge afterward.
@@ -3977,6 +4020,14 @@ class Optimization:
         self.param_load_cost_pos.value = np.maximum(np.asarray(unit_load_cost, dtype=float), 0.0)
         self.param_export_ceiling.value = np.maximum(
             np.asarray(p_pv, dtype=float) - np.asarray(p_load, dtype=float), 0.0
+        )
+        # Price the terminal-SoC miss well above the dearest import slot so the target is
+        # never traded away for energy cost; the 0.001 converts the Wh slacks to kWh. The
+        # floor keeps the penalty meaningful when every tariff is zero or negative.
+        self.param_soc_final_penalty.value = (
+            0.001
+            * SOC_FINAL_DEVIATION_PENALTY_FACTOR
+            * max(float(np.max(np.maximum(np.asarray(unit_load_cost, dtype=float), 0.0))), 1e-3)
         )
         self.param_prod_price.value = unit_prod_price
 

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -7207,10 +7207,15 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
 
         Same high-PV, large-SoC-shed scenario as the non-hybrid test, but with
         inverter_is_hybrid=True.  The fix must leave the hybrid branch unchanged
-        (E<=D), so every export timestep (D=0) still blocks battery discharge (E=0),
-        making the large SoC shed infeasible.  If the fix accidentally removed E<=D
-        from the hybrid branch this test would pass (feasible) and must be treated
-        as a regression.
+        (E<=D), so every export timestep (D=0) still blocks battery discharge (E=0).
+
+        This used to assert infeasibility, using "no schedule exists" as the proxy for
+        "E<=D is still applied".  That proxy no longer holds now that soc_final is a
+        soft target: an unreachable shed relaxes instead of failing the solve, so the
+        scenario returns the closest reachable schedule.  The invariant is therefore
+        asserted directly -- no battery discharge in any exporting timestep -- which
+        also tests the intent more precisely than the status did.  If the fix ever
+        removed E<=D from the hybrid branch, discharge during export would appear here.
         """
         df, soc_init, soc_final = self._make_nodischarge_scenario(inverter_is_hybrid=True)
 
@@ -7224,7 +7229,7 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             emhass_conf,
             logger,
         )
-        opt.perform_optimization(
+        opt_res = opt.perform_optimization(
             df,
             df["p_pv_forecast"].values,
             df["p_load_forecast"].values,
@@ -7233,11 +7238,28 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             soc_init=soc_init,
             soc_final=soc_final,
         )
-        self.assertNotIn(
-            opt.optim_status,
-            VALID_OPTIMAL_STATUSES,
-            f"Hybrid set_nodischarge_to_grid must keep E<=D, blocking discharge during export "
-            f"-> infeasible for large SoC shed; got status={opt.optim_status!r} (issue #936)",
+        if opt.optim_status not in VALID_OPTIMAL_STATUSES:
+            # Also acceptable: E<=D can leave no schedule for the shed at all.
+            return
+
+        epsilon = 1e-3  # W - numerical tolerance
+        p_grid_neg = opt_res["P_grid_neg"].values  # <= 0; grid export
+        p_batt = opt_res["P_batt"].values  # > 0 = discharging
+        exporting = 0
+        for t in range(len(p_batt)):
+            if p_grid_neg[t] < -epsilon:
+                exporting += 1
+                self.assertLessEqual(
+                    p_batt[t],
+                    epsilon,
+                    f"Step {t}: hybrid inverter discharged {p_batt[t]:.1f} W while exporting "
+                    f"(P_grid_neg={p_grid_neg[t]:.1f} W); set_nodischarge_to_grid must keep "
+                    f"E<=D on hybrid inverters (issue #936)",
+                )
+        self.assertGreater(
+            exporting,
+            0,
+            "Scenario misconfigured: expected exporting timesteps to exercise E<=D",
         )
 
     def test_nodischarge_to_grid_curtailment_no_battery_export_issue936(self):
@@ -7360,6 +7382,109 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
                 f"P_PV_curtailment={p_pv_curt[t]:.1f}, pv_avail={pv_available[t]:.1f}); "
                 f"set_nodischarge_to_grid + compute_curtailment must prevent this "
                 f"(issue #936 curtailment fix)",
+            )
+
+    def test_nodischarge_to_grid_deficit_no_battery_export_issue1023(self):
+        """Issue #1023 as originally reported: load exceeds PV, yet the battery covered
+        the whole load so the untouched PV could be exported.
+
+        This is the deficit counterpart to the #936 tests, which all use PV > load. With
+        PV=400 W against a 1000 W load there is no surplus at all, so the correct export
+        is exactly zero and the battery may at most serve the local deficit.
+
+        RED on the raw-PV bound (p_grid_neg + p_pv >= 0): export is capped at 400 W, not
+        at the (zero) surplus, so the solver discharges 1400 W -- 1000 W to the load and
+        400 W to free the PV for export -- and sells battery energy at the feed-in price.
+        GREEN with the surplus bound (p_grid_neg + param_export_ceiling >= 0): the
+        ceiling is max(0, 400 - 1000) = 0, so no export is possible and the battery
+        discharge cannot exceed the load.
+
+        Feed-in is priced above import here so exporting is strictly the more profitable
+        option; the constraint, not the economics, has to be what prevents it.
+        """
+        tz = self.retrieve_hass_conf["time_zone"]
+        n = 6
+        dates = pd.date_range(
+            start=pd.Timestamp("2024-06-15 19:00:00", tz=tz),
+            periods=n,
+            freq=self.retrieve_hass_conf["optimization_time_step"],
+        )
+        df = pd.DataFrame(index=dates)
+        p_pv_w = 400.0
+        p_load_w = 1000.0
+        df["p_pv_forecast"] = p_pv_w
+        df["p_load_forecast"] = p_load_w
+        df[self.fcst.var_load_cost] = 0.20
+        df[self.fcst.var_prod_price] = 1.00  # exporting is the tempting option
+
+        cap = 10000.0  # Wh, loss-free
+        self.plant_conf.update(
+            {
+                "inverter_is_hybrid": False,
+                "compute_curtailment": False,
+                "battery_nominal_energy_capacity": cap,
+                "battery_discharge_power_max": 4000.0,  # >> load, so the cap is not the limiter
+                "battery_charge_power_max": 4000.0,
+                "battery_discharge_efficiency": 1.0,
+                "battery_charge_efficiency": 1.0,
+                "battery_minimum_state_of_charge": 0.0,
+                "battery_maximum_state_of_charge": 1.0,
+            }
+        )
+        self.optim_conf.update(
+            {
+                "set_use_battery": True,
+                "set_nodischarge_to_grid": True,
+                "set_nocharge_from_grid": True,
+                "set_battery_dynamic": False,
+                "number_of_deferrable_loads": 0,
+                "weight_battery_discharge": 0.0,
+                "weight_battery_charge": 0.0,
+            }
+        )
+
+        opt = Optimization(
+            self.retrieve_hass_conf,
+            self.optim_conf,
+            self.plant_conf,
+            self.fcst.var_load_cost,
+            self.fcst.var_prod_price,
+            "profit",
+            emhass_conf,
+            logger,
+        )
+        opt_res = opt.perform_optimization(
+            df,
+            df["p_pv_forecast"].values,
+            df["p_load_forecast"].values,
+            df[opt.var_load_cost].values,
+            df[opt.var_prod_price].values,
+            soc_init=0.9,
+            soc_final=0.5,  # wants to shed more than the local deficit can absorb
+        )
+        self.assertIn(
+            opt.optim_status,
+            VALID_OPTIMAL_STATUSES,
+            f"Deficit scenario must stay solvable (soc_final is a soft target); "
+            f"got status={opt.optim_status!r} (issue #1023)",
+        )
+
+        epsilon = 1e-3  # W
+        p_grid_neg = opt_res["P_grid_neg"].values  # <= 0; grid export
+        p_batt = opt_res["P_batt"].values  # > 0 = discharging
+        for t in range(n):
+            self.assertGreaterEqual(
+                p_grid_neg[t],
+                -epsilon,
+                f"Step {t}: exported {-p_grid_neg[t]:.1f} W while load ({p_load_w:.0f} W) "
+                f"exceeds PV ({p_pv_w:.0f} W) -- there is no surplus, so this can only be "
+                f"battery energy routed to the grid (issue #1023)",
+            )
+            self.assertLessEqual(
+                p_batt[t],
+                p_load_w + epsilon,
+                f"Step {t}: battery discharged {p_batt[t]:.1f} W, more than the {p_load_w:.0f} W "
+                f"local load; the excess can only be leaving via the grid (issue #1023)",
             )
 
     # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the `set_nodischarge_to_grid` battery-to-grid loophole reported in #1023 — a regression of #795.

## Problem

The AC-coupled branch introduced in #981 bounds grid export by raw PV:

```python
constraints.append(self.vars["p_grid_neg"] + p_pv >= 0)   # export <= p_pv
```

This caps the *amount* of export but not its *source*. The optimizer discharges the battery to cover the entire local load, which frees the PV for export — functionally battery-to-grid, exactly the loophole #795 described. `p_grid` ends up equal to `-P_PV` even when no surplus exists.

Example from a real `dayahead-optim` (AC-coupled, `inverter_is_hybrid: false`, `set_nodischarge_to_grid: true`) — `load > PV` in every slot, so there is no surplus, yet it exports:

| time  | PV (W) | load (W) | p_batt (W, + = discharge) | p_grid (W, − = export) |
|-------|-------:|---------:|--------------------------:|-----------------------:|
| 20:00 |    327 |      508 |                  **+508** |               **−327** |
| 20:30 |    241 |      508 |                  **+508** |               **−241** |
| 21:00 |     94 |      545 |                  **+545** |                **−94** |

## Fix

Bound export by the PV **surplus**, `max(0, PV − load)`, rather than raw PV. The surplus is held in a dedicated non-negative `Parameter` (`param_export_ceiling`), mirroring the existing `param_load_cost_pos` so it stays correct across warm-started re-solves (a `cp.maximum` of parameters is not DCP-valid in this `>= 0` constraint). The curtailment branch subtracts `p_pv_curtailment` from the same ceiling.

```python
# build time
self.param_export_ceiling = cp.Parameter(self.num_timesteps, nonneg=True, name="export_ceiling")
# per solve
self.param_export_ceiling.value = np.maximum(np.asarray(p_pv, float) - np.asarray(p_load, float), 0.0)
# constraint (AC-coupled)
constraints.append(self.vars["p_grid_neg"] + self.param_export_ceiling >= 0)
```

This keeps battery-to-load fully allowed (the requirement from #936) while making battery-to-grid structurally impossible (the requirement from #795). Bounding `p_grid` alone can never suffice, because the *source* of the exported energy stays unconstrained.

## Verified locally

Applied to a running 0.17.9 add-on. Same evening after the fix — the battery discharges only the deficit and `p_grid == 0`:

| time  | PV (W) | load (W) | p_batt (W) | p_grid (W) |
|-------|-------:|---------:|-----------:|-----------:|
| 20:00 |    327 |      508 |       +181 |          0 |
| 20:30 |    241 |      508 |       +267 |          0 |
| 21:00 |     94 |      545 |       +451 |          0 |

Genuine PV surplus is unaffected: at 19:00 (PV 502 > load 307) the battery stays idle and 195 W is exported as before. `optim_status` remains `Optimal`, no infeasibility.

Closes #1023.

## Summary by Sourcery

Bound grid export by PV surplus rather than raw PV when set_nodischarge_to_grid is enabled for AC-coupled systems, preventing indirect battery-to-grid export while preserving battery-to-load behavior.

Bug Fixes:
- Fix AC-coupled no-discharge-to-grid regression that allowed battery energy to reach the grid via freeing PV for export.
- Correct curtailment export constraint to apply the PV surplus ceiling minus curtailment instead of raw PV.

Enhancements:
- Introduce a dedicated non-negative export ceiling parameter derived from PV minus load and wire it into both initial and warm-started optimization runs.