### PR TITLE
style: strip whitespace from two blank lines that landed with #1025

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -1341,7 +1341,7 @@ class Forecast:
         self.data_adjust_pv = pd.concat(
             [P_PV.rename("actual"), p_pv_forecast.rename("forecast")], axis=1
         ).dropna()
-        
+
         # Exclude curtailed timesteps (issue #1026): measured production during
         # curtailment is deliberately below the achievable PV power. A one-step
         # margin on either side absorbs execution lag between plan and inverter.
@@ -1369,7 +1369,7 @@ class Forecast:
             date_features=["year", "month", "day_of_week", "day_of_year", "day"],
         )
         self.data_adjust_pv = Forecast.add_cyclic_hour_features(self.data_adjust_pv)
-        
+
         self.data_adjust_pv = Forecast.compute_solar_angles(self.data_adjust_pv, self.lat, self.lon)
         # Features (X) and target (y)
         self.x_adjust_pv = self.data_adjust_pv.drop(columns=["actual"])  # Predictors


### PR DESCRIPTION
Two blank lines with trailing whitespace came in with #1025 (forecast.py:1344 and :1372). Harmless in itself, but the Code Quality workflow runs ruff over the whole tree, so every PR opened against master right now gets a red check from it.

Whitespace-only change, `ruff check` and `ruff format --check` both clean tree-wide after it, forecast test file green locally.

## Summary by Sourcery

Enhancements:
- Clean up formatting by stripping trailing whitespace on blank lines in forecast processing code.