### PR TITLE
fix: re-normalise per-load deferrable arrays after runtime overrides (#1040)

### DIFF
--- a/docs/passing_data.md
+++ b/docs/passing_data.md
@@ -95,6 +95,8 @@ Here is the list of the other additional dictionary keys that can be passed at r
 
 - `set_deferrable_load_single_constant` to define if we should set each deferrable load as a constant fixed value variable with just one startup for each optimization task.
 
+- Note: for the per-load array parameters above (and also `deferrable_load_max_cost`), a value shorter than `number_of_deferrable_loads` is padded with that parameter's default, whether it came from your configuration or from this runtime payload. A runtime-supplied short array also logs a warning naming the parameter and how many entries were added; a config-sourced one stays silent. Pass a full-length array to avoid the warning.
+
 - `solcast_api_key` for the SolCast API key if you want to use this service for PV power production forecast.
 
 - `solcast_rooftop_id` for the ID of your rooftop for the SolCast service implementation.

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -2359,6 +2359,79 @@ async def treat_runtimeparams(
             heat_topology,
         )
 
+    # Re-normalise per-load deferrable array params against the FINAL
+    # number_of_deferrable_loads (#1040). This has to run last: the
+    # association loop above, the def_load_config handling, and the
+    # heat_topology compile step can each change number_of_deferrable_loads
+    # or one of these arrays, and heat_topology runs even when runtimeparams
+    # is None. Mirrors the per-battery re-normalisation above (#610), but
+    # pads short arrays rather than truncating or erroring, matching
+    # check_def_loads's existing pad-to-fit semantics.
+    raw_num_def_loads = optim_conf.get("number_of_deferrable_loads", None)
+    if raw_num_def_loads is not None:
+        try:
+            final_num_def_loads = int(raw_num_def_loads)
+        except (TypeError, ValueError):
+            logger.warning(
+                "number_of_deferrable_loads is not a valid integer "
+                f"({raw_num_def_loads!r}); skipping deferrable load array "
+                "re-normalisation"
+            )
+            final_num_def_loads = None
+        if final_num_def_loads is not None:
+            # Write the cast int back: downstream readers of
+            # optim_conf["number_of_deferrable_loads"] need an int, not
+            # whatever raw value (e.g. a numeric string) the association
+            # loop copied in.
+            optim_conf["number_of_deferrable_loads"] = final_num_def_loads
+            runtime_source = runtimeparams or {}
+            for def_array_name, def_array_default in DEF_LOAD_ARRAY_PARAMS.items():
+                legacy_name = DEF_LOAD_ARRAY_LEGACY_NAMES.get(def_array_name)
+                runtime_value = runtime_source.get(def_array_name)
+                if runtime_value is None and legacy_name is not None:
+                    runtime_value = runtime_source.get(legacy_name)
+                # A JSON null is treated as "not provided", matching the
+                # association loop's own null-skipping - a padded config
+                # array should never be reported as a runtime override.
+                was_provided = runtime_value is not None
+
+                if was_provided and not isinstance(runtime_value, list):
+                    # A runtime scalar means every load, not "pad with the
+                    # default" - mirrors check_batt_params's silent
+                    # broadcast, and overrides any earlier partial handling
+                    # (e.g. set_deferrable_load_single_constant's own scalar
+                    # broadcast above, which doesn't know the final count).
+                    optim_conf[def_array_name] = [runtime_value] * final_num_def_loads
+                    continue
+
+                current_value = optim_conf.get(def_array_name)
+                if isinstance(current_value, list):
+                    # Copy before padding: check_def_loads mutates in place,
+                    # and this list may be the same object as
+                    # runtimeparams[name] or a passed_data alias set earlier
+                    # in this function - only optim_conf's own value should
+                    # change.
+                    before_value = list(current_value)
+                    optim_conf[def_array_name] = list(current_value)
+                else:
+                    before_value = current_value
+                optim_conf[def_array_name] = check_def_loads(
+                    final_num_def_loads,
+                    optim_conf,
+                    def_array_default,
+                    def_array_name,
+                    logger,
+                )
+                _warn_if_runtime_def_array_too_short(
+                    was_provided,
+                    def_array_name,
+                    before_value,
+                    optim_conf[def_array_name],
+                    final_num_def_loads,
+                    logger,
+                )
+            params["optim_conf"] = optim_conf
+
     # Serialize the final params
     params = orjson.dumps(params, default=str).decode()
     return params, retrieve_hass_conf, optim_conf, plant_conf
@@ -3259,69 +3332,17 @@ async def build_params(
     # If not, set defaults it fill in gaps
     if params["optim_conf"].get("number_of_deferrable_loads", None) is not None:
         num_def_loads = params["optim_conf"]["number_of_deferrable_loads"]
-        params["optim_conf"]["start_timesteps_of_each_deferrable_load"] = check_def_loads(
-            num_def_loads,
-            params["optim_conf"],
-            0,
-            "start_timesteps_of_each_deferrable_load",
-            logger,
-        )
-        params["optim_conf"]["end_timesteps_of_each_deferrable_load"] = check_def_loads(
-            num_def_loads,
-            params["optim_conf"],
-            0,
-            "end_timesteps_of_each_deferrable_load",
-            logger,
-        )
-        params["optim_conf"]["set_deferrable_load_single_constant"] = check_def_loads(
-            num_def_loads,
-            params["optim_conf"],
-            False,
-            "set_deferrable_load_single_constant",
-            logger,
-        )
-        params["optim_conf"]["treat_deferrable_load_as_semi_cont"] = check_def_loads(
-            num_def_loads,
-            params["optim_conf"],
-            True,
-            "treat_deferrable_load_as_semi_cont",
-            logger,
-        )
-        params["optim_conf"]["set_deferrable_startup_penalty"] = check_def_loads(
-            num_def_loads,
-            params["optim_conf"],
-            0.0,
-            "set_deferrable_startup_penalty",
-            logger,
-        )
-        params["optim_conf"]["deferrable_load_max_cost"] = check_def_loads(
-            num_def_loads,
-            params["optim_conf"],
-            0.0,
-            "deferrable_load_max_cost",
-            logger,
-        )
-        params["optim_conf"]["set_deferrable_max_startups"] = check_def_loads(
-            num_def_loads,
-            params["optim_conf"],
-            0,
-            "set_deferrable_max_startups",
-            logger,
-        )
-        params["optim_conf"]["operating_hours_of_each_deferrable_load"] = check_def_loads(
-            num_def_loads,
-            params["optim_conf"],
-            0,
-            "operating_hours_of_each_deferrable_load",
-            logger,
-        )
-        params["optim_conf"]["nominal_power_of_deferrable_loads"] = check_def_loads(
-            num_def_loads,
-            params["optim_conf"],
-            0,
-            "nominal_power_of_deferrable_loads",
-            logger,
-        )
+        # Looped over DEF_LOAD_ARRAY_PARAMS (name -> default) instead of 9
+        # repeated calls (#1040) - same order, same defaults, same call
+        # signature per entry, so behaviour is unchanged.
+        for def_array_name, def_array_default in DEF_LOAD_ARRAY_PARAMS.items():
+            params["optim_conf"][def_array_name] = check_def_loads(
+                num_def_loads,
+                params["optim_conf"],
+                def_array_default,
+                def_array_name,
+                logger,
+            )
         # Validate deferrable_load_groups
         groups = params["optim_conf"].get("deferrable_load_groups", [])
         if groups:
@@ -3476,6 +3497,41 @@ async def build_params(
     return params
 
 
+# Per-deferrable-load ARRAY parameters normalised against
+# number_of_deferrable_loads via check_def_loads (#929, #1040). build_params
+# loops over this table to pad each one from config; treat_runtimeparams's
+# re-normalisation pass reuses it to re-apply the same padding after a
+# runtime override may have replaced one of these arrays with a raw,
+# potentially short, value (the per-battery arrays already get an equivalent
+# pass via check_batt_params, #610).
+DEF_LOAD_ARRAY_PARAMS: dict[str, bool | int | float] = {
+    "start_timesteps_of_each_deferrable_load": 0,
+    "end_timesteps_of_each_deferrable_load": 0,
+    "set_deferrable_load_single_constant": False,
+    "treat_deferrable_load_as_semi_cont": True,
+    "set_deferrable_startup_penalty": 0.0,
+    "deferrable_load_max_cost": 0.0,
+    "set_deferrable_max_startups": 0,
+    "operating_hours_of_each_deferrable_load": 0,
+    "nominal_power_of_deferrable_loads": 0,
+}
+# Legacy (pre-#342) names for the same 9 arrays, from
+# src/emhass/data/associations.csv column 2. The association loop accepts
+# either the modern name (column 3) or this legacy one, so the
+# runtime-provided check in treat_runtimeparams has to match both.
+DEF_LOAD_ARRAY_LEGACY_NAMES: dict[str, str] = {
+    "start_timesteps_of_each_deferrable_load": "def_start_timestep",
+    "end_timesteps_of_each_deferrable_load": "def_end_timestep",
+    "set_deferrable_load_single_constant": "set_def_constant",
+    "treat_deferrable_load_as_semi_cont": "treat_def_as_semi_cont",
+    "set_deferrable_startup_penalty": "def_start_penalty",
+    "deferrable_load_max_cost": "deferrable_load_max_cost",
+    "set_deferrable_max_startups": "set_deferrable_max_startups",
+    "operating_hours_of_each_deferrable_load": "def_total_hours",
+    "nominal_power_of_deferrable_loads": "P_deferrable_nom",
+}
+
+
 def check_def_loads(
     num_def_loads: int,
     parameter: list[dict],
@@ -3530,6 +3586,75 @@ def check_def_loads(
         result = [v if v is not None else default for v in result]
         parameter[parameter_name] = result
     return result
+
+
+def _warn_if_runtime_def_array_too_short(
+    was_provided: bool,
+    def_array_name: str,
+    before_value: object,
+    after_value: object,
+    final_num_def_loads: int,
+    logger: logging.Logger,
+) -> None:
+    """
+    Warn when the re-normalisation pass actually changed a runtime-provided
+    per-load deferrable array (#1040).
+
+    check_def_loads pads a short array (and heals a None element) silently at
+    debug level (#929) - correct for a config-sourced array, e.g. a config
+    predating a load-count bump. A runtime-provided array is different: a
+    stale/short one is the foot-gun #1040 reports (an MPC caller resending an
+    old, shorter array after the load count changed elsewhere), so it gets a
+    visible warning instead. The values are unchanged either way - this only
+    makes a runtime-sourced change visible.
+
+    Fires only when the caller has established the value was genuinely
+    provided at runtime (`was_provided`) AND check_def_loads actually changed
+    it. The comparison is by value, not identity, since check_def_loads
+    always returns a freshly built list even when nothing changed - so an
+    identity check would report "changed" even when heat_topology's own
+    compiled value replaced the runtime one and nothing was really padded.
+
+    Describes the outcome rather than the input shape: a length increase says
+    how many entries were padded; a same-length change (a None element
+    healed) says that instead of overclaiming padding.
+
+    :param was_provided: whether the modern or legacy name carried a
+        non-null value in runtimeparams
+    :type was_provided: bool
+    :param def_array_name: the modern per-load array parameter name
+    :type def_array_name: str
+    :param before_value: optim_conf[def_array_name] immediately before this
+        call's check_def_loads (an independent copy, never mutated by it)
+    :type before_value: object
+    :param after_value: optim_conf[def_array_name] immediately after
+    :type after_value: object
+    :param final_num_def_loads: number_of_deferrable_loads after every reset
+        inside treat_runtimeparams has been applied
+    :type final_num_def_loads: int
+    :param logger: The logger object
+    :type logger: logging.Logger
+    """
+    if not was_provided or before_value == after_value:
+        return
+    if (
+        isinstance(before_value, list)
+        and isinstance(after_value, list)
+        and len(before_value) < len(after_value)
+    ):
+        logger.warning(
+            f"{def_array_name}: padded from {len(before_value)} to "
+            f"{len(after_value)} entries to match "
+            f"number_of_deferrable_loads={final_num_def_loads}. Pass a "
+            "full-length array to avoid this warning."
+        )
+    else:
+        logger.warning(
+            f"{def_array_name}: a None/null entry was replaced with the "
+            f"parameter default (number_of_deferrable_loads="
+            f"{final_num_def_loads}). Pass a fully populated array to avoid "
+            "this warning."
+        )
 
 
 # Per-battery ARRAY parameters (#610): scalar accepted and broadcast to every

--- a/tests/test_config_value_resilience.py
+++ b/tests/test_config_value_resilience.py
@@ -138,6 +138,17 @@ _XFAIL_EXCLUDE: frozenset[tuple[str, str]] = frozenset(
         # short-circuits on None (falsy) and 0.5 only appears as a CVXPY float
         # bound which is valid.  No crash for the [None, 0.5] shape.
         ("set_deferrable_max_startups", "none_element"),
+        # #1040: treat_runtimeparams now re-runs check_def_loads over every
+        # DEF_LOAD_ARRAY_PARAMS entry after the runtime association loop, and
+        # check_def_loads has always replaced None elements with the param's
+        # default (see its docstring). That second pass now guards the
+        # [None, 0.5] shape for these 4 params too - only the none_element
+        # case; scalar_null and str_element still crash (unguarded, no
+        # change) so those stay xfail.
+        ("nominal_power_of_deferrable_loads", "none_element"),
+        ("operating_hours_of_each_deferrable_load", "none_element"),
+        ("set_deferrable_startup_penalty", "none_element"),
+        ("deferrable_load_max_cost", "none_element"),
         # #610: check_batt_params coerces a stringly-typed "null" scalar to the
         # per-battery default and broadcasts it - a real guard, so this stays a
         # live regression test even though the same param is xfail'd for the

--- a/tests/test_deferrable_runtime_renormalise.py
+++ b/tests/test_deferrable_runtime_renormalise.py
@@ -1,0 +1,552 @@
+"""
+Deferrable-load per-load array re-normalisation after runtime params (#1040).
+
+The association loop inside treat_runtimeparams (utils.py ~1430) copies a raw
+runtime value into optim_conf for every associations.csv row, modern or
+legacy name, with no length validation. Battery arrays got a post-loop
+re-normalisation for this (#610, ~1469); deferrable arrays never did, so a
+stale short array in a runtime payload survived treat_runtimeparams and blew
+up as an IndexError deep inside optimization.py's
+_add_deferrable_load_constraints (whichever per-load array is read first).
+
+This file proves the fix: after treat_runtimeparams returns, every per-load
+array in utils.DEF_LOAD_ARRAY_PARAMS is padded to the final
+number_of_deferrable_loads, a runtime-provided short array gets a visible
+warning (config-sourced padding stays silent/debug per #929), and correctly
+sized arrays pass through unchanged with no warning.
+
+Base-safety: DEF_LOAD_ARRAY_PARAMS does not exist on master yet, so
+DEF_ARRAY_NAMES below is a hardcoded literal (not read off
+utils.DEF_LOAD_ARRAY_PARAMS) and tests assert on LENGTH/VALUE behaviour, not
+on the new symbol existing - so a RED run on base fails at the behavioural
+assertion, not an ImportError/AttributeError.
+"""
+
+import asyncio
+import json
+import logging
+import pathlib
+
+import orjson
+
+from emhass import utils
+
+root = pathlib.Path(utils.get_root(__file__, num_parent=2))
+emhass_conf = {
+    "data_path": root / "data/",
+    "root_path": root / "src/emhass/",
+    "defaults_path": root / "src/emhass/data/config_defaults.json",
+    "associations_path": root / "src/emhass/data/associations.csv",
+}
+logger, _ = utils.get_logger(__name__, emhass_conf, save_to_file=False)
+
+# The 9 arrays build_params normalises via check_def_loads (utils.py, #929).
+# Hardcoded (not read from utils.DEF_LOAD_ARRAY_PARAMS) so the RED-on-base
+# tests still know what to check for when that table doesn't exist yet.
+DEF_ARRAY_NAMES = [
+    "start_timesteps_of_each_deferrable_load",
+    "end_timesteps_of_each_deferrable_load",
+    "set_deferrable_load_single_constant",
+    "treat_deferrable_load_as_semi_cont",
+    "set_deferrable_startup_penalty",
+    "deferrable_load_max_cost",
+    "set_deferrable_max_startups",
+    "operating_hours_of_each_deferrable_load",
+    "nominal_power_of_deferrable_loads",
+]
+
+
+def _default_config() -> dict:
+    return json.loads(emhass_conf["defaults_path"].read_text(encoding="utf-8"))
+
+
+async def _build_params(overrides: dict | None = None) -> dict:
+    config = _default_config()
+    if overrides:
+        config.update(overrides)
+    _, secrets = await utils.build_secrets(emhass_conf, logger, no_response=True)
+    params = await utils.build_params(emhass_conf, secrets, config, logger)
+    assert params is not False, "build_params failed (see logged error)"
+    return params
+
+
+def build_params(overrides: dict | None = None) -> dict:
+    return asyncio.run(_build_params(overrides))
+
+
+async def _treat_runtime(runtimeparams: dict, base_params: dict, set_type="dayahead-optim"):
+    params_json = orjson.dumps(base_params).decode("utf-8")
+    rh_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+    rp_json = orjson.dumps(runtimeparams).decode("utf-8")
+    return await utils.treat_runtimeparams(
+        rp_json,
+        params_json,
+        rh_conf,
+        optim_conf,
+        plant_conf,
+        set_type,
+        logger,
+        emhass_conf,
+    )
+
+
+def treat_runtime(runtimeparams: dict, base_params: dict, set_type="dayahead-optim"):
+    _, rh_conf, optim_conf, plant_conf = asyncio.run(
+        _treat_runtime(runtimeparams, base_params, set_type)
+    )
+    return rh_conf, optim_conf, plant_conf
+
+
+def _short_warnings(caplog, parameter_name: str) -> list:
+    return [
+        rec
+        for rec in caplog.records
+        if rec.levelname == "WARNING"
+        and parameter_name in rec.message
+        and "padded from" in rec.message
+    ]
+
+
+# ─────────────────────── RED-on-base: length after renormalise ─────────────
+
+
+def test_short_deferrable_load_max_cost_gets_padded_to_final_count():
+    """Reporter's exact repro shape: runtime bumps the load count to 3 and
+    supplies a stale 2-element deferrable_load_max_cost. Every table array
+    must come out length 3 after treat_runtimeparams, not just the one the
+    caller happened to also touch (the crash moves to whichever key
+    optimization.py reads first)."""
+    base = build_params()
+    _, optim_conf, _ = treat_runtime(
+        {
+            "number_of_deferrable_loads": 3,
+            "deferrable_load_max_cost": [0, 0],
+        },
+        base,
+    )
+    assert optim_conf.get("number_of_deferrable_loads") == 3
+    for name in DEF_ARRAY_NAMES:
+        value = optim_conf.get(name)
+        assert isinstance(value, list), f"{name} should be a list, got {value!r}"
+        assert len(value) == 3, f"{name} has {len(value)} entries, expected 3"
+
+
+def test_short_set_deferrable_load_single_constant_gets_padded_to_final_count():
+    """Second variant from the reporter: the short array is a different key
+    (set_deferrable_load_single_constant), proving the fix isn't keyed to one
+    specific param name."""
+    base = build_params()
+    _, optim_conf, _ = treat_runtime(
+        {
+            "number_of_deferrable_loads": 3,
+            "set_deferrable_load_single_constant": [False],
+        },
+        base,
+    )
+    assert optim_conf.get("number_of_deferrable_loads") == 3
+    for name in DEF_ARRAY_NAMES:
+        value = optim_conf.get(name)
+        assert isinstance(value, list), f"{name} should be a list, got {value!r}"
+        assert len(value) == 3, f"{name} has {len(value)} entries, expected 3"
+
+
+# ─────────────────────────── counterfactual passthrough ────────────────────
+
+
+def test_correctly_sized_runtime_arrays_pass_through_unchanged(caplog):
+    """All 9 arrays supplied already sized to the final count: values must be
+    unchanged and no padding/no warning should fire."""
+    base = build_params()
+    runtimeparams = {
+        "number_of_deferrable_loads": 3,
+        "start_timesteps_of_each_deferrable_load": [0, 1, 2],
+        "end_timesteps_of_each_deferrable_load": [10, 11, 12],
+        "set_deferrable_load_single_constant": [False, True, False],
+        "treat_deferrable_load_as_semi_cont": [True, False, True],
+        "set_deferrable_startup_penalty": [0.0, 0.1, 0.2],
+        "deferrable_load_max_cost": [0.0, 1.5, 3.0],
+        "set_deferrable_max_startups": [0, 2, 4],
+        "operating_hours_of_each_deferrable_load": [1, 2, 3],
+        "nominal_power_of_deferrable_loads": [1000, 2000, 3000],
+    }
+    with caplog.at_level(logging.WARNING):
+        _, optim_conf, _ = treat_runtime(runtimeparams, base)
+    for name in DEF_ARRAY_NAMES:
+        assert optim_conf.get(name) == runtimeparams[name], (
+            f"{name}: expected unchanged passthrough of {runtimeparams[name]!r}, "
+            f"got {optim_conf.get(name)!r}"
+        )
+        assert _short_warnings(caplog, name) == [], f"{name} should not have warned"
+
+
+def test_absent_array_pads_silently_config_sourced(caplog):
+    """An array absent from BOTH config and runtime is config-sourced padding
+    (#929) - debug only, never the new runtime-short warning."""
+    base = build_params()
+    with caplog.at_level(logging.WARNING):
+        _, optim_conf, _ = treat_runtime({"number_of_deferrable_loads": 3}, base)
+    assert len(optim_conf.get("deferrable_load_max_cost", [])) == 3
+    assert _short_warnings(caplog, "deferrable_load_max_cost") == []
+
+
+def test_explicit_null_array_pads_silently_from_config(caplog):
+    """The association loop skips a JSON null runtime value (it only copies
+    when the runtime value is not None), so an explicit null never reaches
+    optim_conf - the array that gets padded is the CONFIG one, not a
+    runtime-provided one. Zero re-normalisation warnings, same as if the key
+    were absent (the deferrable_load_max_cost-specific check mirrors the
+    absent-array test above; a bare-message scan guards against a
+    differently-worded regression escaping that filter)."""
+    base = build_params()
+    with caplog.at_level(logging.WARNING):
+        _, optim_conf, _ = treat_runtime(
+            {"number_of_deferrable_loads": 3, "deferrable_load_max_cost": None},
+            base,
+        )
+    assert len(optim_conf.get("deferrable_load_max_cost", [])) == 3
+    assert _short_warnings(caplog, "deferrable_load_max_cost") == []
+    renorm_warnings = [
+        rec.message
+        for rec in caplog.records
+        if rec.levelname == "WARNING" and "deferrable_load_max_cost" in rec.message
+    ]
+    assert renorm_warnings == [], f"expected zero warnings, got {renorm_warnings}"
+
+
+# ─────────────────────────── legacy-name variant ────────────────────────────
+
+
+def test_short_array_via_legacy_name_warns_and_pads(caplog):
+    """The association loop also applies overrides passed under the legacy
+    parameter name (P_deferrable_nom -> nominal_power_of_deferrable_loads,
+    src/emhass/data/associations.csv row 48); the short-array warning and
+    padding must fire for those too."""
+    base = build_params()
+    with caplog.at_level(logging.WARNING):
+        _, optim_conf, _ = treat_runtime(
+            {
+                "number_of_deferrable_loads": 3,
+                "P_deferrable_nom": [1000.0, 2000.0],
+            },
+            base,
+        )
+    assert optim_conf.get("nominal_power_of_deferrable_loads") == [1000.0, 2000.0, 0]
+    warnings = _short_warnings(caplog, "nominal_power_of_deferrable_loads")
+    assert len(warnings) == 1, "expected exactly one runtime-short warning"
+
+
+# ────────────────────── def_load_config interaction ────────────────────────
+
+
+def test_def_load_config_reset_then_short_array_still_normalised():
+    """The def_load_config runtime handling resets number_of_deferrable_loads
+    AFTER the association loop has already applied a short
+    deferrable_load_max_cost; the final normalisation must use the
+    POST-reset count, pinning the fix's placement after that reset."""
+    base = build_params()
+    _, optim_conf, _ = treat_runtime(
+        {
+            "deferrable_load_max_cost": [0, 0],
+            "def_load_config": [{}, {}, {}],
+        },
+        base,
+    )
+    assert optim_conf.get("number_of_deferrable_loads") == 3
+    assert len(optim_conf.get("deferrable_load_max_cost", [])) == 3
+
+
+# ────────────────────────────── string count ────────────────────────────────
+
+
+def test_string_number_of_deferrable_loads_does_not_crash():
+    """number_of_deferrable_loads can arrive at runtime as a string (the
+    association loop copies the raw runtime value); the re-normalisation
+    block must cast defensively instead of crashing on list * str.
+
+    The cast int must also be written back into optim_conf, not just used
+    locally to size the padded arrays - otherwise every downstream reader of
+    optim_conf["number_of_deferrable_loads"] (a bare range()/arithmetic use
+    in optimization.py) still crashes on the string, just relocated. This is
+    the end-to-end claim the test's own name makes."""
+    base = build_params()
+    _, optim_conf, _ = treat_runtime(
+        {
+            "number_of_deferrable_loads": "3",
+            "deferrable_load_max_cost": [0, 0],
+        },
+        base,
+    )
+    assert len(optim_conf.get("deferrable_load_max_cost", [])) == 3
+    assert optim_conf.get("number_of_deferrable_loads") == 3
+    assert isinstance(optim_conf.get("number_of_deferrable_loads"), int), (
+        "number_of_deferrable_loads must be cast back to int, not left as the "
+        f"raw runtime string; got {optim_conf.get('number_of_deferrable_loads')!r}"
+    )
+    # range() over the returned count must not raise - the exact downstream
+    # symptom this pins (optimization.py's bare range() reads).
+    list(range(optim_conf["number_of_deferrable_loads"]))
+
+
+# ─────────────── caller-dict mutation / passed_data aliasing ───────────────
+
+
+def test_treat_runtimeparams_does_not_mutate_callers_dict_and_warns_each_call(caplog):
+    """The association loop assigns runtime list values BY REFERENCE, so
+    optim_conf[name] could end up being the exact same list object as
+    runtimeparams[name]. check_def_loads pads in place, so without a
+    defensive copy, padding optim_conf[name] would also silently pad the
+    caller's own dict - and, on a second call reusing that now-already-padded
+    dict, the warning would stop firing (nothing looks short anymore).
+
+    Calls treat_runtimeparams twice with the SAME dict object (not
+    re-serialised - a JSON round-trip would mask this, since orjson.loads
+    always returns a fresh object)."""
+    base = build_params()
+    params_json = orjson.dumps(base).decode("utf-8")
+    rp = {"number_of_deferrable_loads": 3, "deferrable_load_max_cost": [0, 0]}
+
+    async def _call():
+        rh_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+        return await utils.treat_runtimeparams(
+            rp, params_json, rh_conf, optim_conf, plant_conf, "dayahead-optim", logger, emhass_conf
+        )
+
+    warn_counts = []
+    for _ in range(2):
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            _, _, optim_conf_out, _ = asyncio.run(_call())
+        warn_counts.append(len(_short_warnings(caplog, "deferrable_load_max_cost")))
+        # The caller's dict must be untouched after every call, not just the first.
+        assert rp["deferrable_load_max_cost"] == [0, 0], (
+            f"caller's runtimeparams dict was mutated: {rp['deferrable_load_max_cost']!r}"
+        )
+        assert optim_conf_out["deferrable_load_max_cost"] is not rp["deferrable_load_max_cost"], (
+            "optim_conf must not alias the caller's list object"
+        )
+        assert optim_conf_out["deferrable_load_max_cost"] == [0, 0, 0.0]
+    assert warn_counts == [1, 1], (
+        f"warning must fire on every call reusing the same dict, got counts {warn_counts}"
+    )
+
+
+def test_naive_mpc_passed_data_alias_stays_short(caplog):
+    """Same root cause as the mutation test, different victim: the naive-mpc
+    branch aliases params["passed_data"][name] to params["optim_conf"][name]
+    before the re-normalisation block runs. Because that block copies before
+    padding, optim_conf's array becomes a distinct (padded) object while
+    passed_data keeps pointing at the original (short, pre-pad) one - so the
+    padding is confined to optim_conf, exactly where it belongs, and the
+    serialized passed_data isn't silently lengthened to a count nothing
+    asked it to report."""
+    base = build_params()
+    with caplog.at_level(logging.WARNING):
+        params_str, _, optim_conf, _ = asyncio.run(
+            _treat_runtime(
+                {
+                    "number_of_deferrable_loads": 3,
+                    "operating_hours_of_each_deferrable_load": [4, 0],
+                },
+                base,
+                set_type="naive-mpc-optim",
+            )
+        )
+    params_out = orjson.loads(params_str)
+    assert optim_conf["operating_hours_of_each_deferrable_load"] == [4, 0, 0]
+    assert params_out["passed_data"]["operating_hours_of_each_deferrable_load"] == [4, 0], (
+        "passed_data alias must stay at its pre-padding length/values, not "
+        f"follow optim_conf's padding; got "
+        f"{params_out['passed_data']['operating_hours_of_each_deferrable_load']!r}"
+    )
+
+
+# ──────────────── None-heal on a correctly-sized array ──────────────────────
+
+
+def test_correctly_sized_none_element_healed_and_warns(caplog):
+    """A None element in a correctly-sized RUNTIME array is deliberately
+    healed to the param default - matching what build_params has always done
+    for config arrays - and now fires a visible warning (previously this
+    healed silently with no diagnostic). This test pins that behaviour so it
+    can't be re-litigated as an accidental regression."""
+    base = build_params()
+    with caplog.at_level(logging.WARNING):
+        _, optim_conf, _ = treat_runtime(
+            {
+                "number_of_deferrable_loads": 2,
+                "treat_deferrable_load_as_semi_cont": [None, True],
+            },
+            base,
+        )
+    assert optim_conf.get("treat_deferrable_load_as_semi_cont") == [True, True]
+    warnings = [
+        rec
+        for rec in caplog.records
+        if rec.levelname == "WARNING" and "treat_deferrable_load_as_semi_cont" in rec.message
+    ]
+    assert len(warnings) == 1, "expected exactly one warning for the healed None element"
+    assert "None" in warnings[0].message or "null" in warnings[0].message, (
+        f"warning should describe a None-heal, not overclaim padding: {warnings[0].message!r}"
+    )
+    assert "padded from" not in warnings[0].message, (
+        "same-length change is a None-heal, not padding - the message must not overclaim"
+    )
+
+
+# ──────────────── heat_topology overwrite ───────────────────────────────────
+
+
+_TOPO = {
+    "sources": [
+        {
+            "id": "boiler",
+            "type": "gas",
+            "efficiency": 0.9,
+            "nominal_power": 10000,
+            "min_power": 2000,
+        }
+    ],
+    "storage": [
+        {
+            "id": "tank",
+            "volume": 0.1,
+            "start_temperature": 35,
+            "min_temperature": [25] * 48,
+            "max_temperature": [60] * 48,
+            "thermal_loss": 0.05,
+        }
+    ],
+    "flows": [{"from": "boiler", "to": "tank"}],
+}
+
+
+def test_heat_topology_overwrite_short_runtime_array_matches_compiled_sizing(caplog):
+    """Pins the placement decision: heat_topology compiles to its own
+    number_of_deferrable_loads and force-overwrites every one of the 9 table
+    arrays, which runs AFTER the association loop, so the fix must land
+    after that compile step, not immediately after the association loop. A
+    short runtime array for one of the 9 must not survive - the final arrays
+    must match the heat_topology-compiled sizing, with no crash and no
+    false-positive warning (nothing was actually padded FROM the runtime
+    value; heat_topology's own value won)."""
+    base = build_params({"heat_topology": _TOPO})
+    with caplog.at_level(logging.WARNING):
+        _, optim_conf, _ = treat_runtime(
+            {"deferrable_load_max_cost": []},
+            base,
+        )
+    compiled_count = optim_conf.get("number_of_deferrable_loads")
+    assert compiled_count == 1, f"expected the topology to compile to 1 load, got {compiled_count}"
+    for name in DEF_ARRAY_NAMES:
+        value = optim_conf.get(name)
+        assert isinstance(value, list) and len(value) == compiled_count, (
+            f"{name} must match the compiled count {compiled_count}, got {value!r}"
+        )
+    assert optim_conf.get("nominal_power_of_deferrable_loads") == [10000.0], (
+        "heat_topology's own compiled value must win, not the runtime override's absence"
+    )
+    assert _short_warnings(caplog, "deferrable_load_max_cost") == [], (
+        "no warning should fire: heat_topology already replaced the runtime value "
+        "before this block runs, so nothing was actually padded from it"
+    )
+
+
+# ─────────────────────── runtimeparams=None passthrough ────────────────────
+
+
+def test_runtimeparams_none_passes_through_unchanged():
+    """The block runs unconditionally (even with runtimeparams=None, since
+    heat_topology can mutate these arrays from static config alone). For a
+    WELL-FORMED config (already correctly padded by build_params), that must
+    still be a true no-op: every table array unchanged from what build_params
+    produced."""
+    base = build_params()
+
+    async def _call():
+        params_json = orjson.dumps(base).decode("utf-8")
+        rh_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+        return await utils.treat_runtimeparams(
+            None,
+            params_json,
+            rh_conf,
+            optim_conf,
+            plant_conf,
+            "dayahead-optim",
+            logger,
+            emhass_conf,
+        )
+
+    _, _, optim_conf, _ = asyncio.run(_call())
+    for name in DEF_ARRAY_NAMES:
+        assert optim_conf.get(name) == base["optim_conf"].get(name), (
+            f"{name}: expected unchanged passthrough with runtimeparams=None, "
+            f"got {optim_conf.get(name)!r} vs base {base['optim_conf'].get(name)!r}"
+        )
+    assert optim_conf.get("number_of_deferrable_loads") == base["optim_conf"].get(
+        "number_of_deferrable_loads"
+    )
+
+
+# ───────────────────── oversize array is not truncated ─────────────────────
+
+
+def test_oversize_runtime_array_is_not_truncated():
+    """Non-goal, explicitly: no length-check/truncation of OVERSIZED arrays
+    (the config path doesn't truncate them either, #929's check_def_loads
+    only ever enlarges)."""
+    base = build_params()
+    oversized = [1000.0, 2000.0, 3000.0, 4000.0]
+    _, optim_conf, _ = treat_runtime(
+        {
+            "number_of_deferrable_loads": 2,
+            "nominal_power_of_deferrable_loads": oversized,
+        },
+        base,
+    )
+    assert optim_conf.get("nominal_power_of_deferrable_loads") == oversized, (
+        "an oversized runtime array must pass through untouched, not be truncated "
+        f"to number_of_deferrable_loads; got {optim_conf.get('nominal_power_of_deferrable_loads')!r}"
+    )
+
+
+# ───────────────────────── runtime scalar broadcast ─────────────────────────
+
+
+def test_runtime_scalar_broadcasts_to_final_count(caplog):
+    """A runtime scalar means "every load", not "the first N loads, padded
+    with the table default for the rest". Base crashes on this exact shape
+    (set_deferrable_load_single_constant: true bumping the count to 3 dies
+    with an IndexError deep in the optimizer, since nothing before this fix
+    ever re-sizes the array the earlier scalar-broadcast handling produces),
+    so this pins the head behaviour rather than guarding a regression.
+    Mirrors check_batt_params, which broadcasts a scalar the same way."""
+    base = build_params()
+    with caplog.at_level(logging.WARNING):
+        _, optim_conf, _ = treat_runtime(
+            {
+                "number_of_deferrable_loads": 3,
+                "set_deferrable_load_single_constant": True,
+            },
+            base,
+        )
+    assert optim_conf.get("set_deferrable_load_single_constant") == [True, True, True], (
+        "a runtime scalar True must broadcast to every load, not leave the "
+        f"added load at the table default; got "
+        f"{optim_conf.get('set_deferrable_load_single_constant')!r}"
+    )
+    # A pure scalar broadcast is the user's stated intent, not a stale/short
+    # payload - no re-normalisation warning should fire for it (see the
+    # implementer's notes on this choice).
+    assert _short_warnings(caplog, "set_deferrable_load_single_constant") == []
+
+
+def test_runtime_scalar_broadcast_via_legacy_name():
+    """The same broadcast must apply when the scalar arrives under the
+    legacy name (set_def_constant -> set_deferrable_load_single_constant,
+    src/emhass/data/associations.csv row 55)."""
+    base = build_params()
+    _, optim_conf, _ = treat_runtime(
+        {"number_of_deferrable_loads": 3, "set_def_constant": False},
+        base,
+    )
+    assert optim_conf.get("set_deferrable_load_single_constant") == [False, False, False]


### PR DESCRIPTION
## The bug

A runtime payload carrying a per-load array with fewer entries than
`number_of_deferrable_loads` crashes the optimization with
`IndexError: list index out of range`. @kristianbruun-ctrl hit this with a
stale 2-element `deferrable_load_max_cost` against 3 loads, and showed the
crash just moves to whichever short array gets read first (his second repro
used a short `set_deferrable_load_single_constant`). The earliest unguarded
read is in `Optimization.__init__` (`_initialize_decision_variables`,
optimization.py:1577), so any of the nine per-load arrays being short takes
the whole run down.

Root cause: the association loop in `treat_runtimeparams` copies raw runtime
values into `optim_conf` with no length check. `build_params` normalises all
of these arrays via `check_def_loads`, but that runs before the runtime
override, and nothing re-normalises after it. The per-battery arrays had the
same failure mode and got a post-loop re-normalisation in #610/#1032; this PR
extends the same pattern to the deferrable-load arrays.

## The fix

- New module-level table `DEF_LOAD_ARRAY_PARAMS` holding the nine per-load
  arrays and their defaults (values moved verbatim from the existing
  `check_def_loads` call sites in `build_params`; those nine call sites now
  loop over the table, no semantic change).
- A re-normalisation block at the end of `treat_runtimeparams` re-runs
  `check_def_loads` over the table against the final
  `number_of_deferrable_loads`. It sits last deliberately: both the runtime
  `def_load_config` handling and the `heat_topology` compile step can change
  the load count after the association loop, so normalising any earlier can
  be undone.
- A warning fires when a runtime-provided array (modern or legacy name) was
  actually changed by the normalisation, so a stale payload is visible in the
  log instead of silent.
- The block pads a copy, never the caller's list, and a castable
  `number_of_deferrable_loads` string from the payload is written back as an
  int.

Per-load arrays not in the table (`is_electric_load`,
`minimum_power_of_deferrable_loads`, `cost_forecast_per_deferrable_load`,
`def_load_config`) were each checked: every read path is length-guarded or
padded downstream, so they cannot produce this crash and were left alone.

## Behaviour changes

- A short runtime per-load array now pads with the param default and warns,
  instead of crashing. Same semantics `check_def_loads` has always applied to
  config-sourced arrays (#929).
- A `None` element in a runtime array is now replaced with the param default,
  again matching what `build_params` already does to config arrays. Four
  `none_element` cases in `test_config_value_resilience.py` that documented
  the old crash as expected-fail now pass and moved to that file's exclude
  list.
- A runtime scalar for one of these params (e.g.
  `"set_deferrable_load_single_constant": true`) is now broadcast to all
  loads, the same way the per-battery params treat a scalar. Previously a
  scalar was broadcast to the old array length, which crashed when the load
  count grew, and padding it with defaults instead would have given the value
  to some loads but not others.
- The block also runs when no runtime params are passed at all. That is
  required because `heat_topology` can resize the arrays without any runtime
  payload; for a config that came through `build_params` it is a no-op.

## Tests

New file `tests/test_deferrable_runtime_renormalise.py` covering the
reporter's two repro shapes, correct-size passthrough (byte-identical, no
warning), legacy param names, the `def_load_config` count reset, the
`heat_topology` interaction, `runtimeparams=None`, oversize arrays (not
truncated), `None` healing, string counts, and no mutation of the caller's
dict. Full suite green locally.

Fixes #1040

## Summary by Sourcery

Re-normalise deferrable per-load array parameters after runtime overrides to prevent index errors and align their sizing with the final number_of_deferrable_loads.

Bug Fixes:
- Prevent crashes when runtime-provided deferrable-load arrays are shorter than number_of_deferrable_loads by padding them instead of leaving them undersized.

Enhancements:
- Introduce shared DEF_LOAD_ARRAY_PARAMS and legacy-name mapping to centralise per-load deferrable array defaults and reuse them across config and runtime normalisation.
- Emit warnings when runtime-provided deferrable-load arrays are padded or None elements are healed so stale or malformed runtime payloads are visible in logs.

Documentation:
- Document that per-load deferrable array parameters are padded to number_of_deferrable_loads and that runtime short arrays produce warnings in the passing_data guide.

Tests:
- Add a comprehensive test suite for deferrable-load runtime re-normalisation, covering short and correctly sized arrays, legacy parameter names, heat_topology interactions, scalar broadcasts, None healing, oversize arrays, string load counts, and aliasing/mutation behaviour.
- Update resilience tests to mark previously expected-failing None-element deferrable-load cases as now passing due to the new re-normalisation behaviour.