### PR TITLE
fix: infer publish-data index frequency from the saved CSV (#976)

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -3217,7 +3217,14 @@ def _load_opt_res_latest(
     opt_res_latest.index = pd.to_datetime(opt_res_latest.index, utc=True).tz_convert(
         input_data_dict["retrieve_hass_conf"]["time_zone"]
     )
-    opt_res_latest.index.freq = input_data_dict["retrieve_hass_conf"]["optimization_time_step"]
+    # Infer the index frequency from the saved data itself rather than asserting
+    # the current request's optimization_time_step onto it (#976): the CSV may
+    # have been written by a run with a different runtime optimization_time_step,
+    # and pandas raises on the mismatch. The publish path only needs the
+    # timestamps for nearest-index matching. Frames with fewer than 2 rows carry
+    # no inferable spacing, so leave their freq unset.
+    if len(opt_res_latest.index) > 1:
+        opt_res_latest = utils.set_df_index_freq(opt_res_latest)
     return opt_res_latest
 
 

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -3142,6 +3142,85 @@ class TestDstFixes(unittest.TestCase):
         self.assertEqual(zones, {"Europe/Paris"}, f"Unexpected timezone(s) in result: {zones}")
 
 
+class TestLoadOptResLatestFreqInference(unittest.TestCase):
+    """Unit tests for #976: _load_opt_res_latest must infer the index frequency
+    from the saved CSV instead of asserting the current request's
+    optimization_time_step onto it.
+
+    An optimization run with a runtime optimization_time_step (e.g. 60) writes
+    an hourly CSV; a later publish-data call whose body does not repeat that
+    key falls back to the config value (e.g. 30 min) and the old freq
+    assignment raised 'Inferred frequency h from passed values does not
+    conform to passed frequency 30min'. The publish path only uses the
+    timestamps for nearest-index matching, so the frequency baked into the
+    saved data is the correct one.
+    """
+
+    @staticmethod
+    def _write_csv(tmp_path: pathlib.Path, periods: int, freq: str) -> pd.DataFrame:
+        idx = pd.date_range("2026-08-01 00:00", periods=periods, freq=freq, tz="UTC")
+        df = pd.DataFrame({"P_Load": range(periods)}, index=idx)
+        df.index.name = "timestamp"
+        df.to_csv(tmp_path / "opt_res_latest.csv")
+        return df
+
+    @staticmethod
+    def _input_data_dict(tmp_path: pathlib.Path, step_minutes: int) -> dict:
+        import pytz
+
+        return {
+            "emhass_conf": {"data_path": tmp_path},
+            "retrieve_hass_conf": {
+                "time_zone": pytz.timezone("Europe/Paris"),
+                "optimization_time_step": pd.Timedelta(minutes=step_minutes),
+            },
+        }
+
+    def _load_result(self, periods: int, freq: str, step_minutes: int) -> pd.DataFrame | None:
+        """Write a CSV and load it back through _load_opt_res_latest."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = pathlib.Path(tmpdir)
+            self._write_csv(tmp_path, periods=periods, freq=freq)
+            return _load_opt_res_latest(
+                self._input_data_dict(tmp_path, step_minutes=step_minutes),
+                logger,
+                save_data_to_file=False,
+            )
+
+    def test_mismatched_step_loads_and_infers_freq(self):
+        """An hourly CSV must load under a 30-min config instead of raising.
+
+        This is the #976 repro: naive-mpc-optim wrote the CSV with a runtime
+        optimization_time_step of 60; publish-data then arrived using the
+        config default of 30 min.
+        """
+        result = self._load_result(periods=8, freq="60min", step_minutes=30)
+
+        self.assertIsNotNone(result, "_load_opt_res_latest returned None for an hourly CSV")
+        self.assertEqual(len(result), 8)
+        # The frequency must come from the data, not the request config.
+        self.assertEqual(result.index.freq, pd.tseries.frequencies.to_offset("60min"))
+        self.assertListEqual(list(result["P_Load"]), list(range(8)))
+
+    def test_matching_step_keeps_frame_and_freq(self):
+        """Counterfactual: the healthy matching-step path must be unchanged."""
+        result = self._load_result(periods=8, freq="30min", step_minutes=30)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 8)
+        self.assertEqual(result.index.freq, pd.tseries.frequencies.to_offset("30min"))
+        self.assertListEqual(list(result["P_Load"]), list(range(8)))
+
+    def test_single_row_csv_does_not_crash(self):
+        """A frame with fewer than 2 rows carries no inferable spacing; it must
+        load without crashing (the downstream P_Load/optim_status guard in
+        publish_data handles degenerate frames)."""
+        result = self._load_result(periods=1, freq="30min", step_minutes=30)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+
+
 class TestOptimizationCacheIntegration(unittest.IsolatedAsyncioTestCase):
     """Integration tests for CLI warm-start flow using actual naive_mpc_optim calls."""
 


### PR DESCRIPTION
Fixes #976.

**The bug.** `_load_opt_res_latest` force-assigns the current request's `optimization_time_step` onto the index of the saved results CSV. That config value is rebuilt for every HTTP call, so when an optimization runs with a runtime `optimization_time_step` (say 60) and the publish-data call that follows doesn't repeat that key, publish falls back to the config default (say 30 min) and pandas raises `ValueError: Inferred frequency h from passed values does not conform to passed frequency 30min`, surfacing as an unhandled 500. Full diagnosis in the issue thread.

**The fix** (option 1 as discussed in the issue). The frequency now comes from the saved data itself, via the existing `utils.set_df_index_freq` helper, the same idiom `retrieve_hass` and `forecast` already use in 11 places. The publish path only uses the timestamps for nearest-index matching, so the step baked into the CSV is correct by construction. This also matches what the saved-entities publish path already does: `publish_json` reads the step from the per-entity metadata written at optimization time, not from the current request.

Frames with fewer than 2 rows carry no inferable spacing, so they skip the inference and keep their freq unset. Nothing downstream reads the attribute: I traced `_get_closest_index`, every `_publish_*` helper and `post_data` (the entity metadata write uses the RetrieveHass instance freq, not the loaded frame's).

**Behaviour changes to be aware of.**
- Publishing saved results produced with a different `optimization_time_step` than the current request: crashed before, works now.
- Two malformed shapes that previously crashed at the freq assignment now load, per standard `set_df_index_freq` behaviour: a CSV with duplicated timestamps gets deduplicated, and a CSV with a gap gets reindexed onto the inferred grid with NaN rows. Neither shape is producible by EMHASS's own writers.

**Tests.** New `TestLoadOptResLatestFreqInference` in `tests/test_command_line_utils.py`: the mismatch repro (hourly CSV under a 30-min config, red on master with the reporter's exact error), a matching-step counterfactual pinning the healthy path unchanged, and a sub-2-row guard. The existing DST mixed-offset test for this function stays green. Full suite: 933 passed, 36 xfailed, 0 failed.

## Summary by Sourcery

Infer the index frequency for saved optimization results from the CSV data instead of the current request configuration to prevent publish-time failures when time steps differ.

Bug Fixes:
- Fix publish-data failures caused by mismatched optimization_time_step between the saved results and the current request configuration by deriving the index frequency from the stored data.

Tests:
- Add unit tests for _load_opt_res_latest to cover frequency inference, mismatched vs matching time steps, and single-row CSV handling.