### PR TITLE
fix: keep the optim path load history index tz-aware (#1036)

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -1774,7 +1774,10 @@ class Forecast:
         var_list = [self.var_load]
         var_replace_zero = None
         var_interp = [self.var_load]
-        time_zone_load_forecast = None
+        # Pass the configured time zone so the retrieved index stays tz-aware: with None,
+        # the websocket statistics path runs the index through tz_convert(None), which
+        # strips the tz entirely and later crashes the weather covariate horizon build.
+        time_zone_load_forecast = self.time_zone
         rh = RetrieveHass(
             self.retrieve_hass_conf["hass_url"],
             self.retrieve_hass_conf["long_lived_token"],
@@ -1946,6 +1949,17 @@ class Forecast:
             start=data_last_window.index[-1] + window_freq,
             periods=steps,
             freq=window_freq,
+        )
+        # get_weather_covariates subtracts a tz-aware "now" from this index, so it must be
+        # tz-aware; date_range inherits tz-naivety from data_last_window's index.
+        future_index = (
+            future_index.tz_localize(
+                self.time_zone,
+                ambiguous="infer",
+                nonexistent="shift_forward",
+            )
+            if future_index.tz is None
+            else future_index.tz_convert(self.time_zone)
         )
         return await self.get_weather_covariates(future_index, weather_features)
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -575,6 +575,131 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError, msg="Expected ValueError for non-uniform index"):
             await self.fcst._build_weather_future(data_last_window, mock_mlf)
 
+    @staticmethod
+    def _open_meteo_covariate_payload(full: pd.DatetimeIndex) -> dict:
+        """Synthetic Open-Meteo minutely_15 payload covering the ``full`` (tz-aware) index."""
+        times = (full.tz_convert("UTC").astype("int64") // 10**9).tolist()
+        n = len(full)
+        return {
+            "minutely_15": {
+                "time": times,
+                "temperature_2m": [20.0] * n,
+                "relative_humidity_2m": [50.0] * n,
+                "cloud_cover": [30.0] * n,
+                "wind_speed_10m": [5.0] * n,
+                "shortwave_radiation": [200.0] * n,
+                "direct_radiation": [150.0] * n,
+                "diffuse_radiation": [50.0] * n,
+                "precipitation": [0.0] * n,
+            }
+        }
+
+    async def test_build_weather_future_localizes_naive_window_index(self):
+        """A tz-naive last-window index no longer crashes the weather horizon build (#1036).
+
+        The optim path's websocket statistics retrieval used to hand this method a tz-naive
+        index, and the naive future horizon crashed get_weather_covariates with
+        'Cannot subtract tz-naive and tz-aware datetime-like objects'. The horizon must now
+        reach get_weather_covariates as tz-aware, in the configured time zone.
+        """
+        from unittest.mock import MagicMock, patch
+
+        num_lags = 16
+        naive_window_index = self.fcst.forecast_dates[:8].tz_localize(None)
+        data_last_window = pd.DataFrame(index=naive_window_index)
+        # Naive wall times are interpreted as the configured local time zone.
+        expected_index = pd.date_range(
+            start=naive_window_index[-1] + self.fcst.freq,
+            periods=num_lags,
+            freq=self.fcst.freq,
+        ).tz_localize(self.fcst.time_zone)
+        full = pd.date_range(
+            start=expected_index[0] - 4 * self.fcst.freq,
+            end=expected_index[-1] + 4 * self.fcst.freq,
+            freq=self.fcst.freq,
+        )
+        payload = self._open_meteo_covariate_payload(full)
+        mock_mlf = MagicMock()
+        mock_mlf.weather_features = ["temp_air"]
+        mock_mlf.is_tuned = False
+        mock_mlf.num_lags = num_lags
+
+        with patch.object(self.fcst, "_fetch_open_meteo_covariates_json", return_value=payload):
+            weather_future = await self.fcst._build_weather_future(data_last_window, mock_mlf)
+
+        self.assertIsNotNone(weather_future)
+        self.assertEqual(len(weather_future), num_lags)
+        self.assertIsNotNone(weather_future.index.tz)
+        self.assertEqual(weather_future.index.tz, self.fcst.time_zone)
+        self.assertTrue(weather_future.index.equals(expected_index))
+
+    async def test_build_weather_future_converts_aware_window_index(self):
+        """A tz-aware last-window index in another zone keeps its instants.
+
+        Cross-zone tz-aware input never crashed; the horizon is now normalized to the
+        configured time zone, which must not move the instants.
+        """
+        from unittest.mock import MagicMock, patch
+
+        num_lags = 16
+        utc_window_index = self.fcst.forecast_dates[:8].tz_convert("UTC")
+        data_last_window = pd.DataFrame(index=utc_window_index)
+        expected_index = pd.date_range(
+            start=utc_window_index[-1] + self.fcst.freq,
+            periods=num_lags,
+            freq=self.fcst.freq,
+            tz="UTC",
+        ).tz_convert(self.fcst.time_zone)
+        full = pd.date_range(
+            start=expected_index[0] - 4 * self.fcst.freq,
+            end=expected_index[-1] + 4 * self.fcst.freq,
+            freq=self.fcst.freq,
+        )
+        payload = self._open_meteo_covariate_payload(full)
+        mock_mlf = MagicMock()
+        mock_mlf.weather_features = ["temp_air"]
+        mock_mlf.is_tuned = False
+        mock_mlf.num_lags = num_lags
+
+        with patch.object(self.fcst, "_fetch_open_meteo_covariates_json", return_value=payload):
+            weather_future = await self.fcst._build_weather_future(data_last_window, mock_mlf)
+
+        self.assertIsNotNone(weather_future)
+        self.assertEqual(len(weather_future), num_lags)
+        self.assertEqual(weather_future.index.tz, self.fcst.time_zone)
+        self.assertTrue(weather_future.index.equals(expected_index))
+
+    async def test_prepare_hass_load_data_uses_configured_time_zone(self):
+        """_prepare_hass_load_data builds its internal RetrieveHass with the configured tz (#1036).
+
+        With time_zone=None the websocket statistics retrieval path strips the index tz
+        (tz_convert(None)), producing the naive index behind the #1036 crash.
+        """
+        from unittest.mock import patch
+
+        # self.fcst.get_data_from_file is True by default, so after construction the code
+        # takes the aiofiles-pickle branch, not rh.get_data() -- there's no natural await
+        # failure to stop on. Raise a sentinel from the constructor itself to capture its
+        # args without also mocking the unrelated file-read/prepare_data pipeline.
+        class _CtorCapture(Exception):
+            pass
+
+        captured = {}
+
+        def _capture_ctor(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            raise _CtorCapture()
+
+        with patch.object(forecast_module, "RetrieveHass", side_effect=_capture_ctor):
+            with self.assertRaises(_CtorCapture):
+                await self.fcst._prepare_hass_load_data(3, "mlforecaster")
+
+        # Signature: (hass_url, long_lived_token, freq, time_zone, params, emhass_conf, logger)
+        passed_time_zone = captured["args"][3]
+        self.assertIsNotNone(passed_time_zone)
+        self.assertEqual(passed_time_zone, self.fcst.time_zone)
+
     # Test output weather forecast using Solcast with mock get request data
     async def test_get_weather_forecast_solcast_method_mock(self):
         self.fcst.params = {


### PR DESCRIPTION
Fixes #1036

## The bug

Running naive-mpc-optim or dayahead-optim with `mlforecaster_weather_features` set crashes with `TypeError: Cannot subtract tz-naive and tz-aware datetime-like objects` at `get_weather_covariates` (forecast.py), while fit and predict on the same model work fine. Confirmed by the reporter on a `use_websocket: true` setup.

Root cause, as traced in the issue thread: the optim path builds its own `RetrieveHass` inside `_prepare_hass_load_data` with `time_zone=None`. The websocket statistics retrieval path then runs the index through `tz_convert(self.time_zone)` with that `None`, and `tz_convert(None)` strips the timezone entirely. The naive index flows into `_build_weather_future`, whose `pd.date_range` inherits the naivety, and the tz-aware `now` minus the naive `index.min()` blows up. Fit and predict never hit this because they use the main `RetrieveHass`, which is constructed with the configured timezone.

## The fix

Two changes, both in forecast.py:

1. `_prepare_hass_load_data` now passes the configured timezone to its internal `RetrieveHass`, same as the other two `RetrieveHass` constructions in the codebase. This fixes the producer: the websocket path converts to the configured zone instead of stripping it.
2. A defensive localize-or-convert on the future index in `_build_weather_future`, using the same pattern this file already applies in two other places, so a naive index can never reach that subtraction again. This covers both callers (the optim path and `forecast_model_predict`).

## Behaviour changes to be aware of

- On the optim path the retrieved load history index is now tz-aware in the configured zone. Before, the REST history path happened to keep a UTC-aware index and the websocket path produced the naive one that crashed. The ML model's calendar features (hour, day of week) on the optim path are now computed in local time, matching what fit and predict already did, which is what the model was trained on. The same applies in file mode (`get_data_from_file`), where the pickled history index previously skipped the conversion. The forecast output itself is re-stamped positionally onto the request's forecast dates, so optimizer inputs keep the exact same shape and index as before.
- The defensive guard also normalizes a tz-aware index in some other zone to the configured zone. That is a pure representation change, the instants are identical, and nothing downstream reads the zone off that index.

## Tests

- `test_build_weather_future_localizes_naive_window_index`: the reporter's scenario. Fails on current master with the exact `TypeError` from the issue, passes with the fix.
- `test_prepare_hass_load_data_uses_configured_time_zone`: pins the internal `RetrieveHass` construction to the configured timezone.
- `test_build_weather_future_converts_aware_window_index`: a tz-aware index in another zone keeps its instants.

Full suite passes locally. The `mlforecaster_weather_features: []` workaround from the thread is no longer needed after this.

## Summary by Sourcery

Ensure forecast optimization path keeps load history and weather horizon indices timezone-aware in the configured time zone to prevent tz-naive/aware subtraction errors.

Bug Fixes:
- Fix crash in the optimization path when building weather covariates from tz-naive load history indices by normalizing indices to the configured time zone.
- Prevent websocket-based statistics retrieval from stripping timezones by passing the configured time zone into the internal RetrieveHass instance used for load history.

Enhancements:
- Normalize tz-aware load history indices from other time zones to the configured time zone while preserving instants in the weather horizon build.

Tests:
- Add tests verifying naive last-window indices are localized to the configured time zone when building the weather horizon.
- Add tests verifying tz-aware indices in other zones are converted without shifting instants in the weather horizon.
- Add a test ensuring _prepare_hass_load_data constructs RetrieveHass with the configured time zone.