### PR TITLE
docs: fix ruff formatting 

### DIFF
--- a/docs/cookbook/tariff_demand_charge.md
+++ b/docs/cookbook/tariff_demand_charge.md
@@ -84,8 +84,8 @@ Expected: with a non-zero `current_period_peak`, the plan stops shaving below th
 
 ```python
 # From the EMHASS optimization result DataFrame `opt_res`:
-peak_off = opt_res["P_grid"].clip(lower=0).max()   # capacity_cost_per_kw = 0.0
-peak_on  = opt_res["P_grid"].clip(lower=0).max()   # capacity_cost_per_kw = 8.0
+peak_off = opt_res["P_grid"].clip(lower=0).max()  # capacity_cost_per_kw = 0.0
+peak_on = opt_res["P_grid"].clip(lower=0).max()  # capacity_cost_per_kw = 8.0
 # Expect peak_on <= peak_off, at the cost of a small rise in the energy-only cost_fun term.
 ```
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -349,15 +349,15 @@ Add your parameter to the `OptimizationCacheKey` dataclass and the `_compute_cac
 ```python
 @dataclass(frozen=True)
 class OptimizationCacheKey:
-# ... existing parameters ...
-       this_parameter_is_amazing: tuple
+    # ... existing parameters ...
+    this_parameter_is_amazing: tuple
 
 
-   # Inside _compute_cache_key:
-   return OptimizationCacheKey(
-       # ... existing parameters ...
-       this_parameter_is_amazing=to_tuple(optim_conf.get("this_parameter_is_amazing", [])),
-   )
+# Inside _compute_cache_key:
+return OptimizationCacheKey(
+    # ... existing parameters ...
+    this_parameter_is_amazing=to_tuple(optim_conf.get("this_parameter_is_amazing", [])),
+)
 ```
 
 #### Note on Deferrable Load Lists

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -349,16 +349,15 @@ Add your parameter to the `OptimizationCacheKey` dataclass and the `_compute_cac
 ```python
 @dataclass(frozen=True)
 class OptimizationCacheKey:
-    # ... existing parameters ...
-    this_parameter_is_amazing: tuple
+# ... existing parameters ...
+       this_parameter_is_amazing: tuple
 
-# Inside _compute_cache_key:
-return OptimizationCacheKey(
-    # ... existing parameters ...
-    this_parameter_is_amazing=to_tuple(
-        optim_conf.get("this_parameter_is_amazing", [])
-    ),
-)
+
+   # Inside _compute_cache_key:
+   return OptimizationCacheKey(
+       # ... existing parameters ...
+       this_parameter_is_amazing=to_tuple(optim_conf.get("this_parameter_is_amazing", [])),
+   )
 ```
 
 #### Note on Deferrable Load Lists

--- a/docs/mlforecaster.md
+++ b/docs/mlforecaster.md
@@ -41,14 +41,14 @@ The minimum number of `historic_days_to_retrieve` is hard coded to 9 by default.
 The default values for these parameters are:
 ```python
 runtimeparams = {
-    'historic_days_to_retrieve': 9,
+    "historic_days_to_retrieve": 9,
     "model_type": "long_train_data",
     "var_model": "sensor.power_load_no_var_loads",
     "sklearn_model": "KNeighborsRegressor",
     "num_lags": 48,
-    "split_date_delta": '48h',
+    "split_date_delta": "48h",
     "perform_backtest": False,
-    "mlforecaster_weather_features": []
+    "mlforecaster_weather_features": [],
 }
 ```
 
@@ -203,7 +203,7 @@ runtimeparams = {
     "model_predict_publish": False,
     "model_predict_entity_id": "sensor.p_load_forecast_custom_model",
     "model_predict_unit_of_measurement": "W",
-    "model_predict_friendly_name": "Load Power Forecast custom ML model"
+    "model_predict_friendly_name": "Load Power Forecast custom ML model",
 }
 ```
 
@@ -218,9 +218,7 @@ curl -i -H "Content-Type:application/json" -X POST -d '{"var_model": "sensor.pow
 It is possible to pass the `n_trials` parameter to define the number of trials to perform during the optimization.
 The default value for this parameter is:
 ```python
-runtimeparams = {
-    "n_trials": 10
-}
+runtimeparams = {"n_trials": 10}
 ```
 This will launch the optimization routine and optimize the internal hyperparameters of the `scikit-learn` regressor and it will find the optimal number of lags.
 The following are the logs with the results obtained after the optimization for a KNN regressor:

--- a/docs/mlregressor.md
+++ b/docs/mlregressor.md
@@ -37,8 +37,8 @@ runtimeparams = {
     "regression_model": "RandomForestRegression",
     "model_type": "heating_hours_degreeday",
     "timestamp": "timestamp",
-    "date_features": ["month", "day_of_week"]
-    }
+    "date_features": ["month", "day_of_week"],
+}
 ```
 
 A correct `curl` call to launch a model fit can look like this:
@@ -102,7 +102,7 @@ runtimeparams = {
     "mlr_predict_unit_of_measurement": None,
     "mlr_predict_friendly_name": "mlr predictor",
     "new_values": [8.2, 7.23, 2, 6],
-    "model_type": "heating_hours_degreeday"
+    "model_type": "heating_hours_degreeday",
 }
 ```
 

--- a/docs/study_cases/dhw_walkthrough.md
+++ b/docs/study_cases/dhw_walkthrough.md
@@ -54,10 +54,19 @@ Reference Python sketch for the deadline profile (30-minute timesteps, 24 h hori
 ```python
 from datetime import datetime, timedelta
 
-def build_dhw_profile(now, horizon=48, timestep_min=30,
-                      base=45.0,
-                      morning_temp=48.0, morning_hour=7, morning_window_slots=1,
-                      evening_temp=50.0, evening_hour=18, evening_window_slots=2):
+
+def build_dhw_profile(
+    now,
+    horizon=48,
+    timestep_min=30,
+    base=45.0,
+    morning_temp=48.0,
+    morning_hour=7,
+    morning_window_slots=1,
+    evening_temp=50.0,
+    evening_hour=18,
+    evening_window_slots=2,
+):
     """Return a list of length `horizon` with the deadline-driven target temps.
 
     Each spike fires in the last `*_window_slots` timesteps that end at or

--- a/docs/study_cases/heat_pump_walkthrough.md
+++ b/docs/study_cases/heat_pump_walkthrough.md
@@ -33,24 +33,24 @@ Add `set_use_pv: true`, `set_use_battery: true` plus the standard battery parame
 
 ```python
 {
-  "def_load_config": [
-    {},
-    {
-      "thermal_battery": {
-        "supply_temperature": 35.0,
-        "volume": 20.0,
-        "start_temperature": 22.0,
-        "min_temperatures": [20.0] * 48,
-        "max_temperatures": [26.0] * 48,
-        "carnot_efficiency": 0.45,
-        "u_value": 0.35,
-        "envelope_area": 280.0,
-        "ventilation_rate": 0.4,
-        "heated_volume": 320.0,
-        "thermal_inertia_time_constant": 2.0
-      }
-    }
-  ]
+    "def_load_config": [
+        {},
+        {
+            "thermal_battery": {
+                "supply_temperature": 35.0,
+                "volume": 20.0,
+                "start_temperature": 22.0,
+                "min_temperatures": [20.0] * 48,
+                "max_temperatures": [26.0] * 48,
+                "carnot_efficiency": 0.45,
+                "u_value": 0.35,
+                "envelope_area": 280.0,
+                "ventilation_rate": 0.4,
+                "heated_volume": 320.0,
+                "thermal_inertia_time_constant": 2.0,
+            }
+        },
+    ]
 }
 ```
 

--- a/docs/thermal_battery.md
+++ b/docs/thermal_battery.md
@@ -373,25 +373,25 @@ This example shows a well-insulated modern home with underfloor heating, using t
 
 ```python
 {
-  "def_load_config": [
-    {
-      "thermal_battery": {
-        "supply_temperature": 35.0,
-        "volume": 18.0,
-        "start_temperature": 22.0,
-        "min_temperatures": [20.0] * 48,  # Constant 20°C minimum
-        "max_temperatures": [28.0] * 48,  # Constant 28°C maximum
-        "carnot_efficiency": 0.45,
-        "u_value": 0.35,
-        "envelope_area": 380.0,
-        "ventilation_rate": 0.4,
-        "heated_volume": 240.0,
-        "window_area": 28.0,
-        "shgc": 0.6,
-        "internal_gains_factor": 0.7
-      }
-    }
-  ]
+    "def_load_config": [
+        {
+            "thermal_battery": {
+                "supply_temperature": 35.0,
+                "volume": 18.0,
+                "start_temperature": 22.0,
+                "min_temperatures": [20.0] * 48,  # Constant 20°C minimum
+                "max_temperatures": [28.0] * 48,  # Constant 28°C maximum
+                "carnot_efficiency": 0.45,
+                "u_value": 0.35,
+                "envelope_area": 380.0,
+                "ventilation_rate": 0.4,
+                "heated_volume": 240.0,
+                "window_area": 28.0,
+                "shgc": 0.6,
+                "internal_gains_factor": 0.7,
+            }
+        }
+    ]
 }
 ```
 
@@ -410,22 +410,22 @@ This example uses the simpler HDD-based approach for an older home with radiator
 
 ```python
 {
-  "def_load_config": [
-    {
-      "thermal_battery": {
-        "supply_temperature": 50.0,
-        "volume": 12.0,
-        "start_temperature": 45.0,
-        "min_temperatures": [40.0] * 48,  # Constant 40°C minimum
-        "max_temperatures": [65.0] * 48,  # Constant 65°C maximum
-        "carnot_efficiency": 0.38,
-        "specific_heating_demand": 95.0,
-        "area": 120.0,
-        "base_temperature": 18.0,
-        "annual_reference_hdd": 2800.0
-      }
-    }
-  ]
+    "def_load_config": [
+        {
+            "thermal_battery": {
+                "supply_temperature": 50.0,
+                "volume": 12.0,
+                "start_temperature": 45.0,
+                "min_temperatures": [40.0] * 48,  # Constant 40°C minimum
+                "max_temperatures": [65.0] * 48,  # Constant 65°C maximum
+                "carnot_efficiency": 0.38,
+                "specific_heating_demand": 95.0,
+                "area": 120.0,
+                "base_temperature": 18.0,
+                "annual_reference_hdd": 2800.0,
+            }
+        }
+    ]
 }
 ```
 
@@ -443,23 +443,23 @@ This example shows how to use the thermal inertia filter for a system where ther
 
 ```python
 {
-  "def_load_config": [
-    {
-      "thermal_battery": {
-        "supply_temperature": 35.0,
-        "volume": 18.0,
-        "start_temperature": 22.0,
-        "min_temperatures": [20.0] * 48,
-        "max_temperatures": [28.0] * 48,
-        "carnot_efficiency": 0.45,
-        "u_value": 0.35,
-        "envelope_area": 380.0,
-        "ventilation_rate": 0.4,
-        "heated_volume": 240.0,
-        "thermal_inertia_time_constant": 2.0
-      }
-    }
-  ]
+    "def_load_config": [
+        {
+            "thermal_battery": {
+                "supply_temperature": 35.0,
+                "volume": 18.0,
+                "start_temperature": 22.0,
+                "min_temperatures": [20.0] * 48,
+                "max_temperatures": [28.0] * 48,
+                "carnot_efficiency": 0.45,
+                "u_value": 0.35,
+                "envelope_area": 380.0,
+                "ventilation_rate": 0.4,
+                "heated_volume": 240.0,
+                "thermal_inertia_time_constant": 2.0,
+            }
+        }
+    ]
 }
 ```
 
@@ -475,23 +475,23 @@ If you have other deferrable loads (EV charger, dishwasher, etc.) along with you
 
 ```python
 {
-  "def_load_config": [
-    {},
-    {
-      "thermal_battery": {
-        "supply_temperature": 35.0,
-        "volume": 15.0,
-        "start_temperature": 22.0,
-        "min_temperatures": [20.0] * 48,  # Constant 20°C minimum
-        "max_temperatures": [26.0] * 48,  # Constant 26°C maximum
-        "u_value": 0.45,
-        "envelope_area": 320.0,
-        "ventilation_rate": 0.5,
-        "heated_volume": 200.0
-      }
-    },
-    {}
-  ]
+    "def_load_config": [
+        {},
+        {
+            "thermal_battery": {
+                "supply_temperature": 35.0,
+                "volume": 15.0,
+                "start_temperature": 22.0,
+                "min_temperatures": [20.0] * 48,  # Constant 20°C minimum
+                "max_temperatures": [26.0] * 48,  # Constant 26°C maximum
+                "u_value": 0.45,
+                "envelope_area": 320.0,
+                "ventilation_rate": 0.5,
+                "heated_volume": 200.0,
+            }
+        },
+        {},
+    ]
 }
 ```
 
@@ -506,25 +506,71 @@ A 200-liter hot water tank heated by a heat pump, with a daily shower profile.
 
 ```python
 {
-  "def_load_config": [
-    {
-      "thermal_battery": {
-        "supply_temperature": 45.0,
-        "volume": 0.2,
-        "density": 997,
-        "heat_capacity": 4.184,
-        "thermal_loss": 0.035,
-        "start_temperature": 50.0,
-        "min_temperatures": [40.0] * 48,
-        "max_temperatures": [60.0] * 48,
-        "carnot_efficiency": 0.40,
-        "draw_off_demand": [0,0,0,0,0,0, 0,0,0,0,0,0,
-                            0.5,0.3,0,0,0,0, 0,0,0,0,0,0,
-                            0,0,0,0,0,0, 0,0,0,0,0,0,
-                            0.8,0.5,0.3,0,0,0, 0,0,0,0,0,0]
-      }
-    }
-  ]
+    "def_load_config": [
+        {
+            "thermal_battery": {
+                "supply_temperature": 45.0,
+                "volume": 0.2,
+                "density": 997,
+                "heat_capacity": 4.184,
+                "thermal_loss": 0.035,
+                "start_temperature": 50.0,
+                "min_temperatures": [40.0] * 48,
+                "max_temperatures": [60.0] * 48,
+                "carnot_efficiency": 0.40,
+                "draw_off_demand": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0.5,
+                    0.3,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0.8,
+                    0.5,
+                    0.3,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+            }
+        }
+    ]
 }
 ```
 
@@ -542,23 +588,23 @@ A 200-liter hot water tank heated by a heat pump, without any `draw_off_demand`.
 
 ```python
 {
-  "def_load_config": [
-    {
-      "thermal_battery": {
-        "supply_temperature": 45.0,
-        "volume": 0.2,
-        "density": 997,
-        "heat_capacity": 4.184,
-        "thermal_loss": 0.035,
-        "start_temperature": 50.0,
-        "min_temperatures": [40.0] * 48,
-        "max_temperatures": [60.0] * 48,
-        "carnot_efficiency": 0.40,
-        "specific_heating_demand": 0.0,
-        "area": 1.0
-      }
-    }
-  ]
+    "def_load_config": [
+        {
+            "thermal_battery": {
+                "supply_temperature": 45.0,
+                "volume": 0.2,
+                "density": 997,
+                "heat_capacity": 4.184,
+                "thermal_loss": 0.035,
+                "start_temperature": 50.0,
+                "min_temperatures": [40.0] * 48,
+                "max_temperatures": [60.0] * 48,
+                "carnot_efficiency": 0.40,
+                "specific_heating_demand": 0.0,
+                "area": 1.0,
+            }
+        }
+    ]
 }
 ```
 
@@ -577,29 +623,30 @@ Without a `draw_off_demand`, the thermal_battery automatically switches to space
 
 ```python
 {
-  "def_load_config": [
-    {
-      "thermal_battery": {
-        # The building is the thermal mass. Sizing rules of thumb:
-        # concrete equivalent ~ 0.05 m^3 per m^3 of heated volume
-        # for a typical brick / concrete envelope (heavier construction -> more).
-        "volume": 12.0,            # m^3 equivalent
-        "density": 2400, "heat_capacity": 0.88,  # concrete defaults
-        "thermal_loss": 0.05,
-        "start_temperature": 20.0,      # current measured indoor T
-        "min_temperatures": [19.0]*48,  # comfort lower bound
-        "max_temperatures": [22.0]*48,  # comfort upper bound
-        # Building envelope physics drives the demand each slot.
-        "u_value": 0.45,
-        "envelope_area": 180.0,
-        "ventilation_rate": 0.4,
-        "heated_volume": 240.0,
-        "indoor_target_temperature": 21.0,
-        # Source: constant-efficiency for gas, supply_temperature/heating_curve for HP
-        "efficiency": 0.92
-      }
-    }
-  ]
+    "def_load_config": [
+        {
+            "thermal_battery": {
+                # The building is the thermal mass. Sizing rules of thumb:
+                # concrete equivalent ~ 0.05 m^3 per m^3 of heated volume
+                # for a typical brick / concrete envelope (heavier construction -> more).
+                "volume": 12.0,  # m^3 equivalent
+                "density": 2400,
+                "heat_capacity": 0.88,  # concrete defaults
+                "thermal_loss": 0.05,
+                "start_temperature": 20.0,  # current measured indoor T
+                "min_temperatures": [19.0] * 48,  # comfort lower bound
+                "max_temperatures": [22.0] * 48,  # comfort upper bound
+                # Building envelope physics drives the demand each slot.
+                "u_value": 0.45,
+                "envelope_area": 180.0,
+                "ventilation_rate": 0.4,
+                "heated_volume": 240.0,
+                "indoor_target_temperature": 21.0,
+                # Source: constant-efficiency for gas, supply_temperature/heating_curve for HP
+                "efficiency": 0.92,
+            }
+        }
+    ]
 }
 ```
 
@@ -617,29 +664,75 @@ Same hot water tank but with soft constraints to target 50°C while allowing dev
 
 ```python
 {
-  "def_load_config": [
-    {
-      "thermal_battery": {
-        "supply_temperature": 45.0,
-        "volume": 0.2,
-        "density": 997,
-        "heat_capacity": 4.184,
-        "thermal_loss": 0.035,
-        "start_temperature": 50.0,
-        "min_temperatures": [40.0] * 48,
-        "max_temperatures": [60.0] * 48,
-        "desired_temperatures": [50.0] * 48,
-        "overshoot_temperature": 55.0,
-        "penalty_factor": 10,
-        "sense": "heat",
-        "carnot_efficiency": 0.40,
-        "draw_off_demand": [0,0,0,0,0,0, 0,0,0,0,0,0,
-                            0.5,0.3,0,0,0,0, 0,0,0,0,0,0,
-                            0,0,0,0,0,0, 0,0,0,0,0,0,
-                            0.8,0.5,0.3,0,0,0, 0,0,0,0,0,0]
-      }
-    }
-  ]
+    "def_load_config": [
+        {
+            "thermal_battery": {
+                "supply_temperature": 45.0,
+                "volume": 0.2,
+                "density": 997,
+                "heat_capacity": 4.184,
+                "thermal_loss": 0.035,
+                "start_temperature": 50.0,
+                "min_temperatures": [40.0] * 48,
+                "max_temperatures": [60.0] * 48,
+                "desired_temperatures": [50.0] * 48,
+                "overshoot_temperature": 55.0,
+                "penalty_factor": 10,
+                "sense": "heat",
+                "carnot_efficiency": 0.40,
+                "draw_off_demand": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0.5,
+                    0.3,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0.8,
+                    0.5,
+                    0.3,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+            }
+        }
+    ]
 }
 ```
 
@@ -654,44 +747,89 @@ A single heat pump serving both underfloor heating and a hot water tank. The opt
 
 ```python
 {
-  "num_def_loads": 2,
-  "nominal_power_of_deferrable_loads": [1000, 2000],
-  "treat_deferrable_load_as_semi_cont": [true, false],
-  "def_load_config": [
-    {
-      "thermal_battery": {
-        "indoor_target_temperature": 22,
-        "volume": 8,
-        "u_value": 0.3,
-        "envelope_area": 400.0,
-        "ventilation_rate": 0.5,
-        "heated_volume": 450.0,
-        "carnot_efficiency": 0.32,
-        "supply_temperature": 30.0,
-        "min_temperatures": [20.0] * 48,
-        "max_temperatures": [22.0] * 48,
-        "start_temperature": 20.0
-      }
-    },
-    {
-      "thermal_battery": {
-        "supply_temperature": 45.0,
-        "volume": 0.2,
-        "density": 997,
-        "heat_capacity": 4.184,
-        "thermal_loss": 0.035,
-        "carnot_efficiency": 0.32,
-        "start_temperature": 50.0,
-        "min_temperatures": [40.0] * 48,
-        "max_temperatures": [60.0] * 48,
-        "carnot_efficiency": 0.40,
-        "draw_off_demand": [0,0,0,0,0,0, 0,0,0,0,0,0,
-                            0.5,0.3,0,0,0,0, 0,0,0,0,0,0,
-                            0,0,0,0,0,0, 0,0,0,0,0,0,
-                            0.8,0.5,0.3,0,0,0, 0,0,0,0,0,0]
-      }
-    }
-  ]
+    "num_def_loads": 2,
+    "nominal_power_of_deferrable_loads": [1000, 2000],
+    "treat_deferrable_load_as_semi_cont": [true, false],
+    "def_load_config": [
+        {
+            "thermal_battery": {
+                "indoor_target_temperature": 22,
+                "volume": 8,
+                "u_value": 0.3,
+                "envelope_area": 400.0,
+                "ventilation_rate": 0.5,
+                "heated_volume": 450.0,
+                "carnot_efficiency": 0.32,
+                "supply_temperature": 30.0,
+                "min_temperatures": [20.0] * 48,
+                "max_temperatures": [22.0] * 48,
+                "start_temperature": 20.0,
+            }
+        },
+        {
+            "thermal_battery": {
+                "supply_temperature": 45.0,
+                "volume": 0.2,
+                "density": 997,
+                "heat_capacity": 4.184,
+                "thermal_loss": 0.035,
+                "carnot_efficiency": 0.40,
+                "start_temperature": 50.0,
+                "min_temperatures": [40.0] * 48,
+                "max_temperatures": [60.0] * 48,
+                "draw_off_demand": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0.5,
+                    0.3,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0.8,
+                    0.5,
+                    0.3,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+            }
+        },
+    ],
 }
 ```
 


### PR DESCRIPTION
## What
Fixes the `ruff format --check` failures currently on master's Code Quality Scan,
plus one genuine content bug.

I found this while syncing my fork with upstream after merging master in, my
own fork's Code Quality Scan started failing. I initially assumed I'd broken
something in the merge, so I cloned a fresh, untouched copy of
davidusb-geek/emhass and ran the same check locally (`ruff format --check --diff .`)
to compare. It failed identically on master too (verified against commit
aef76a4b), confirming this is pre-existing and repo-wide, not something my fork
introduced.

I reviewed the logs after each run and worked through the failures one file at
a time.

This is also independently confirmed by @Whatsonyourmind in #1043, who hit the
same issue.

## Files fixed (formatting only, unless noted)
- docs/cookbook/tariff_demand_charge.md
- docs/develop.md
- docs/mlforecaster.md
- docs/mlregressor.md
- docs/study_cases/dhw_walkthrough.md
- docs/study_cases/heat_pump_walkthrough.md
- docs/thermal_battery.md - formatting, plus one real bug, a duplicate
  `carnot_efficiency` key in the water-tank example that was set to 0.32, then
  immediately overwritten by 0.40 in the same dict. Removed the dead line.

## Testing
Verified on fork branch `docs-action-codequalityscan` by running
`ruff format --check .` and `ruff check .`  both pass clean, with 112 files
formatted and all checks passed.

## Summary by Sourcery

Reformat documentation code examples to comply with Ruff formatting rules and correct a duplicated carnot_efficiency field in a thermal battery example.

Documentation:
- Align thermal battery, heat pump walkthrough, DHW walkthrough, ML forecaster, ML regressor, and tariff demand charge documentation examples with Ruff formatting and style guidelines.
- Fix a duplicated carnot_efficiency key in a thermal battery hot water tank example so the configuration is consistent and unambiguous.