### PR TITLE
docs: re-green Code Quality by formatting the heat topology example

### DIFF
--- a/docs/heat_topology.md
+++ b/docs/heat_topology.md
@@ -144,13 +144,7 @@ This example models one 200 L DHW tank supplied by a 3.5 kW heat pump and a
 ```python
 HORIZON = 48
 
-draw_off = (
-    [0.0] * 12
-    + [0.5, 0.3]
-    + [0.0] * 22
-    + [0.8, 0.5, 0.3]
-    + [0.0] * 9
-)
+draw_off = [0.0] * 12 + [0.5, 0.3] + [0.0] * 22 + [0.8, 0.5, 0.3] + [0.0] * 9
 
 heat_topology = {
     "sources": [


### PR DESCRIPTION
The Code Quality Scan has been red on master since #1039 landed: the new ruff wants the draw_off list concatenation in docs/heat_topology.md on one line. #1044 fixed the earlier drift but #1039 merged just before it and brought this one in. Single hunk, no content change. Both `uvx ruff format --check --diff` and `uvx ruff check .` exit clean on the tree with it applied.

## Summary by Sourcery

Documentation:
- Update the heat_topology draw_off example in docs to use single-line list concatenation without changing its behavior.