### PR TITLE
fix: keep the relaxed-LP rescue one-shot so it cannot poison the cached problem (#1048)

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -323,6 +323,14 @@ class Optimization:
         # Note: The self.prob object will be constructed in a subsequent step
         self.prob = None
 
+        # Stress configs built alongside self.prob, kept for the relaxed-retry
+        # path: a solve failure on a cached problem rebuilds constraints and
+        # objective, and must reuse the same stress configs (same CVXPY
+        # variables) the cached problem was built with (issue #1048). Refreshed
+        # unconditionally whenever the build block runs.
+        self._batt_stress_conf = None
+        self._inv_stress_conf = None
+
     def _init_soc_recovery_params(self) -> None:
         """Initialize CVXPY parameters used for out-of-band SOC recovery.
 
@@ -5059,14 +5067,19 @@ class Optimization:
                         f"Deferrable load {k}: deactivated (no operating timesteps, not thermal)"
                     )
 
-        # Initialize stress config variables (needed by retry path even when
-        # self.prob is cached from a previous call, see #770)
-        inv_stress_conf = None
-        batt_stress_conf = None
+        # Stress configs are needed by the retry path even when self.prob is
+        # cached from a previous call (see #770). Start from the configs built
+        # with the cached problem so a cached-retry rebuild keeps the stress
+        # constraints and objective terms instead of silently dropping them
+        # (issue #1048); they reference the same CVXPY variables as self.vars.
+        inv_stress_conf = self._inv_stress_conf
+        batt_stress_conf = self._batt_stress_conf
 
         # Build Problem (Lazy Construction)
         if self.prob is None:
             self.logger.info("Building CVXPY problem structure...")
+            inv_stress_conf = None
+            batt_stress_conf = None
 
             # Start with bound constraints
             constraints = self.constraints[:]
@@ -5149,6 +5162,18 @@ class Optimization:
                 objective_expr.args[0] += penalty_terms_total
 
             self.prob = cp.Problem(objective_expr, constraints)
+            # Keep the stress configs paired with the problem they were built
+            # for, so cached-retry rebuilds see them (issue #1048).
+            self._batt_stress_conf = batt_stress_conf
+            self._inv_stress_conf = inv_stress_conf
+
+        # Thermal artifacts read by the extraction below. Locals so a relaxed
+        # retry can swap in its own rebuilt artifacts for this run only, while
+        # the instance attributes stay paired with the cached problem
+        # (issue #1048).
+        predicted_temps = self.predicted_temps
+        heating_demands = self.heating_demands
+        q_inputs = self.q_inputs
 
         # Solver Configuration
         solver_opts = {"verbose": False}
@@ -5234,6 +5259,13 @@ class Optimization:
                 f"Solver {selected_solver} failed: {e}. Checking status for fallback..."
             )
 
+        # The problem whose status/value the extraction below reads. Stays
+        # self.prob on a clean solve; points at the relaxed problem after a
+        # retry WITHOUT replacing self.prob, so the cached problem survives
+        # intact for the next run (issue #1048: caching prob_relaxed made the
+        # stress-free, binary-relaxed rescue permanent).
+        solved_prob = self.prob
+
         # Check for failure or "bad" status
         # Note: "user_limit" often means timeout. "infeasible" means configuration conflict.
         fail_statuses = ["infeasible", "unbounded", "user_limit", None]
@@ -5251,6 +5283,23 @@ class Optimization:
                 self.optim_conf.get("set_deferrable_load_single_constant", [])
             )
 
+            # The rebuild below replaces a few instance-held references with new
+            # objects that only live in the relaxed problem (the hybrid inverter
+            # transfer variables and the thermal q_input persistence hooks).
+            # Snapshot them so they can be restored after the rescue: instance
+            # state must keep pointing at the cached problem's objects, or later
+            # cache-hit runs would read variables the solver no longer touches
+            # (issue #1048).
+            hybrid_var_keys = ("p_dc_ac", "p_ac_dc", "is_dc_sourcing")
+            original_hybrid_vars = {
+                key: self.vars[key] for key in hybrid_var_keys if key in self.vars
+            }
+            original_q_input_vars = {
+                k: params["q_input_var"]
+                for k, params in self.param_thermal.items()
+                if "q_input_var" in params
+            }
+
             # Relax Configuration: Disable Binary Logic
             n_def = self.optim_conf["number_of_deferrable_loads"]
             self.optim_conf["treat_deferrable_load_as_semi_cont"] = [False] * n_def
@@ -5261,11 +5310,12 @@ class Optimization:
 
             # Re-apply main constraints
             self._add_main_power_balance_constraints(constraints_relaxed)
-            # (Note: We reuse previous stress configs as they don't change with relaxation)
-            # Guard on feature flags, not on the stress conf objects: stress conf is None
-            # on cached-problem retry paths (self.prob is not None), so guarding on the
-            # object itself would silently skip these constraints on every retry after the
-            # first call, leaving the relaxed problem without battery/inverter constraints.
+            # (Note: We reuse previous stress configs as they don't change with relaxation.
+            # On a cached-problem retry they come from self._*_stress_conf, the configs
+            # the cached problem was built with, see issue #1048.)
+            # Guard on feature flags, matching the build block's own gating: these
+            # builders also add the non-stress battery/inverter constraints, so they
+            # must run whenever the feature is on, stress cost or not.
             if self.plant_conf.get("inverter_is_hybrid", False):
                 self._add_hybrid_inverter_constraints(constraints_relaxed, inv_stress_conf)
             if self.optim_conf.get("set_use_battery", False):
@@ -5279,8 +5329,11 @@ class Optimization:
                     self.vars["SC"] <= self.param_load_forecast + self.vars["p_def_sum"]
                 )
 
-            # Re-call deferrable load constraints (Skipping binary logic due to config change)
-            self.predicted_temps, self.heating_demands, penalty_terms_total, self.q_inputs = (
+            # Re-call deferrable load constraints (Skipping binary logic due to
+            # config change). The rebuilt thermal artifacts go into the LOCALS
+            # used by this run's extraction; the instance attributes keep the
+            # build-time artifacts paired with the cached problem (issue #1048).
+            predicted_temps, heating_demands, penalty_terms_total, q_inputs = (
                 self._add_deferrable_load_constraints(
                     constraints_relaxed,
                     data_opt,
@@ -5310,14 +5363,16 @@ class Optimization:
 
                 if prob_relaxed.status in [cp.OPTIMAL, cp.OPTIMAL_INACCURATE]:
                     self.logger.info("Relaxed optimization successful!")
-                    self.prob = prob_relaxed  # Use this result
                     # Mark status so user knows it was relaxed
-                    self.prob._status = "Optimal (Relaxed)"
+                    prob_relaxed._status = "Optimal (Relaxed)"
                 else:
                     self.logger.error(
                         f"Relaxed optimization also failed with status: {prob_relaxed.status}"
                     )
-                    self.prob = prob_relaxed
+                # Use the relaxed result for this run only. self.prob keeps
+                # pointing at the clean cached problem: the relaxed solve is a
+                # one-shot rescue, never a permanent replacement (issue #1048).
+                solved_prob = prob_relaxed
             except Exception as e:
                 self.logger.error(f"Relaxed optimization crashed: {e}")
 
@@ -5325,17 +5380,26 @@ class Optimization:
             self.optim_conf["treat_deferrable_load_as_semi_cont"] = original_semi_cont
             self.optim_conf["set_deferrable_load_single_constant"] = original_single_const
 
+            # Restore the instance-held references the rebuild replaced, so the
+            # next run reads the cached problem's own objects (issue #1048).
+            self.vars.update(original_hybrid_vars)
+            for k, params in self.param_thermal.items():
+                if k in original_q_input_vars:
+                    params["q_input_var"] = original_q_input_vars[k]
+                else:
+                    params.pop("q_input_var", None)
+
         # Stage-timer breadcrumb: end of solve phase, start of extract phase.
         _extract_start_perf = time.perf_counter() if stage_times is not None else 0.0
         if stage_times is not None:
             stage_times["optim_solve.solve"] = _extract_start_perf - _solve_start_perf
 
         # Fix for Status Case: Map "optimal" -> "Optimal"
-        status_raw = self.prob.status
+        status_raw = solved_prob.status
         self.optim_status = status_raw.title() if status_raw else "Failure"
 
         # Helper: Ensure we return "Optimal" for tests if it was "Optimal (Relaxed)" or "Optimal_Inaccurate"
-        if self.prob.value is None or self.prob.status not in [
+        if solved_prob.value is None or solved_prob.status not in [
             cp.OPTIMAL,
             cp.OPTIMAL_INACCURATE,
             "Optimal (Relaxed)",
@@ -5355,7 +5419,7 @@ class Optimization:
         else:
             self.logger.info(
                 "Total value of the Cost function = %.02f",
-                self.prob.value,
+                solved_prob.value,
             )
 
         # Results Extraction
@@ -5373,10 +5437,10 @@ class Optimization:
             p_load,
             p_pv,
             soc_init_for_results,
-            self.predicted_temps,
-            self.heating_demands,
+            predicted_temps,
+            heating_demands,
             debug,
-            q_inputs=self.q_inputs,
+            q_inputs=q_inputs,
         )
         if stage_times is not None:
             stage_times["optim_solve.extract"] = time.perf_counter() - _extract_start_perf

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -8982,6 +8982,475 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             f"{bin2.sum():.1f}. bin2={bin2}",
         )
 
+    # ------------------------------------------------------------------
+    # Issue #1048: cache-hit relaxed-LP rescue must not poison the cache
+    # ------------------------------------------------------------------
+
+    def _rescued_solve_patch(self, fail_status="user_limit"):
+        """Return a context manager that fails the FIRST ``cvxpy.Problem.solve()``
+        call inside the ``with`` block and lets every later call run for real.
+
+        Simulates e.g. a HiGHS timeout (mapped to status "user_limit" by cvxpy
+        1.7.5), which is the trigger the #1048 reporter hit. Deterministic and
+        instant -- no actual solver timeout is needed. Setting ``prob._status``/
+        ``prob._value`` directly follows the same pattern the production retry
+        code itself uses to mark the relaxed rescue's status (optimization.py,
+        ``prob_relaxed._status = "Optimal (Relaxed)"``), so this is in-repo
+        precedent, not a cvxpy internals hack invented for the test.
+        """
+        import cvxpy as cp
+
+        real_solve = cp.Problem.solve
+        calls = {"n": 0}
+
+        def fake_solve(prob_self, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                prob_self._status = fail_status
+                prob_self._value = None
+                return None
+            return real_solve(prob_self, *args, **kwargs)
+
+        return mock.patch.object(cp.Problem, "solve", new=fake_solve)
+
+    def test_relaxed_rescue_keeps_cached_problem(self):
+        """Issue #1048: a relaxed-LP rescue on a cache-HIT run must not replace
+        ``self.prob``.
+
+        Before the fix, a successful (or failed) relaxed retry did
+        ``self.prob = prob_relaxed``, permanently swapping the cached MILP
+        for the stress-free, binary-relaxed LP: every later cache-hit run
+        then re-solved that degraded problem and reported plain "Optimal"
+        (title-cased), hiding the fact it was never the real MILP again.
+
+        Solve 1 builds and caches the problem normally. Solve 2 has its first
+        solver call forced to fail (`self._rescued_solve_patch`), triggering
+        the one-shot relaxed rescue: status must read "Optimal (Relaxed)" but
+        ``self.opt.prob`` must still be the SAME object built in solve 1
+        (``assertIs``, not just equal). Solve 3 runs clean again on that same
+        cached problem and must report plain "Optimal" -- proving the rescue
+        was one-shot, not a permanent replacement.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        self.optim_conf.update(
+            {
+                "set_use_battery": True,
+                "treat_deferrable_load_as_semi_cont": [True, True],
+                "set_deferrable_load_single_constant": [True, True],
+            }
+        )
+        self.opt = self.create_optimization()
+        prediction_horizon = 10
+        mpc_kwargs = {
+            "soc_init": 0.5,
+            "soc_final": 0.5,
+            "def_total_hours": None,
+            "def_total_timestep": [4, 3],
+            "def_start_timestep": [0, 0],
+            "def_end_timestep": [0, 0],
+        }
+
+        # Solve 1: clean build, establishes the cached problem.
+        self.opt.perform_naive_mpc_optim(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast,
+            self.p_load_forecast,
+            prediction_horizon,
+            **mpc_kwargs,
+        )
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+        prob_before = self.opt.prob
+        self.assertIsNotNone(prob_before)
+
+        # Solve 2: cache-HIT run whose first solve() call is forced to fail,
+        # triggering the relaxed rescue.
+        with self._rescued_solve_patch():
+            self.opt.perform_naive_mpc_optim(
+                self.df_input_data_dayahead,
+                self.p_pv_forecast,
+                self.p_load_forecast,
+                prediction_horizon,
+                **mpc_kwargs,
+            )
+        self.assertEqual(self.opt.optim_status, "Optimal (Relaxed)")
+        self.assertIs(
+            self.opt.prob,
+            prob_before,
+            "self.prob must never be replaced by the relaxed rescue problem (#1048)",
+        )
+
+        # Solve 3: clean cache-hit run again, on the SAME cached problem.
+        self.opt.perform_naive_mpc_optim(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast,
+            self.p_load_forecast,
+            prediction_horizon,
+            **mpc_kwargs,
+        )
+        self.assertEqual(
+            self.opt.optim_status,
+            "Optimal",
+            "A follow-up clean run must re-attempt the real MILP, not the "
+            "retained relaxed LP from solve 2 (#1048 poisoning).",
+        )
+        self.assertIs(self.opt.prob, prob_before)
+
+    def test_relaxed_rescue_does_not_poison_followup_runs(self):
+        """Issue #1048 headline behaviour: a rescued cache-hit run must not
+        change the DISPATCH of later clean runs.
+
+        Discrimination logic: one deferrable load, 3000 W nominal,
+        ``set_deferrable_load_single_constant=True`` (MILP: exactly one
+        contiguous ON block) with ``treat_deferrable_load_as_semi_cont=False``
+        (so the relaxed-LP retry -- which forces both flags off -- turns this
+        load into a plain continuous variable, box-capped at nominal power per
+        step, with total energy still pinned to 4 timesteps' worth). Over a
+        10-step horizon the load cost is [0.1, 0.1, 9, 9, 9, 9, 9, 9, 0.1, 0.1]
+        (production price pinned to a flat 0.05 for the same rows so the
+        sell side never competes for these values):
+
+        - MILP (single-constant): must run ONE contiguous 4-step block. The
+          two cheapest *contiguous* 4-step windows are the edges (steps
+          0-3 or 6-9, cost 0.1+0.1+9+9=18.2); nothing else contiguous is
+          cheaper, so the solve is forced into one of those blocks.
+        - Relaxed LP (binary/single-constant forced off): with the box cap at
+          nominal power and 4 timesteps of energy required, the cheapest
+          answer is to run flat-out at the 4 individually cheapest steps
+          {0, 1, 8, 9} (cost 0.1*4=0.4) -- a NON-contiguous split across the
+          two cheap valleys. This is strictly cheaper than any contiguous
+          block, so an unconstrained LP always prefers it.
+
+        On the un-fixed base, solve 2's rescue caches prob_relaxed permanently
+        (self.prob = prob_relaxed), so solve 3 -- a clean call with no forced
+        failure -- would still solve that retained relaxed/binary-off problem
+        and reproduce the non-contiguous {0,1,8,9} split. With the fix, solve
+        3 re-attempts the real cached MILP and is back to a single contiguous
+        block.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        self.optim_conf.update(
+            {
+                "set_use_battery": False,
+                "number_of_deferrable_loads": 1,
+                "nominal_power_of_deferrable_loads": [3000],
+                "treat_deferrable_load_as_semi_cont": [False],
+                "set_deferrable_load_single_constant": [True],
+            }
+        )
+        self.opt = self.create_optimization()
+        prediction_horizon = 10
+
+        price_vector = [0.1, 0.1, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 0.1, 0.1]
+        horizon_index = self.df_input_data_dayahead.index[:prediction_horizon]
+        self.df_input_data_dayahead.loc[horizon_index, self.opt.var_load_cost] = price_vector
+        self.df_input_data_dayahead.loc[horizon_index, self.opt.var_prod_price] = 0.05
+
+        mpc_kwargs = {
+            "def_total_hours": None,
+            "def_total_timestep": [4],
+            "def_start_timestep": [0],
+            "def_end_timestep": [0],
+        }
+
+        def active_block(power_series):
+            active_idx = np.where(power_series.to_numpy() > 1e-3)[0]
+            span = (active_idx[-1] - active_idx[0] + 1) if len(active_idx) else 0
+            return active_idx, span
+
+        # Solve 1: clean MILP build -- must be a single contiguous block.
+        opt_res_1 = self.opt.perform_naive_mpc_optim(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast,
+            self.p_load_forecast,
+            prediction_horizon,
+            **mpc_kwargs,
+        )
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+        active_idx_1, span_1 = active_block(opt_res_1["P_deferrable0"])
+        self.assertEqual(
+            len(active_idx_1), 4, f"Solve 1: expected 4 active steps, got {active_idx_1}"
+        )
+        self.assertEqual(
+            span_1,
+            4,
+            f"Solve 1: MILP dispatch must be one contiguous block, got indices {active_idx_1}",
+        )
+
+        # Solve 2: cache-HIT run, first solve() forced to fail -> relaxed rescue.
+        with self._rescued_solve_patch():
+            self.opt.perform_naive_mpc_optim(
+                self.df_input_data_dayahead,
+                self.p_pv_forecast,
+                self.p_load_forecast,
+                prediction_horizon,
+                **mpc_kwargs,
+            )
+        self.assertEqual(self.opt.optim_status, "Optimal (Relaxed)")
+
+        # Solve 3: clean run again -- the poisoning check. Must be back to a
+        # single contiguous MILP block, not the relaxed {0,1,8,9} split.
+        opt_res_3 = self.opt.perform_naive_mpc_optim(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast,
+            self.p_load_forecast,
+            prediction_horizon,
+            **mpc_kwargs,
+        )
+        self.assertEqual(
+            self.opt.optim_status,
+            "Optimal",
+            "Solve 3 must re-attempt the real MILP, not report the retained relaxed status.",
+        )
+        active_idx_3, span_3 = active_block(opt_res_3["P_deferrable0"])
+        self.assertEqual(
+            len(active_idx_3), 4, f"Solve 3: expected 4 active steps, got {active_idx_3}"
+        )
+        self.assertEqual(
+            span_3,
+            4,
+            f"Solve 3: dispatch must be one contiguous block again (#1048 poisoning check), "
+            f"got indices {active_idx_3} (a {{0,1,8,9}}-style split means the relaxed problem "
+            "from solve 2 was retained).",
+        )
+
+    def test_cached_retry_rebuilds_stress_configs(self):
+        """Issue #1048: on a cache-HIT retry, the relaxed rebuild's objective
+        call must receive the SAME (non-None) battery stress conf the cached
+        problem was built with.
+
+        Before the fix, ``batt_stress_conf``/``inv_stress_conf`` were only
+        populated inside the ``self.prob is None`` build block, so on a
+        cache-HIT call they stayed ``None`` and the relaxed rebuild silently
+        dropped the stress constraints/objective terms. The fix caches them
+        on the instance (``self._batt_stress_conf``) so a cache-hit retry
+        rebuild reads the same confs the original build produced.
+
+        Spies on ``_build_objective_function`` (wrapped, not replaced) across
+        a rescued cache-hit run: it must be called exactly once (the retry's
+        rebuild -- the initial build block is skipped on a cache hit) with a
+        non-None ``batt_stress_conf`` that IS (identity) ``self.opt._batt_stress_conf``.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        self.optim_conf.update(
+            {
+                "set_use_battery": True,
+                "treat_deferrable_load_as_semi_cont": [True, True],
+                "set_deferrable_load_single_constant": [True, True],
+            }
+        )
+        self.plant_conf["battery_stress_cost"] = 0.05
+        self.opt = self.create_optimization()
+        prediction_horizon = 10
+        mpc_kwargs = {
+            "soc_init": 0.5,
+            "soc_final": 0.5,
+            "def_total_hours": None,
+            "def_total_timestep": [4, 3],
+            "def_start_timestep": [0, 0],
+            "def_end_timestep": [0, 0],
+        }
+
+        # Solve 1: clean build -- populates self._batt_stress_conf.
+        self.opt.perform_naive_mpc_optim(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast,
+            self.p_load_forecast,
+            prediction_horizon,
+            **mpc_kwargs,
+        )
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+        # getattr keeps this test base-safe: on the un-fixed base the attribute
+        # does not exist, and the RED proof must fail on the behavioural
+        # assertion below, not on an AttributeError.
+        cached_batt_stress_conf = getattr(self.opt, "_batt_stress_conf", None)
+        self.assertIsNotNone(
+            cached_batt_stress_conf,
+            "The build block must cache the battery stress conf on the instance (#1048)",
+        )
+        self.assertTrue(
+            cached_batt_stress_conf[0]["active"],
+            "battery_stress_cost > 0 with a positive max power must yield an active stress conf",
+        )
+
+        # Solve 2: cache-HIT run, first solve() forced to fail -> relaxed retry
+        # rebuilds the objective. Spy (wraps=real method) on the rebuild call.
+        with mock.patch.object(
+            self.opt, "_build_objective_function", wraps=self.opt._build_objective_function
+        ) as spy:
+            with self._rescued_solve_patch():
+                self.opt.perform_naive_mpc_optim(
+                    self.df_input_data_dayahead,
+                    self.p_pv_forecast,
+                    self.p_load_forecast,
+                    prediction_horizon,
+                    **mpc_kwargs,
+                )
+
+        self.assertEqual(self.opt.optim_status, "Optimal (Relaxed)")
+        self.assertEqual(
+            spy.call_count,
+            1,
+            "On a cache-HIT retry, _build_objective_function must be called exactly once "
+            "(the retry rebuild only -- the initial build block is skipped on a cache hit).",
+        )
+        called_batt_stress_conf = spy.call_args[0][0]
+        self.assertIsNotNone(
+            called_batt_stress_conf,
+            "The retry's objective rebuild must receive the cached (non-None) stress conf (#1048)",
+        )
+        self.assertIs(called_batt_stress_conf, cached_batt_stress_conf)
+
+    def test_relaxed_rescue_keeps_thermal_artifacts_fresh(self):
+        """Issue #1048: regression guard for the run-local-rescue property of
+        the fix -- the rescue's rebuilt thermal artifacts must stay confined
+        to the run that triggered it, never permanently replacing the
+        instance-held references that extraction and warm-starting read from.
+
+        This pins a *narrower* bug than the other three #1048 tests: an early
+        version of the fix already stopped ``self.prob`` itself from being
+        replaced (see ``test_relaxed_rescue_keeps_cached_problem``), but still
+        let the relaxed retry overwrite ``self.predicted_temps`` /
+        ``self.heating_demands`` / ``self.q_inputs`` and
+        ``self.param_thermal[k]["q_input_var"]`` with variables that only
+        live in the discarded ``prob_relaxed``. Every later cache-hit run
+        would then extract ``predicted_temp_heater0`` / ``q_input_heater0``
+        from those dead variables -- byte-frozen at whatever value they held
+        right after the one-shot rescue solve, never re-solved again. The
+        current fix routes the rescue's rebuilt artifacts into locals used
+        only by that run's own extraction (see the ``predicted_temps =
+        self.predicted_temps`` / ``q_inputs = self.q_inputs`` locals in
+        ``perform_optimization``), and snapshots/restores the instance
+        thermal hooks around the rescue.
+
+        NOTE: this test is NOT expected to be RED on unpatched master. On
+        master, a failed first solve makes the retry set ``self.prob =
+        prob_relaxed`` outright (the headline #1048 bug), so a later clean
+        call re-solves that swapped-in problem for real with the new
+        outdoor-temperature parameter values -- giving a genuinely different
+        (not frozen) result and not tripping the assertions below either.
+        This test is green on both master and the fix; it exists purely to
+        pin the fix's run-local-rescue property so a future refactor can't
+        silently reintroduce the narrower dead-variable regression an
+        earlier draft of the fix had.
+
+        Uses a ``thermal_battery`` deferrable load (not plain
+        ``thermal_config``): only ``_add_thermal_battery_constraints``
+        supports ``thermal_inertia_time_constant`` / the ``q_input_var``
+        low-pass-filter hook and populates ``self.heating_demands`` /
+        ``self.q_inputs`` -- ``thermal_config``'s constraint builder reads a
+        differently-named ``thermal_inertia`` key and always returns a None
+        q_input, so it cannot exercise the ``q_input_var`` snapshot/restore
+        path this test targets.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        self.df_input_data_dayahead["outdoor_temperature_forecast"] = 10.0
+
+        config = {
+            "start_temperature": 20.0,
+            "supply_temperature": 35.0,
+            "volume": 50.0,
+            "specific_heating_demand": 100.0,
+            "area": 100.0,
+            "min_temperatures": [18.0] * 48,
+            "max_temperatures": [22.0] * 48,
+            "thermal_inertia_time_constant": 1.0,
+        }
+        self.optim_conf["def_load_config"] = [{"thermal_battery": config}]
+        self.opt = self.create_optimization()
+
+        unit_load_cost = self.df_input_data_dayahead[self.opt.var_load_cost].values
+        unit_prod_price = self.df_input_data_dayahead[self.opt.var_prod_price].values
+
+        # Solve 1: clean build -- establishes the cached problem and the
+        # instance-held thermal references extraction/warm-start read from.
+        opt_res_1 = self.opt.perform_optimization(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast.values.ravel(),
+            self.p_load_forecast.values.ravel(),
+            unit_load_cost,
+            unit_prod_price,
+        )
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+        self.assertIn(
+            "q_input_heater0",
+            opt_res_1.columns,
+            "thermal_inertia_time_constant > 0 must produce a q_input_heater0 column",
+        )
+        q_hook_before = self.opt.param_thermal[0].get("q_input_var")
+        self.assertIsNotNone(q_hook_before, "Solve 1 must populate the q_input_var hook (tau > 0)")
+        predicted_temps_before = self.opt.predicted_temps.get(0)
+        self.assertIsNotNone(
+            predicted_temps_before, "Solve 1 must populate self.predicted_temps[0]"
+        )
+
+        # Solve 2: cache-HIT run, first solve() forced to fail -> relaxed rescue.
+        with self._rescued_solve_patch():
+            opt_res_2 = self.opt.perform_optimization(
+                self.df_input_data_dayahead,
+                self.p_pv_forecast.values.ravel(),
+                self.p_load_forecast.values.ravel(),
+                unit_load_cost,
+                unit_prod_price,
+            )
+        self.assertEqual(self.opt.optim_status, "Optimal (Relaxed)")
+        self.assertIs(
+            self.opt.param_thermal[0]["q_input_var"],
+            q_hook_before,
+            "The rescue must restore the instance's q_input_var hook to the "
+            "cached problem's own variable, not leave it pointing at the "
+            "discarded prob_relaxed's variable (#1048).",
+        )
+        self.assertIs(
+            self.opt.predicted_temps.get(0),
+            predicted_temps_before,
+            "The rescue must not permanently replace self.predicted_temps[0] "
+            "with the discarded prob_relaxed's variable (#1048).",
+        )
+
+        # Solve 3: clean cache-hit run again, with a DIFFERENT outdoor
+        # temperature forecast so the true predicted temperatures (and the
+        # heating-demand/thermal-loss terms that depend on outdoor temp
+        # directly) must change from solve 2's.
+        df_shifted = self.df_input_data_dayahead.copy()
+        df_shifted["outdoor_temperature_forecast"] = (
+            df_shifted["outdoor_temperature_forecast"] + 10.0
+        )
+        unit_load_cost_3 = df_shifted[self.opt.var_load_cost].values
+        unit_prod_price_3 = df_shifted[self.opt.var_prod_price].values
+        opt_res_3 = self.opt.perform_optimization(
+            df_shifted,
+            self.p_pv_forecast.values.ravel(),
+            self.p_load_forecast.values.ravel(),
+            unit_load_cost_3,
+            unit_prod_price_3,
+        )
+        self.assertEqual(
+            self.opt.optim_status,
+            "Optimal",
+            "Solve 3 must re-attempt the real cached MILP, not report a retained relaxed status.",
+        )
+
+        temp_2 = opt_res_2["predicted_temp_heater0"].to_numpy()
+        temp_3 = opt_res_3["predicted_temp_heater0"].to_numpy()
+        self.assertFalse(
+            np.isnan(temp_3).any(), "predicted_temp_heater0 in solve 3 must not contain NaN"
+        )
+        self.assertFalse(
+            np.allclose(temp_2, temp_3),
+            "Solve 3's predicted_temp_heater0 must differ from solve 2's: a "
+            "+10C outdoor shift changes the thermal-loss/heating-demand "
+            "terms directly, so identical values here mean extraction read a "
+            "dead variable frozen at the rescue's values instead of the live "
+            "cached-problem variable (#1048).",
+        )
+        self.assertAlmostEqual(
+            temp_3[0],
+            config["start_temperature"],
+            places=2,
+            msg="predicted_temp_heater0[0] is pinned to start_temperature by "
+            "construction regardless of outdoor forecast",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1048.

## The bug

I dug into this in [the issue thread](https://github.com/davidusb-geek/emhass/issues/1048#issuecomment-5148868324): the relaxed-LP retry path permanently poisons the cached optimization problem.

The chain, on current master:

1. On a cache-hit run (`self.prob` already built), `batt_stress_conf` and `inv_stress_conf` are `None`. Only the `self.prob is None` build block populates them.
2. If that solve fails (`infeasible` / `unbounded` / `user_limit`, which is how a HiGHS timeout comes back), the relaxed retry rebuilds constraints and objective with those `None` confs. The stress epigraph constraints get skipped and the stress terms drop out of the objective.
3. `self.prob = prob_relaxed` then replaces the cached problem permanently. Every later cache-hit run re-solves the stress-free, binary-relaxed LP and reports plain "Optimal". Only the poisoning run itself ever shows "Optimal (Relaxed)".

That also explains the strangest symptom in the report: nudging `battery_stress_cost` in either direction changes `plant_conf_hash` in the cache key, forces a MISS, and rebuilds a clean problem. Any structural config change "fixes" it until the next failed solve. Runtime-excluded keys don't, which is a nice confirmation of the mechanism: tweaking `lp_solver_timeout` or `lp_solver_mip_rel_gap` themselves would not have helped, because those are excluded from the cache key.

The reporter's setup made this easy to hit: `lp_solver_mip_rel_gap: 0` (exact optimal instead of the shipped 1%) plus a 45s timeout on a true MILP (`inverter_is_hybrid: true`), so `user_limit` timeouts were routine.

## The fix

Three parts, all in `optimization.py` (the new attributes are initialised in `__init__`, everything else is in `perform_optimization`):

1. The stress configs built alongside the problem are now kept on the instance (`self._batt_stress_conf` / `self._inv_stress_conf`) and read back on cache-hit runs, so a retry rebuild gets the same configs (same CVXPY variables) the cached problem was built with. The existing #770 fix at the retry site already handled the constraint gating half of this gap; this closes it for the constraint and objective content too.
2. The rescue result is routed through a local `solved_prob`. `self.prob` is never replaced by `prob_relaxed`: the relaxed solve is a one-shot rescue for that run only, and the next run re-attempts the clean cached MILP.
3. Because the rescue problem is now discarded, everything the retry rebuild produces is kept run-local. The rebuilt thermal artifacts (predicted temperatures, heating demands, q_input) go into locals used only by that run's extraction, and the instance-held references the builders replace (the hybrid inverter transfer variables and the thermal `q_input_var` persistence hooks) are snapshotted and restored around the rescue. Without this, a rescued run would leave those references pointing at variables of the discarded problem, and later runs would extract thermal columns frozen at the rescue values.

The binary relaxation itself (forcing `treat_deferrable_load_as_semi_cont` and `set_deferrable_load_single_constant` off for the rescue solve) is clearly intentional, so I have not touched it. The bug was that it became permanent.

## Behaviour changes

- A rescued cache-hit run now honours the battery/inverter stress constraints and costs instead of silently dropping them.
- Poisoned follow-up runs are gone. Every run after a rescue re-attempts the real MILP. This also fixes the latent second bug where the semi-continuous / single-constant binary logic stayed permanently dropped after one rescue, which bites even with all stress costs at zero.
- Status reporting is now honest: each rescued run reports "Optimal (Relaxed)". Previously the poisoned follow-up runs reported plain "Optimal" while solving the degraded problem.
- A config that fails every run now pays the relaxed rebuild on each failing run instead of cheaply re-solving the retained relaxed LP. I think that cost is correct: the fast path was fast because it had silently stopped being the configured problem.
- One consequence of honest statuses: the `/api/v1/plan` store only refreshes on plain "Optimal" (command_line.py), so a config that fails every single run keeps serving the last clean plan instead of refreshing with rescue results labelled "Optimal". Previously it refreshed because the poisoned runs were mislabelled. Rescued runs still return and publish their own results through the normal response path, as they do today; only the plan store gate is stricter about them, and it always has been.
- For thermal loads with inertia, the q_input carried into the run after a rescue now comes from the cached problem's own last solve (the failed MILP's incumbent) rather than the discarded rescue problem. If that solve produced no values, the existing heating-demand fallback and forced rebuild take over, so there is no stuck state.

## Tests

- `test_relaxed_rescue_keeps_cached_problem`: the cached problem object survives a rescue (identity), and the following clean run reports plain "Optimal" again.
- `test_relaxed_rescue_does_not_poison_followup_runs`: behavioural check with a single-constant load and a price shape where the MILP must pick one contiguous block but the relaxed LP strictly prefers a split dispatch. On master the run after a rescue produces the split; with the fix it is back to the contiguous MILP dispatch.
- `test_cached_retry_rebuilds_stress_configs`: on a cache-hit retry, the objective rebuild receives the cached non-None stress config.
- `test_relaxed_rescue_keeps_thermal_artifacts_fresh`: regression guard for the run-local rescue. The thermal persistence hooks survive a rescue by identity, and the thermal columns of the run after a rescue track a changed outdoor forecast instead of freezing at the rescue values. This one is green on master too (the retained-problem behaviour masked it); it pins the property that keeps the one-shot rescue safe.

The first three fail on master at the behavioural assertion and pass with the fix. Full suite green locally.

## Summary by Sourcery

Prevent relaxed-LP rescue on cache-hit runs from permanently replacing the cached MILP problem and associated thermal artifacts, ensuring the rescue remains a one-shot fallback tied to the failing run only.

Bug Fixes:
- Ensure cache-hit retries reuse the original battery and inverter stress configurations so stress constraints and costs are preserved during relaxed-LP rescue solves.
- Avoid poisoning follow-up runs by keeping the cached MILP problem intact and routing relaxed-LP rescue results through a separate solved problem reference.
- Prevent thermal persistence hooks and artifacts from being overwritten by variables belonging to the transient relaxed problem, avoiding frozen or stale thermal outputs after a rescue.

Tests:
- Add regression tests that simulate solver failures to verify the cached problem survives relaxed-LP rescue and that subsequent runs revert to normal MILP behaviour and dispatch.
- Add tests to confirm cache-hit retries rebuild stress configs correctly and pass non-None cached stress configurations into the objective rebuild.
- Add tests that validate thermal artifacts remain fresh across rescues, with predicted temperatures and q_input values responding correctly to changing outdoor forecasts.