### PR TITLE
fix: battery identification no longer counts throughput across recorder gaps (#1051)

### DIFF
--- a/docs/battery_identification.md
+++ b/docs/battery_identification.md
@@ -13,6 +13,8 @@ This is opt-in and default off. In this first version it is advisory only: it re
 
 The two sensors are only retrieved when battery self-identification is enabled, so they cost nothing on a normal run. Their signed values are kept intact on this retrieval regardless of the `set_zero_min` data cleaning setting, which continues to sanitize the load data as usual.
 
+Stretches of history with no recorded data are excluded from the fit. Any step between two samples longer than three times the `optimization_time_step` counts as a recorder gap: the battery state across it is unobserved, so it contributes no energy throughput and no state of charge change, and any charge or discharge run in progress ends at the last sample before the gap. This means history riddled with long gaps (a recorder outage, or a power sensor that only reports on changes and stays silent for hours) can honestly come back as "not enough data" rather than producing an estimate from invented energy. Shorter dropouts, up to two consecutive missing steps, are still bridged.
+
 ## Enabling it
 
 Set these in your configuration:

--- a/src/emhass/battery_identification.py
+++ b/src/emhass/battery_identification.py
@@ -58,6 +58,13 @@ POWER_DEADBAND_W = 25.0  # |power| below this is treated as idle (sign hysteresi
 SOC_REVERSAL_HYSTERESIS = 1.0  # SoC points of counter-move tolerated before a run splits
 MIN_SEGMENT_DURATION = pd.Timedelta(minutes=20)
 MIN_SOC_SWING_PER_SEGMENT = 10.0  # a segment must move at least this many SoC points to be "deep"
+# A step between consecutive observed samples longer than this many multiples of
+# the expected sample step is a recorder GAP (#1051): the battery state across it
+# is unobserved, so the step must contribute neither throughput nor dSoC. Gaps
+# end the current run at the last observed sample. Up to two consecutive missing
+# resample buckets (dt == 3x step) are tolerated as benign recorder jitter and
+# still bridged by the trapezoid.
+MAX_GAP_STEP_MULTIPLE = 3.0
 
 # Sufficiency floors
 MIN_DEEP_SEGMENTS = 3  # per direction, before a capacity fit is attempted
@@ -224,8 +231,18 @@ def _intercept_diag(x: np.ndarray, y: np.ndarray) -> float:
 class BatteryIdentification:
     """Pure estimator: history in, :class:`BatteryIdentificationResult` out."""
 
-    def __init__(self, logger: logging.Logger):
+    def __init__(self, logger: logging.Logger, time_step: pd.Timedelta | None = None):
+        """
+        :param logger: Logger for diagnostics.
+        :param time_step: The expected spacing of the history samples (the
+            retrieval resample step, ``optimization_time_step`` in production).
+            Used to tell recorder gaps apart from ordinary steps. When ``None``
+            the step is inferred as the median spacing of the data itself,
+            which keeps the estimator usable standalone but is only reliable
+            while most consecutive samples are actually adjacent.
+        """
         self.logger = logger
+        self.time_step = time_step
 
     # -- segmentation ---------------------------------------------------------
     def _segment(self, df: pd.DataFrame, power_col: str, soc_col: str) -> list[_Segment]:
@@ -246,15 +263,49 @@ class BatteryIdentification:
         # Float hours since the first sample (tz-safe, resolution-independent).
         hours_axis = (times - times[0]).total_seconds().to_numpy() / 3600.0
 
+        # Recorder gaps (#1051): after the retrieval resample, missing history
+        # shows up as NaN buckets which the dropna above removes, leaving one
+        # oversized step between the samples on either side of the gap. The
+        # battery state across that step is UNOBSERVED, so it must contribute
+        # neither throughput (the trapezoid would fabricate p_avg * gap_hours)
+        # nor dSoC. Oversized steps are treated as run boundaries below and are
+        # excluded from the sign vote here.
+        # Compare spacings in integer nanoseconds, not float hours: a dropout of
+        # exactly MAX_GAP_STEP_MULTIPLE missing-plus-one buckets must stay
+        # bridged on EVERY grid, and float division (1 min = 1/60 h) turns that
+        # equality into a spurious ">" on steps that are not a binary fraction
+        # of an hour. The index is normalized to nanoseconds first: asi8 counts
+        # in the index's own resolution (microseconds by default on pandas 3),
+        # while Timedelta.value is always nanoseconds.
+        dt_ns = np.diff(times.as_unit("ns").asi8)
+        if self.time_step is not None:
+            base_step_ns = float(pd.Timedelta(self.time_step).as_unit("ns").value)
+        else:
+            base_step_ns = float(np.median(dt_ns)) if len(dt_ns) else 0.0
+        if base_step_ns > 0:
+            gap_mask = dt_ns > MAX_GAP_STEP_MULTIPLE * base_step_ns
+        else:
+            # Degenerate spacing (e.g. duplicate timestamps dominating the
+            # median): no reliable notion of a "normal" step, so no gap logic.
+            gap_mask = np.zeros(len(dt_ns), dtype=bool)
+        n_gaps = int(gap_mask.sum())
+        if n_gaps:
+            self.logger.debug(
+                "battery_identification: %d recorder gap(s) longer than %.2g h "
+                "excluded from segmentation",
+                n_gaps,
+                MAX_GAP_STEP_MULTIPLE * base_step_ns / 3.6e12,  # ns -> h (3600 s/h * 1e9 ns/s)
+            )
+
         # Auto-detect the sign convention from the data itself. Each rising-SoC
         # interval [k, k+1] is CAUSED by the power held over it, power[k] (the
         # same convention the trapezoid integral uses), NOT power[k+1] - pairing
         # with the end sample mislabels pulsed charge-then-discharge data. Over
         # charging intervals the causing power must be positive; if the net vote
         # is negative the meter reports charge as negative and we flip so that
-        # positive = charge.
+        # positive = charge. Gap steps are unobserved and do not vote.
         d_soc_step = np.diff(soc)
-        rising = d_soc_step > 0
+        rising = (d_soc_step > 0) & ~gap_mask
         if rising.any():
             charge_power_vote = float(np.sum(power[:-1][rising]))
             self.logger.debug(
@@ -284,6 +335,19 @@ class BatteryIdentification:
             step_dir = 0
             if abs(power[i]) >= POWER_DEADBAND_W:
                 step_dir = 1 if power[i] > 0 else -1
+            if gap_mask[i - 1]:
+                # The step into sample i spans a recorder gap. The current run
+                # (if any) ends at the last observed sample, mirroring the
+                # end-of-data flush. Any new run starts AT the first post-gap
+                # sample - never at i-1, which would bridge the gap back into
+                # a segment's dSoC and duration.
+                _flush(i - 1)
+                run_dir = step_dir
+                if run_dir != 0:
+                    run_start = i
+                    run_soc_extreme = soc[i]
+                    run_extreme_idx = i
+                continue
             if run_dir == 0:
                 if step_dir != 0:
                     run_dir = step_dir

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -1448,9 +1448,9 @@ async def _identify_battery_impl(
             )
             return
         configured_capacity_wh = float(plant_conf.get("battery_nominal_energy_capacity", 0) or 0)
-        result = BatteryIdentification(logger).identify(
-            df, power_col, soc_col, configured_capacity_wh
-        )
+        result = BatteryIdentification(
+            logger, time_step=retrieve_hass_conf.get("optimization_time_step")
+        ).identify(df, power_col, soc_col, configured_capacity_wh)
         for msg in result.messages:
             logger.info("Battery identification: %s", msg)
         if not result.is_ok:
@@ -1568,9 +1568,9 @@ async def _identify_battery_impl(
         configured_capacity_wh = float(
             _batt_conf_val(plant_conf.get("battery_nominal_energy_capacity", 0), k) or 0
         )
-        result = BatteryIdentification(logger).identify(
-            df, power_col, soc_col, configured_capacity_wh
-        )
+        result = BatteryIdentification(
+            logger, time_step=retrieve_hass_conf.get("optimization_time_step")
+        ).identify(df, power_col, soc_col, configured_capacity_wh)
         for msg in result.messages:
             logger.info("Battery %d identification: %s", k, msg)
         if not result.is_ok:

--- a/tests/test_battery_identification.py
+++ b/tests/test_battery_identification.py
@@ -879,5 +879,314 @@ class TestIsModelOutdatedLabel(unittest.TestCase):
         self.assertTrue(any("Battery identification model" in m for m in cm.output))
 
 
+@unittest.skipUnless(HAVE_FEATURE, "battery_identification feature not present (base commit)")
+class TestGapHandling(unittest.TestCase):
+    """
+    Recorder gaps must contribute zero throughput and zero dSoC (#1051).
+
+    After the retrieval resample, missing history becomes NaN buckets which the
+    segmentation's dropna removes, leaving one oversized step spanning the gap.
+    On the base commit the trapezoid integrates AC power across that step, so a
+    multi-day gap fabricates p_avg * gap_hours of throughput (the reported 79 h
+    outage became an 89,809 Wh "discharge segment" on a 10 kWh pack). The
+    tests that avoid the ``time_step`` kwarg are base-safe: they drive the
+    estimator through calls whose signatures exist on base too, so their RED
+    assertions fail behaviourally there. The ones passing ``time_step``
+    exercise fix-only surface and error on base instead.
+    """
+
+    def setUp(self):
+        self.logger = logging.getLogger("test_battery_id_gaps")
+        self.power_col = "sensor_power_battery"
+        self.soc_col = "sensor_battery_state_of_charge"
+
+    @staticmethod
+    def _two_block_charge(
+        gap_hours: float = 79.0,
+        dt_minutes: int = 30,
+        n_side: int = 10,
+        power_w: float = 1000.0,
+        cap_wh: float = 20000.0,
+        rte: float = 0.90,
+    ) -> pd.DataFrame:
+        """
+        Two charge blocks separated by a silent stretch with SoC flat across it:
+        the recorder died mid-charge and came back while the battery (which sat
+        idle in between) was charging again. The sample on each side of the gap
+        carries active charge power, exactly the bridged shape from the issue.
+        """
+        eta = float(np.sqrt(rte))
+        dt_h = dt_minutes / 60.0
+        step_pts = eta * power_w * dt_h / cap_wh * 100.0
+        idx1 = pd.date_range(
+            "2026-01-01 00:00:00", periods=n_side, freq=f"{dt_minutes}min", tz="UTC"
+        )
+        idx2 = pd.date_range(
+            idx1[-1] + pd.Timedelta(hours=gap_hours),
+            periods=n_side,
+            freq=f"{dt_minutes}min",
+            tz="UTC",
+        )
+        soc1 = [20.0 + step_pts * k for k in range(n_side)]
+        soc2 = [soc1[-1] + step_pts * k for k in range(n_side)]
+        return pd.DataFrame(
+            {
+                "sensor_power_battery": [power_w] * (2 * n_side),
+                "sensor_battery_state_of_charge": soc1 + soc2,
+            },
+            index=idx1.append(idx2),
+        )
+
+    # -- the #1051 bug itself (RED on base) -----------------------------------
+    def test_gap_contributes_zero_throughput(self):
+        """A 79 h recorder gap must add nothing to segment throughput."""
+        df = self._two_block_charge()
+        segs = BatteryIdentification(self.logger)._segment(df, self.power_col, self.soc_col)
+        total_throughput = sum(s.throughput_wh for s in segs)
+        # Ground truth: 9 half-hour intervals per block at 1000 W = 4500 Wh per
+        # block, 9000 Wh measured in total. On base the bridged trapezoid adds
+        # 1000 W * 79 h = 79,000 Wh on top, so this bound fails behaviourally.
+        self.assertLess(
+            total_throughput,
+            9000.0 * 1.10,
+            "segment throughput must not exceed the energy actually measured "
+            f"(got {total_throughput:.0f} Wh)",
+        )
+        for s in segs:
+            self.assertLess(
+                s.end - s.start,
+                pd.Timedelta(hours=79),
+                "no segment may span the recorder gap",
+            )
+
+    def test_gap_contributes_zero_dsoc(self):
+        """The run ends at the gap: unobserved SoC change is never credited."""
+        df = self._two_block_charge()
+        segs = BatteryIdentification(self.logger)._segment(df, self.power_col, self.soc_col)
+        self.assertTrue(segs, "each observed block is deep enough to segment")
+        eta = float(np.sqrt(0.90))
+        per_block_swing = 9 * (eta * 1000.0 * 0.5 / 20000.0 * 100.0)
+        for s in segs:
+            # On base the single bridged segment carries both blocks' swing
+            # (double this bound), so this fails behaviourally there.
+            self.assertLessEqual(
+                abs(s.d_soc),
+                per_block_swing + 0.1,
+                "a segment must not carry SoC change from beyond the gap",
+            )
+
+    def test_identify_recovers_truth_despite_gap(self):
+        """End to end: a huge mid-run gap no longer corrupts the fit."""
+        cap_true, rte_true = 10000.0, 0.90
+        df = _make_history(cap_true, rte_true, n_cycles=20, dt_minutes=30, idle_steps=4)
+        # Cut from mid-charge-run to mid-charge-run roughly 79 h later, so the
+        # samples on BOTH sides of the gap carry active charge power and the
+        # bridged trapezoid on base fabricates ~3 kW * ~80 h of throughput.
+        run_rows = df[df[self.power_col] > 0]
+        mid = run_rows.index[len(run_rows) // 2 + 2]
+        later = run_rows.index[run_rows.index >= mid + pd.Timedelta(hours=79)]
+        end = later[2]
+        mask = (df.index >= mid) & (df.index < end)
+        gapped = df.loc[~mask]
+        res = BatteryIdentification(self.logger).identify(
+            gapped, self.power_col, self.soc_col, cap_true
+        )
+        self.assertEqual(res.status, "ok", msg=str(res.messages))
+        self.assertAlmostEqual(res.capacity_wh, cap_true, delta=0.05 * cap_true)
+        self.assertAlmostEqual(res.round_trip_efficiency, rte_true, delta=0.03)
+
+    # -- the fix's own risk: splitting must not eat healthy profiles ----------
+    def test_idle_gaps_between_cycles_keep_segments(self):
+        """
+        The change-only profile from the issue: dense reporting while cycling,
+        silent while idle. Gaps sit BETWEEN runs, so excluding them must not
+        cost any segments and the fit must stay accurate.
+        """
+        cap_true, rte_true = 10000.0, 0.90
+        df = _make_history(cap_true, rte_true, n_cycles=6, dt_minutes=30, idle_steps=12)
+        # Silence every idle stretch (power == 0) except one edge sample on
+        # each side, as a change-only sensor would.
+        idle = df[self.power_col] == 0.0
+        edges = idle & (~idle.shift(1, fill_value=False) | ~idle.shift(-1, fill_value=False))
+        gapped = df[~idle | edges]
+        res = BatteryIdentification(self.logger).identify(
+            gapped, self.power_col, self.soc_col, cap_true
+        )
+        self.assertEqual(res.status, "ok", msg=str(res.messages))
+        self.assertAlmostEqual(res.capacity_wh, cap_true, delta=0.05 * cap_true)
+
+    def test_sub_threshold_dropout_still_bridged(self):
+        """Up to two consecutive missing samples is jitter, not a gap: no split."""
+        df = _make_history(10000.0, 0.90, n_cycles=1, dt_minutes=30, idle_steps=4)
+        run_rows = df[df[self.power_col] > 0]
+        mid_pos = len(run_rows) // 2
+        # Drop exactly two consecutive in-run samples -> dt == 3x step, at the
+        # documented tolerance boundary.
+        to_drop = run_rows.index[mid_pos : mid_pos + 2]
+        jittered = df.drop(index=to_drop)
+        segs_ref = BatteryIdentification(self.logger)._segment(df, self.power_col, self.soc_col)
+        segs_jit = BatteryIdentification(self.logger)._segment(
+            jittered, self.power_col, self.soc_col
+        )
+        self.assertEqual(
+            len(segs_jit),
+            len(segs_ref),
+            "a two-sample dropout must not split the run",
+        )
+        # Depth must survive too: a >=-threshold variant would split here and
+        # the surviving half would shrink dSoC while the count stays equal.
+        for ref, jit in zip(segs_ref, segs_jit):
+            self.assertEqual(jit.direction, ref.direction)
+            self.assertAlmostEqual(jit.d_soc, ref.d_soc, places=6)
+
+    def test_sub_threshold_dropout_bridges_on_odd_grids(self):
+        """
+        The 3x tolerance must hold on grids whose step is not a binary
+        fraction of an hour (float-hours comparison misclassified exactly-3x
+        dropouts at 1/2/3/6/7/13 min steps; spacing is compared in integer
+        nanoseconds precisely so this cannot happen).
+        """
+        for dt_minutes in (1, 3, 7, 13):
+            df = _make_history(
+                10000.0, 0.90, n_cycles=1, power_w=300.0, dt_minutes=dt_minutes, idle_steps=4
+            )
+            run_rows = df[df[self.power_col] > 0]
+            mid_pos = len(run_rows) // 2
+            to_drop = run_rows.index[mid_pos : mid_pos + 2]
+            jittered = df.drop(index=to_drop)
+            with self.subTest(dt_minutes=dt_minutes):
+                segs_ref = BatteryIdentification(
+                    self.logger, time_step=pd.Timedelta(minutes=dt_minutes)
+                )._segment(df, self.power_col, self.soc_col)
+                segs_jit = BatteryIdentification(
+                    self.logger, time_step=pd.Timedelta(minutes=dt_minutes)
+                )._segment(jittered, self.power_col, self.soc_col)
+                self.assertEqual(
+                    [(s.direction, round(s.d_soc, 6)) for s in segs_jit],
+                    [(s.direction, round(s.d_soc, 6)) for s in segs_ref],
+                    f"exactly-3x dropout must stay bridged at {dt_minutes} min",
+                )
+
+    def test_discharge_gap_contributes_nothing(self):
+        """Same guarantee for the discharge direction: two discharge blocks."""
+        eta = float(np.sqrt(0.90))
+        step_pts = 1000.0 * 0.5 / (eta * 20000.0) * 100.0
+        idx1 = pd.date_range("2026-01-01 00:00:00", periods=10, freq="30min", tz="UTC")
+        idx2 = pd.date_range(idx1[-1] + pd.Timedelta(hours=79), periods=10, freq="30min", tz="UTC")
+        soc1 = [90.0 - step_pts * k for k in range(10)]
+        soc2 = [soc1[-1] - step_pts * k for k in range(10)]
+        df = pd.DataFrame(
+            {
+                "sensor_power_battery": [-1000.0] * 20,
+                "sensor_battery_state_of_charge": soc1 + soc2,
+            },
+            index=idx1.append(idx2),
+        )
+        segs = BatteryIdentification(self.logger)._segment(df, self.power_col, self.soc_col)
+        self.assertEqual(len(segs), 2, "one discharge segment per observed block")
+        for s in segs:
+            self.assertEqual(s.direction, "discharge")
+            self.assertLess(s.end - s.start, pd.Timedelta(hours=79))
+        self.assertLess(
+            sum(s.throughput_wh for s in segs),
+            9000.0 * 1.10,
+            "the bridged 79 h discharge trapezoid must not be counted",
+        )
+
+    def test_gap_at_series_edges_is_harmless(self):
+        """A lone pre-history or post-history sample must change nothing."""
+        df = _make_history(10000.0, 0.90, n_cycles=2, dt_minutes=30, idle_steps=4)
+        lone_before = pd.DataFrame(
+            {self.power_col: [3000.0], self.soc_col: [50.0]},
+            index=pd.DatetimeIndex([df.index[0] - pd.Timedelta(hours=79)]),
+        )
+        lone_after = pd.DataFrame(
+            {self.power_col: [-3000.0], self.soc_col: [30.0]},
+            index=pd.DatetimeIndex([df.index[-1] + pd.Timedelta(hours=79)]),
+        )
+        padded = pd.concat([lone_before, df, lone_after])
+        segs_ref = BatteryIdentification(self.logger)._segment(df, self.power_col, self.soc_col)
+        segs_pad = BatteryIdentification(self.logger)._segment(padded, self.power_col, self.soc_col)
+        self.assertEqual(
+            [(s.direction, round(s.d_soc, 6)) for s in segs_pad],
+            [(s.direction, round(s.d_soc, 6)) for s in segs_ref],
+            "lone samples across an edge gap must contribute nothing",
+        )
+
+    def test_gap_detected_on_microsecond_index(self):
+        """
+        Gap detection must survive a non-nanosecond index resolution: pandas 3
+        builds datetime64[us] indexes by default, where asi8 counts
+        microseconds while Timedelta.value is nanoseconds. A unit mix-up makes
+        the threshold 1000x too big and silently disables gap handling under
+        an explicit time_step (the production configuration).
+        """
+        df = self._two_block_charge()
+        df.index = df.index.as_unit("us")
+        segs = BatteryIdentification(self.logger, time_step=pd.Timedelta(minutes=30))._segment(
+            df, self.power_col, self.soc_col
+        )
+        self.assertEqual(len(segs), 2, "the 79 h gap must still split on a us-unit index")
+        self.assertLess(sum(s.throughput_wh for s in segs), 9000.0 * 1.10)
+
+    def test_explicit_time_step_overrides_inference(self):
+        """
+        With an explicit time_step the gap threshold follows the configured
+        step, not the data spacing: a 65 min hole in 5 min data is a gap when
+        inferring (threshold 15 min) but tolerated jitter at a 30 min
+        configured step (threshold 90 min).
+        """
+        df = _make_history(10000.0, 0.90, n_cycles=1, power_w=1500.0, dt_minutes=5, idle_steps=4)
+        run_rows = df[df[self.power_col] > 0]
+        mid = run_rows.index[len(run_rows) // 2]
+        mask = (df.index >= mid) & (df.index < mid + pd.Timedelta(minutes=60))
+        gapped = df.loc[~mask]
+        inferred = BatteryIdentification(self.logger)._segment(gapped, self.power_col, self.soc_col)
+        explicit = BatteryIdentification(self.logger, time_step=pd.Timedelta(minutes=30))._segment(
+            gapped, self.power_col, self.soc_col
+        )
+        n_charge_inferred = sum(1 for s in inferred if s.direction == "charge")
+        n_charge_explicit = sum(1 for s in explicit if s.direction == "charge")
+        self.assertEqual(n_charge_explicit, 1, "65 min hole within 3x30 min must bridge")
+        self.assertEqual(n_charge_inferred, 2, "65 min hole beyond 3x5 min must split")
+
+    def test_gap_steps_do_not_vote_on_sign_convention(self):
+        """
+        A gap step must not contribute its (stale) left-sample power to the
+        sign auto-detection vote. Here the meter reports charge as negative,
+        the battery started a hard discharge right before the recorder died,
+        and SoC came back higher. Unmasked, that one stale high-power vote
+        outweighs every real charging step and the convention flips the wrong
+        way; masked, the real steps win.
+        """
+        step_pts = float(np.sqrt(0.90)) * 1000.0 * 0.5 / 20000.0 * 100.0
+        idx1 = pd.date_range("2026-01-01 00:00:00", periods=11, freq="30min", tz="UTC")
+        idx2 = pd.date_range(idx1[-1] + pd.Timedelta(hours=79), periods=10, freq="30min", tz="UTC")
+        # Charge = NEGATIVE on this meter. Ten charging samples, then one
+        # discharge spike sample right before the gap, then charging again
+        # with SoC a little higher than where it went dark.
+        powers = [-1000.0] * 10 + [20000.0] + [-1000.0] * 10
+        soc1 = [20.0 + step_pts * k for k in range(11)]  # still rising into the spike
+        soc2 = [soc1[-1] + 5.0 + step_pts * k for k in range(10)]
+        df = pd.DataFrame(
+            {
+                "sensor_power_battery": powers,
+                "sensor_battery_state_of_charge": soc1 + soc2,
+            },
+            index=idx1.append(idx2),
+        )
+        segs = BatteryIdentification(self.logger)._segment(df, self.power_col, self.soc_col)
+        # Masked vote -> convention flips correctly -> one charge block on each
+        # side of the gap. An unmasked vote leaves the convention inverted and
+        # the post-gap block comes out labelled discharge instead.
+        self.assertEqual(len(segs), 2, "one segment per observed block")
+        for s in segs:
+            self.assertEqual(
+                s.direction,
+                "charge",
+                "sign convention must be detected from real steps, not the gap step",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1051.

## The bug

Battery identification retrieves history resampled to `optimization_time_step` and the segmentation drops the NaN buckets a recorder gap leaves behind. The two samples on either side of the gap then sit next to each other, and the trapezoidal integral bridges them with a single step spanning the whole gap. With active power on both sides that fabricates `p_avg * gap_hours` of throughput out of nothing. That's the 89,809 Wh "discharge segment" from @JoshC1994's 79 h outage on a 10 kWh pack, and the milder version of it taxes every gap in @volschin's change-only profile (69 gaps over 30 min in his 14 day census, 61% of wall-clock inside gaps).

## The fix

A step between consecutive observed samples longer than 3x the expected sample step is treated as a recorder gap. The expected step is `optimization_time_step`, now passed into `BatteryIdentification` at both call sites; without it (standalone use) the estimator falls back to the median spacing of the data. Gap handling is an internal constant, not a new config param.

A gap ends the current charge/discharge run at the last observed sample, mirroring the existing end-of-data flush, and any new run starts at the first sample after the gap. So a gap contributes zero throughput and zero dSoC. Gap steps are also excluded from the sign-convention vote, which otherwise counts one stale pre-gap power sample against the real steps.

Dropouts up to two consecutive missing resample buckets (dt = 3x step) are still bridged, so ordinary recorder jitter doesn't split runs.

## Design choice, disclosed

There were two ways to make a gap contribute zero throughput:

1. Drop only the oversized trapezoid step but keep the run alive across the gap, keeping its full dSoC span.
2. End the run at the gap (what this PR does).

Option 1 looks gentler on segment counts, but it credits the run with SoC change that happened while nobody was watching. On a multi-day outage the SoC drifts, so throughput excludes the gap while dSoC includes it, and the capacity estimate biases low. It can also stitch two shallow cycles on either side of a gap into one segment that clears the 10-point depth floor on unobserved state. Ending the run keeps every segment's throughput and dSoC internally consistent.

The honest cost: on gap-heavy history, runs that used to be bridged now split, and each piece has to clear the depth and duration floors on its own. A profile like volschin's can land on `insufficient_data` instead of a fabricated fit. That's the intended behaviour change: no estimate beats a wrong estimate, and his cycles are densely reported while active, so real segments survive.

Forward-filling change-only sensors at retrieval (so idle periods come back as real flat data instead of gaps) is a separate improvement and stays a follow-up, as discussed in the issue.

## Behaviour changes

- Gap-free history is byte-identical to before (strict `>` threshold, a regular grid never trips it).
- Gapped history: fewer, cleaner segments; fits that only passed because of fabricated throughput now fail honestly (`insufficient_data` or unchanged guardrail rejections).
- No new config params, no schema or persistence changes.

## Tests

Eleven new tests in `tests/test_battery_identification.py` (`TestGapHandling`). Four are proven red on master before the fix, on the behavioural asserts:

- a 79 h gap adds zero throughput and zero dSoC (red on master: 88,000 Wh counted vs 9,000 Wh actually measured)
- end to end, a 79 h mid-run gap no longer corrupts the fit (red on master with exactly the reported failure signature, `rejected_sanity_check`)
- gap steps don't vote on the sign convention (red on master)

The rest pin the fix's own edges: the change-only idle-gap profile keeps its segments and stays accurate, a two-bucket dropout still bridges (with segment depth checked, on 30 min and on odd grid steps where a float-hours comparison would misclassify), the same guarantees hold for discharge runs and for lone samples at the series edges, explicit `time_step` overrides the median inference, and gap detection survives a microsecond-resolution index (pandas 3 default, where a naive epoch-integer comparison against nanoseconds would silently disable it).

Full suite green locally on Windows (970 passed, 32 xfailed), pandas 3.0.3.

@volschin you offered to re-run your gap census against a patched build, that would be the perfect acceptance check for scenario 2 here. @JoshC1994 your 79 h case is scenario 1 and is what the end-to-end test reproduces.

## Summary by Sourcery

Prevent battery identification from counting energy throughput and state-of-charge changes across recorder gaps, using the configured optimization time step to detect gaps and ending runs at gap boundaries.

Bug Fixes:
- Stop trapezoidal integration from fabricating throughput over long recorder outages or change-only sensor gaps by treating oversized steps as gaps with zero contribution.
- Exclude gap steps from sign-convention detection so stale pre-gap power cannot flip charge/discharge labeling.

Enhancements:
- Add optional time_step parameter to BatteryIdentification to control gap detection and keep standalone usage functional.
- Make gap detection robust to different timestamp resolutions and odd sampling grids, preserving segments through short dropouts.

Documentation:
- Document that long gaps in battery history are excluded from identification, may lead to insufficient-data outcomes, and that short dropouts remain bridged.

Tests:
- Add a comprehensive TestGapHandling suite covering gap throughput/dSoC behavior, end-to-end fit integrity, short-dropout bridging, discharge direction gaps, edge samples, explicit time_step behavior, and sign-convention voting.