### PR TITLE
fix: exempt battery identification sensors from the set_zero_min clip

### DIFF
--- a/docs/battery_identification.md
+++ b/docs/battery_identification.md
@@ -11,7 +11,7 @@ This is opt-in and default off. In this first version it is advisory only: it re
 - The measured battery state of charge, set as `sensor_battery_state_of_charge` (in percent).
 - Enough history. The fit needs weeks of signed power and state of charge with enough reasonably deep charge and discharge cycles. If the data is too shallow, or the fit fails an internal sanity check, it publishes nothing and keeps your configured values.
 
-The two sensors are only retrieved when battery self-identification is enabled, so they cost nothing on a normal run.
+The two sensors are only retrieved when battery self-identification is enabled, so they cost nothing on a normal run. Their signed values are kept intact on this retrieval regardless of the `set_zero_min` data cleaning setting, which continues to sanitize the load data as usual.
 
 ## Enabling it
 

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -551,6 +551,12 @@ def _append_entity_ids(var_list: list, value) -> None:
         var_list.append(value)
 
 
+def _append_battery_id_sensors(var_list: list, retrieve_hass_conf: dict) -> None:
+    """Append the battery power and SoC sensor config values to ``var_list``."""
+    _append_entity_ids(var_list, retrieve_hass_conf["sensor_power_battery"])
+    _append_entity_ids(var_list, retrieve_hass_conf["sensor_battery_state_of_charge"])
+
+
 async def _retrieve_from_hass(
     set_type: str,
     retrieve_hass_conf: dict,
@@ -570,16 +576,13 @@ async def _retrieve_from_hass(
     if set_type == "battery_id":
         # Battery identification needs signed battery power and measured SoC,
         # one pair per battery. The load sensor stays at var_list[0] so
-        # prepare_data's load handling is unchanged (its set_zero_min clip, on
-        # by default, still applies to every retrieved column including
-        # these - a pre-existing limitation tracked upstream separately). A
-        # list value (N>1, already resolved by _identify_battery_impl) is
+        # prepare_data's load handling is unchanged; the battery columns are
+        # passed to prepare_data as protected_columns so its set_zero_min clip
+        # cannot destroy the discharge direction or a measured 0% SoC (#1041).
+        # A list value (N>1, already resolved by _identify_battery_impl) is
         # appended per-id, deduped against var_list; a bare string (N=1) is
         # the plain single-sensor case.
-        power_cfg = retrieve_hass_conf["sensor_power_battery"]
-        soc_cfg = retrieve_hass_conf["sensor_battery_state_of_charge"]
-        _append_entity_ids(var_list, power_cfg)
-        _append_entity_ids(var_list, soc_cfg)
+        _append_battery_id_sensors(var_list, retrieve_hass_conf)
         if logger:
             logger.debug(f"Variable list for battery_id retrieval: {var_list}")
     elif optim_conf.get("set_use_pv", True):
@@ -616,12 +619,21 @@ async def retrieve_home_assistant_data(
         )
     if not success:
         return False, None, days_list
+    protected_columns = None
+    if set_type == "battery_id":
+        # The identifier needs both flow directions of the signed battery
+        # power sensor and any legitimately measured 0% SoC sample, so these
+        # columns are exempt from the set_zero_min clip (#1041). Columns not
+        # present in the retrieved frame are ignored by prepare_data.
+        protected_columns = []
+        _append_battery_id_sensors(protected_columns, retrieve_hass_conf)
     rh.prepare_data(
         retrieve_hass_conf["sensor_power_load_no_var_loads"],
         load_negative=retrieve_hass_conf["load_negative"],
         set_zero_min=retrieve_hass_conf["set_zero_min"],
         var_replace_zero=retrieve_hass_conf["sensor_replace_zero"],
         var_interp=retrieve_hass_conf["sensor_linear_interp"],
+        protected_columns=protected_columns,
     )
     return True, rh.df_final.copy(), days_list
 

--- a/src/emhass/retrieve_hass.py
+++ b/src/emhass/retrieve_hass.py
@@ -1224,6 +1224,7 @@ class RetrieveHass:
         var_replace_zero: list[str],
         var_interp: list[str],
         skip_renaming: bool = False,
+        protected_columns: list[str] | None = None,
     ) -> bool:
         r"""
         Apply some data treatment in preparation for the optimization task.
@@ -1242,6 +1243,13 @@ class RetrieveHass:
         :param var_interp: A list of retrived variables that we would want to \
             interpolate nan values using linear interpolation, defaults to None
         :type var_interp: list, optional
+        :param protected_columns: Columns excluded from the ``set_zero_min`` \
+            clip and zero-to-nan replacement, for signed data that must keep \
+            both directions (e.g. battery power) or legitimate zero readings \
+            (e.g. a measured 0% state of charge). All other treatment \
+            (timezone conversion, duplicate-index cleanup) still applies to \
+            them, defaults to None
+        :type protected_columns: list, optional
         :return: The DataFrame populated with the retrieved data from hass and \
             after the data treatment
         :rtype: pandas.DataFrame
@@ -1267,8 +1275,16 @@ class RetrieveHass:
             return False
         # Apply Zero Saturation (Min value clipping)
         if set_zero_min:
-            self.df_final.clip(lower=0.0, inplace=True, axis=1)
-            self.df_final.replace(to_replace=0.0, value=np.nan, inplace=True)
+            protected = [c for c in (protected_columns or []) if c in self.df_final.columns]
+            if not protected:
+                self.df_final.clip(lower=0.0, inplace=True, axis=1)
+                self.df_final.replace(to_replace=0.0, value=np.nan, inplace=True)
+            else:
+                unprotected = [c for c in self.df_final.columns if c not in protected]
+                self.df_final[unprotected] = self.df_final[unprotected].clip(lower=0.0)
+                self.df_final[unprotected] = self.df_final[unprotected].replace(
+                    to_replace=0.0, value=np.nan
+                )
         # Map Variable Names (Update lists to match new column names)
         # Only call mapping if the list is not empty to avoid spurious warnings
         new_var_replace_zero = None

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -1594,6 +1594,69 @@ class TestCommandLineAsyncUtils(unittest.IsolatedAsyncioTestCase):
         mock_logger.debug.assert_called()
         call_args = str(mock_logger.debug.call_args)
         self.assertIn("Variable list for data retrieval", call_args)
+        # Non-battery_id retrieval must not protect any column from the
+        # set_zero_min treatment (#1041)
+        self.assertIsNone(mock_rh.prepare_data.call_args.kwargs.get("protected_columns"))
+
+    async def test_retrieve_from_hass_battery_id_protected_columns(self):
+        """
+        battery_id retrieval must pass the battery power and SoC sensors to
+        prepare_data as protected_columns, so the set_zero_min clip cannot
+        destroy the discharge direction or a measured 0% SoC (#1041).
+        Covers the bare-string (N=1) and list (N>1) config forms.
+        """
+        optim_conf = {"set_use_pv": True, "set_use_adjusted_pv": True}
+        base_conf = {
+            "historic_days_to_retrieve": 2,
+            "sensor_power_load_no_var_loads": "sensor.load",
+            "sensor_power_photovoltaics": "sensor.pv",
+            "sensor_power_photovoltaics_forecast": "sensor.pv_forecast",
+            "load_negative": False,
+            "set_zero_min": True,
+            "sensor_replace_zero": [],
+            "sensor_linear_interp": [],
+        }
+        cases = [
+            (
+                "sensor.batt_power",
+                "sensor.batt_soc",
+                ["sensor.batt_power", "sensor.batt_soc"],
+            ),
+            (
+                ["sensor.batt_power1", "sensor.batt_power2"],
+                ["sensor.batt_soc1", "sensor.batt_soc2"],
+                [
+                    "sensor.batt_power1",
+                    "sensor.batt_power2",
+                    "sensor.batt_soc1",
+                    "sensor.batt_soc2",
+                ],
+            ),
+        ]
+        for power_cfg, soc_cfg, expected in cases:
+            with self.subTest(power_cfg=power_cfg, soc_cfg=soc_cfg):
+                retrieve_hass_conf = dict(base_conf)
+                retrieve_hass_conf["sensor_power_battery"] = power_cfg
+                retrieve_hass_conf["sensor_battery_state_of_charge"] = soc_cfg
+                mock_rh = Mock()
+                mock_rh.get_data = AsyncMock(return_value=True)
+                mock_rh.prepare_data = Mock()
+                mock_rh.df_final = pd.DataFrame()
+                success, _, _ = await retrieve_home_assistant_data(
+                    set_type="battery_id",
+                    get_data_from_file=False,
+                    retrieve_hass_conf=retrieve_hass_conf,
+                    optim_conf=optim_conf,
+                    rh=mock_rh,
+                    emhass_conf={},
+                    test_df_literal="test.pkl",
+                    logger=Mock(),
+                )
+                self.assertTrue(success)
+                self.assertEqual(
+                    mock_rh.prepare_data.call_args.kwargs.get("protected_columns"),
+                    expected,
+                )
 
     async def test_adjust_pv_forecast_generic_exception(self):
         """

--- a/tests/test_retrieve_hass.py
+++ b/tests/test_retrieve_hass.py
@@ -325,6 +325,90 @@ class TestRetrieveHass(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.rh.df_final[actual_pv_sensor].isna().sum(), 0)
         self.assertEqual(self.rh.df_final[forecast_pv_sensor].isna().sum(), 0)
 
+    # Battery identification needs the signed battery power and a possible
+    # measured 0% SoC to survive prepare_data's set_zero_min treatment (#1041).
+    # Base-safe: the protected_columns kwarg is only passed when the running
+    # source accepts it, so on a source without the fix this test fails on the
+    # behavioural assertions below, not on a TypeError.
+    def test_prepare_data_protected_columns(self):
+        import inspect
+
+        load_sensor = self.retrieve_hass_conf["sensor_power_load_no_var_loads"]
+        power_col = "sensor.power_battery_test"
+        soc_col = "sensor.battery_soc_test"
+        probe_col = "sensor.unprotected_probe"
+        n = len(self.rh.df_final)
+        # Signed battery power: both flow directions present
+        power = np.full(n, 300.0)
+        power[: n // 2] = -400.0
+        self.rh.df_final[power_col] = power
+        # SoC sweep including a legitimately measured 0% sample
+        soc = np.linspace(0.0, 100.0, n)
+        soc[0] = 0.0
+        self.rh.df_final[soc_col] = soc
+        # Counterfactual: an unprotected negative column must still be clipped
+        self.rh.df_final[probe_col] = np.full(n, -1.0)
+        self.rh.var_list = list(self.var_list) + [power_col, soc_col, probe_col]
+        neg_before = int((self.rh.df_final[power_col] < 0).sum())
+        self.assertGreater(neg_before, 0)
+        kwargs = {}
+        if "protected_columns" in inspect.signature(self.rh.prepare_data).parameters:
+            kwargs["protected_columns"] = [power_col, soc_col]
+        self.rh.prepare_data(
+            load_sensor,
+            load_negative=self.retrieve_hass_conf["load_negative"],
+            set_zero_min=True,
+            var_replace_zero=self.retrieve_hass_conf["sensor_replace_zero"],
+            var_interp=self.retrieve_hass_conf["sensor_linear_interp"],
+            **kwargs,
+        )
+        # Protected columns: discharge samples and the 0% SoC sample survive
+        self.assertEqual(int((self.rh.df_final[power_col] < 0).sum()), neg_before)
+        self.assertEqual(self.rh.df_final[power_col].isna().sum(), 0)
+        self.assertEqual(int((self.rh.df_final[soc_col] == 0.0).sum()), 1)
+        self.assertEqual(self.rh.df_final[soc_col].isna().sum(), 0)
+        # Counterfactual: the unprotected probe column was clipped then NaN'd
+        self.assertEqual(int((self.rh.df_final[probe_col] < 0).sum()), 0)
+        self.assertTrue(self.rh.df_final[probe_col].isna().all())
+        # Load handling is unchanged: renamed column present, no negatives
+        self.assertIn(load_sensor + "_positive", self.rh.df_final.columns)
+        self.assertFalse((self.rh.df_final[load_sensor + "_positive"] < 0).any())
+
+    # protected_columns=None, an omitted kwarg, and a list naming no column in
+    # the frame must all reproduce today's clipping behaviour exactly.
+    def test_prepare_data_protected_columns_default_noop(self):
+        import inspect
+
+        if "protected_columns" not in inspect.signature(self.rh.prepare_data).parameters:
+            self.skipTest("running source has no protected_columns support")
+        load_sensor = self.retrieve_hass_conf["sensor_power_load_no_var_loads"]
+        signed_col = "sensor.signed_probe"
+        df_raw = self.rh.df_final.copy()
+        df_raw[signed_col] = np.linspace(-100.0, 100.0, len(df_raw))
+        var_list_raw = list(self.var_list) + [signed_col]
+        runs = {}
+        for label, protected in (
+            ("omitted", "OMIT"),
+            ("none", None),
+            ("absent", ["sensor.not_in_frame"]),
+        ):
+            self.rh.df_final = df_raw.copy()
+            self.rh.var_list = list(var_list_raw)
+            kwargs = {} if protected == "OMIT" else {"protected_columns": protected}
+            self.rh.prepare_data(
+                load_sensor,
+                load_negative=self.retrieve_hass_conf["load_negative"],
+                set_zero_min=True,
+                var_replace_zero=self.retrieve_hass_conf["sensor_replace_zero"],
+                var_interp=self.retrieve_hass_conf["sensor_linear_interp"],
+                **kwargs,
+            )
+            runs[label] = self.rh.df_final.copy()
+        pd.testing.assert_frame_equal(runs["omitted"], runs["none"])
+        pd.testing.assert_frame_equal(runs["omitted"], runs["absent"])
+        # And the clip really ran: no negatives survive anywhere
+        self.assertEqual(int((runs["omitted"][signed_col] < 0).sum()), 0)
+
     # Proposed new test method for InfluxDB
     @patch("influxdb.InfluxDBClient", autospec=True)
     async def test_get_data_influxdb_mock(self, mock_influx_client_class):


### PR DESCRIPTION
Fixes #1041.

## The bug

`retrieve_home_assistant_data()` runs `prepare_data()` on the retrieved frame for every `set_type`, and `prepare_data()`'s `set_zero_min` treatment (on by default) clips the whole DataFrame to `>= 0` and then replaces `0.0` with NaN. On the `battery_id` path this destroys exactly the data battery self-identification exists to consume: every discharge sample of the signed `sensor_power_battery` becomes NaN, so `_segment()` can never produce a discharge run and `identify()` always exits with `insufficient_data`. On a default configuration the feature is structurally unreachable, as @volschin's repro table in #1041 shows (110 negative samples before, 0 after). The same `replace(0.0, NaN)` line also eats a legitimately measured 0 % SoC sample.

## The fix

The shape agreed in the issue thread: an explicit `protected_columns` argument on `prepare_data()`, excluded from the clip and zero-to-NaN replacement only. Everything else `prepare_data()` does still applies to the protected columns (timezone conversion, duplicate-index cleanup, and the `sensor_replace_zero` / `sensor_linear_interp` treatment if a user configures them there). Skipping `prepare_data()` wholesale for `battery_id` was rejected in-thread because it would drag those unrelated behaviours along.

`retrieve_home_assistant_data()` passes the battery power and SoC entity ids as `protected_columns` when `set_type == "battery_id"`, reusing `_append_entity_ids` so the bare-string (N=1) and list (N>1, #1046) config forms are handled identically to retrieval. Every other `set_type` passes None.

When no protected column is present in the frame, the original two clip lines run verbatim, so the default path is the exact code that runs today (same pattern as the N=1 branch in #1046: the no-op claim stays auditable by inspection). The load column cannot be captured by protection even if a battery sensor were configured equal to the load sensor: the load column is renamed to `<sensor>_positive` before the clip, and protected names not present in the frame are ignored.

## Behaviour changes, disclosed

- `battery_id` retrieval only: the identifier now sees signed battery power (both flow directions) and exact 0 % SoC samples. This is the fix; it makes identification reachable on default config. Fits that previously exited `insufficient_data` will now actually run and be judged by the existing guardrails.
- Every other path: no change. `protected_columns` defaults to None and the guard branch keeps the existing whole-frame clip byte-for-byte. A no-op test pins that an omitted argument, an explicit None, and a list naming no present column all produce identical frames.

## Tests

- `test_prepare_data_protected_columns`: a battery_id-shaped frame keeps its negative power samples and a measured 0.0 SoC under protection, while an unprotected negative probe column in the same frame is still clipped to NaN (counterfactual) and load handling is unchanged. Fails on current master on the behavioural assertions.
- `test_prepare_data_protected_columns_default_noop`: omitted kwarg, explicit None, and an absent-column list produce frame-identical results, with the clip proven to have run.
- `test_retrieve_from_hass_battery_id_protected_columns`: the battery_id call site threads the right columns for both the N=1 string and N>1 list config forms; the naive-mpc test now also pins that non-battery paths pass None. Fails on current master.

Docs: one sentence in `docs/battery_identification.md` stating the signed sensors are preserved regardless of `set_zero_min`.

The two secondary observations from the issue are deliberately out of scope here, they have their own issues now: #1051 (trapezoid bridging over recorder gaps) and #1052 (failed fits not persisted).

## Summary by Sourcery

Preserve signed battery power and 0% state-of-charge samples during Home Assistant data preparation for battery self-identification while keeping existing clipping behavior unchanged elsewhere.

Bug Fixes:
- Prevent battery identification frames from having negative battery power samples and 0% SoC readings clipped to NaN by the default set_zero_min data cleaning.

Enhancements:
- Introduce a protected_columns parameter to prepare_data that exempts selected columns from the set_zero_min clip and zero-to-NaN replacement while still applying other preprocessing.
- Thread battery power and SoC sensor ids through battery_id retrieval and into prepare_data as protected_columns, covering both single-sensor and multi-sensor configurations.

Documentation:
- Clarify in battery_identification documentation that signed battery sensors are preserved on battery_id retrieval regardless of set_zero_min, while load data remains sanitized.

Tests:
- Add tests verifying that protected_columns preserves negative battery power and 0% SoC samples for battery_id while unprotected data is still clipped.
- Add tests ensuring that omitting protected_columns, passing None, or naming absent columns all reproduce the current clipping behavior exactly.
- Add a battery_id retrieval test asserting that protected_columns receives the correct battery power and SoC sensors and that non-battery_id paths do not set it.