### PR TITLE
Fix: duplicate forecast_dates when Forecast is constructed on an exact half-interval tie second

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -215,7 +215,18 @@ class Forecast:
             self.params = orjson.loads(params)
 
         if self.method_ts_round == "nearest":
-            self.start_forecast = pd.Timestamp.now(tz=self.time_zone).replace(microsecond=0)
+            # Round the start once, in UTC (no DST ambiguity there). A range built
+            # from an aligned start at a fixed freq is aligned by construction;
+            # rounding the built index stamp-by-stamp instead lets round-half-to-even
+            # collapse neighbouring stamps into duplicates whenever now() falls
+            # exactly on a half-interval boundary (HH:15:00 / HH:45:00 at 30 min).
+            self.start_forecast = (
+                pd.Timestamp.now(tz=self.time_zone)
+                .replace(microsecond=0)
+                .tz_convert("utc")
+                .round(self.freq)
+                .tz_convert(self.time_zone)
+            )
         elif self.method_ts_round == "first":
             self.start_forecast = (
                 pd.Timestamp.now(tz=self.time_zone).replace(microsecond=0).floor(freq=self.freq)
@@ -242,16 +253,11 @@ class Forecast:
             self.end_forecast = (self.start_forecast + pd.DateOffset(days=_delta_days)).replace(
                 microsecond=0
             )
-        self.forecast_dates = (
-            pd.date_range(
-                start=self.start_forecast,
-                end=self.end_forecast - self.freq,
-                freq=self.freq,
-                tz=self.time_zone,
-            )
-            .tz_convert("utc")
-            .round(self.freq, ambiguous="infer", nonexistent="shift_forward")
-            .tz_convert(self.time_zone)
+        self.forecast_dates = pd.date_range(
+            start=self.start_forecast,
+            end=self.end_forecast - self.freq,
+            freq=self.freq,
+            tz=self.time_zone,
         )
         if (
             params is not None
@@ -1541,7 +1547,15 @@ class Forecast:
         """
         start_forecast_csv = pd.Timestamp.now(tz=self.time_zone).replace(microsecond=0)
         if self.method_ts_round == "nearest":
-            start_forecast_csv = pd.Timestamp.now(tz=self.time_zone).replace(microsecond=0)
+            # Same start alignment as __init__: round once in UTC so the built
+            # range needs no stamp-by-stamp round (see the comment there).
+            start_forecast_csv = (
+                pd.Timestamp.now(tz=self.time_zone)
+                .replace(microsecond=0)
+                .tz_convert("utc")
+                .round(self.freq)
+                .tz_convert(self.time_zone)
+            )
         elif self.method_ts_round == "first":
             start_forecast_csv = (
                 pd.Timestamp.now(tz=self.time_zone).replace(microsecond=0).floor(freq=self.freq)
@@ -1555,16 +1569,11 @@ class Forecast:
         end_forecast_csv = (
             start_forecast_csv + pd.DateOffset(days=self.optim_conf["delta_forecast_daily"].days)
         ).replace(microsecond=0)
-        forecast_dates_csv = (
-            pd.date_range(
-                start=start_forecast_csv,
-                end=end_forecast_csv + timedelta(days=timedelta_days) - self.freq,
-                freq=self.freq,
-                tz=self.time_zone,
-            )
-            .tz_convert("utc")
-            .round(self.freq, ambiguous="infer", nonexistent="shift_forward")
-            .tz_convert(self.time_zone)
+        forecast_dates_csv = pd.date_range(
+            start=start_forecast_csv,
+            end=end_forecast_csv + timedelta(days=timedelta_days) - self.freq,
+            freq=self.freq,
+            tz=self.time_zone,
         )
         if (
             self.params is not None
@@ -2428,16 +2437,11 @@ class Forecast:
         end_forecast = (
             self.start_forecast + pd.DateOffset(days=self.optim_conf["delta_forecast_daily"].days)
         ).replace(microsecond=0)
-        forecast_dates = (
-            pd.date_range(
-                start=self.start_forecast,
-                end=end_forecast - self.freq,
-                freq=self.freq,
-                tz=self.time_zone,
-            )
-            .tz_convert("utc")
-            .round(self.freq, ambiguous="infer", nonexistent="shift_forward")
-            .tz_convert(self.time_zone)
+        forecast_dates = pd.date_range(
+            start=self.start_forecast,
+            end=end_forecast - self.freq,
+            freq=self.freq,
+            tz=self.time_zone,
         )
         data = data.loc[forecast_dates[0] : forecast_dates[-1]]
         return data

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -3041,6 +3041,161 @@ class TestGetMixForecast(unittest.TestCase):
         self.assertEqual(int(out.iloc[2]), 800)
 
 
+class TestForecastDatesTieAlignment(unittest.IsolatedAsyncioTestCase):
+    """Forecast date-range construction when now() lands exactly on a half-interval tie.
+
+    With ``method_ts_round: "nearest"`` a constructor running at exactly HH:15:00
+    or HH:45:00 (with a 30-min step) makes every stamp of the built range an
+    exact round-to-freq tie; rounding the whole index stamp-by-stamp then
+    collapses neighbouring stamps into duplicates via round-half-to-even, and the
+    first downstream index assignment raises "ValueError: Length mismatch:
+    Expected axis has 24/25 elements, new values have 48". These tests pin
+    ``pd.Timestamp.now`` to tie seconds to prove the index stays unique, and pin
+    non-tie seconds to prove the aligned-start construction is a no-op for all
+    three ``method_ts_round`` modes.
+    """
+
+    async def asyncSetUp(self):
+        import pytz
+
+        params = await TestForecast.get_test_params()
+        params_json = orjson.dumps(params).decode("utf-8")
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+        self.retrieve_hass_conf = retrieve_hass_conf
+        self.optim_conf = optim_conf
+        self.plant_conf = plant_conf
+        self.params = params
+        self.time_zone = pytz.timezone("Europe/Paris")
+
+    def _build_forecast(self, now_utc, method_ts_round="nearest", tz_name=None, step=None):
+        """Construct a Forecast with ``pd.Timestamp.now`` pinned to ``now_utc``.
+
+        Only ``now`` is patched (works on pandas 2.2 and 3.x, which both allow
+        class attribute assignment on ``Timestamp``), so every other use of the
+        class keeps its real behaviour. The patch scope is confined to the
+        constructor call, the only place ``Forecast.__init__`` reads the clock.
+        """
+        import pytz
+
+        conf = copy.deepcopy(self.retrieve_hass_conf)
+        conf["method_ts_round"] = method_ts_round
+        conf["time_zone"] = pytz.timezone(tz_name) if tz_name else self.time_zone
+        if step is not None:
+            conf["optimization_time_step"] = step
+        real_timestamp = pd.Timestamp
+
+        def _pinned_now(tz=None):
+            ts = real_timestamp(now_utc, tz="UTC")
+            return ts.tz_convert(tz) if tz is not None else ts.tz_localize(None)
+
+        with unittest.mock.patch.object(pd.Timestamp, "now", staticmethod(_pinned_now)):
+            fcst = Forecast(
+                conf,
+                self.optim_conf,
+                self.plant_conf,
+                copy.deepcopy(self.params),
+                emhass_conf,
+                logger,
+                get_data_from_file=True,
+            )
+        return fcst
+
+    def test_nearest_tie_second_keeps_forecast_dates_unique(self):
+        # 03:45:00 UTC collapses to 24 unique stamps on the unfixed builder,
+        # 03:15:00 UTC to 25 - the two lengths seen in the CI failures.
+        for now_utc in ("2026-08-05 03:45:00", "2026-08-05 03:15:00"):
+            with self.subTest(now_utc=now_utc):
+                fcst = self._build_forecast(now_utc)
+                fd = fcst.forecast_dates
+                self.assertEqual(len(fd), 48)
+                self.assertTrue(
+                    fd.is_unique,
+                    f"forecast_dates has duplicates: {list(fd[fd.duplicated()])}",
+                )
+                self.assertTrue((fd[1:] - fd[:-1] == fcst.freq).all())
+
+    async def test_typical_load_forecast_survives_tie_second(self):
+        # End-to-end repro of the CI crash: on the unfixed builder this raises
+        # ValueError("Length mismatch: Expected axis has 24 elements, new
+        # values have 48") when _get_load_forecast_typical assigns
+        # forecast_dates as the output index.
+        fcst = self._build_forecast("2026-08-05 03:45:00")
+        p_load_forecast = await fcst.get_load_forecast(method="typical")
+        self.assertEqual(len(p_load_forecast), len(fcst.forecast_dates))
+        self.assertTrue(p_load_forecast.index.equals(fcst.forecast_dates))
+
+    def test_tie_second_across_dst_transitions(self):
+        # A tie-second start whose one-day range crosses a DST transition:
+        # spring-forward day has 46 half-hour slots, fall-back day 50, and the
+        # index must stay unique through both.
+        for now_utc, expected_len in (
+            ("2026-03-28 22:45:00", 46),  # crosses Paris spring-forward 2026-03-29
+            ("2026-10-24 22:45:00", 50),  # crosses Paris fall-back 2026-10-25
+        ):
+            with self.subTest(now_utc=now_utc):
+                fcst = self._build_forecast(now_utc)
+                fd = fcst.forecast_dates
+                self.assertEqual(len(fd), expected_len)
+                self.assertTrue(
+                    fd.is_unique,
+                    f"forecast_dates has duplicates: {list(fd[fd.duplicated()])}",
+                )
+
+    def test_non_tie_starts_match_rounded_index_for_all_modes(self):
+        # Counterfactual no-op guard: away from tie seconds the aligned-start
+        # construction must reproduce, stamp for stamp, what the previous
+        # build-then-round pipeline produced, for all three method_ts_round
+        # modes. This recomputes that pipeline inline as the expectation, so it
+        # passes on the old builder too - it pins byte-identity, not the fix.
+        # One instant rounds down and one rounds up, so a floor posing as a
+        # round cannot slip through.
+        for now_utc in ("2026-08-05 03:37:23", "2026-08-05 03:52:23"):
+            for mode in ("nearest", "first", "last"):
+                with self.subTest(now_utc=now_utc, mode=mode):
+                    fcst = self._build_forecast(now_utc, method_ts_round=mode)
+                    tz = fcst.time_zone
+                    start_raw = pd.Timestamp(now_utc, tz="UTC").tz_convert(tz)
+                    if mode == "first":
+                        base_start = start_raw.floor(freq=fcst.freq)
+                        self.assertEqual(fcst.start_forecast, base_start)
+                    elif mode == "last":
+                        base_start = start_raw.ceil(freq=fcst.freq)
+                        self.assertEqual(fcst.start_forecast, base_start)
+                    else:
+                        base_start = start_raw
+                    base_end = (base_start + pd.DateOffset(days=1)).replace(microsecond=0)
+                    expected = (
+                        pd.date_range(
+                            start=base_start,
+                            end=base_end - fcst.freq,
+                            freq=fcst.freq,
+                            tz=tz,
+                        )
+                        .tz_convert("utc")
+                        .round(fcst.freq, ambiguous="infer", nonexistent="shift_forward")
+                        .tz_convert(tz)
+                    )
+                    self.assertTrue(fcst.forecast_dates.equals(expected))
+
+    def test_nearest_alignment_rounds_in_utc_not_local_wall_time(self):
+        # Australia/Adelaide sits at UTC+9:30, so with a 60-min step the local
+        # wall-time grid and the UTC grid disagree by 30 minutes. The old
+        # pipeline rounded the built index in UTC; the aligned start must take
+        # the same route. A local wall-time round would land on :00 local,
+        # 30 minutes away from every stamp the old builder produced.
+        fcst = self._build_forecast(
+            "2026-08-05 03:37:23",
+            tz_name="Australia/Adelaide",
+            step=pd.Timedelta("1h"),
+        )
+        expected_start = (
+            pd.Timestamp("2026-08-05 03:37:23", tz="UTC").round("1h").tz_convert(fcst.time_zone)
+        )
+        self.assertEqual(fcst.forecast_dates[0], expected_start)
+        self.assertEqual(len(fcst.forecast_dates), 24)
+        self.assertTrue(fcst.forecast_dates.is_unique)
+
+
 if __name__ == "__main__":
     unittest.main()
     ch.close()


### PR DESCRIPTION
Fixes the long-standing intermittent CI failure in tests/test_optimization.py:

```
ValueError: Length mismatch: Expected axis has 24 elements, new values have 48 elements
```

(sometimes 25 instead of 24). This has been failing random CI runs on otherwise green PRs for months, most recently twice in one day on #1063. It is not a test problem: the same crash can hit any real run on the default config.

## Root cause

With `method_ts_round: "nearest"` (the shipped default), `Forecast.__init__` keeps the raw wall time as `start_forecast`, only stripping microseconds. The `forecast_dates` builder then rounds the whole `date_range` in UTC, stamp by stamp.

If the constructor happens to run at exactly HH:15:00 or HH:45:00 (seconds zero), every stamp in the 30 minute range sits exactly halfway between two grid points. Pandas rounds half-to-even, so neighbouring stamps collapse into duplicates: a :45 start gives 24 unique values out of 48, a :15 start gives 25. Those are exactly the two numbers CI has been reporting. The first downstream index assignment then crashes, for example `forecast_out.index = self.forecast_dates` in `_get_load_forecast_typical`.

Deterministic repro (pandas 2.2.3, 3.0.3 and 3.0.5):

```python
import pandas as pd
freq = pd.Timedelta("30min"); tz = "Europe/Paris"
start = pd.Timestamp("2026-08-05 04:45:00", tz=tz)
end = start + pd.DateOffset(days=1)
fd = (pd.date_range(start, end - freq, freq=freq, tz=tz).tz_convert("utc")
      .round(freq, ambiguous="infer", nonexistent="shift_forward").tz_convert(tz))
print(len(fd), len(fd.unique()))   # 48, 24
```

So every `Forecast` construction is a 2-seconds-per-hour lottery, on any OS and any pandas since 2.2. That is also why the flake never correlated with anything: it looked Windows-only and time-of-day dependent for a while, but that was sampling noise over which runners happened to construct a `Forecast` in a tie second.

## The fix

Round the start once instead of rounding the built index. The "nearest" branch now aligns `start_forecast` with a single-stamp round through the same UTC route the index round used (`tz_convert("utc").round(freq).tz_convert(tz)`), and the index-wide `.round()` chain is deleted from the three date_range builders (`__init__`, `get_forecast_days_csv`, `set_cached_forecast_data`). A range built from an aligned start at a fixed freq is aligned by construction, so the per-stamp tie ambiguity disappears.

Rounding the scalar in UTC keeps the DST safety the old chain had: UTC has no ambiguous or nonexistent times, which is also why the old `ambiguous="infer"` kwarg was inert once f754cf99 moved the round to UTC (scalar `Timestamp.round` rejects `"infer"` anyway).

The "first" and "last" branches already floor/ceil the start, so for them deleting the round changes nothing in timezones whose UTC offset is a multiple of the step. In zones where it is not (Chatham, Kathmandu or Eucla with a 30 minute step, half-hour-offset zones with a 60 minute step), the floored local start put every stamp exactly halfway between UTC grid points, so the old round collapsed the index on every single run; those zones were unusable and this fixes them too. I swept over 2000 start/mode combinations through the old and new pipelines, including DST-crossing days in both directions and offset-timezone cases: byte-identical output everywhere the old code did not crash, outside the narrow DST windows disclosed below.

## Behaviour change, disclosed

A "nearest" run whose constructor lands in a tie second now gets a deterministic aligned index instead of a crash, and under "first" and "last", timezones whose UTC offset is not a multiple of the optimization step go from crashing on every run to working.

Every start that did not crash before produces byte-identical `forecast_dates`, with one narrow exception: "nearest" starts inside a window up to half a step wide right before a DST transition (or before the same wall-clock time on its eve). There the shorter index is an exact prefix of the longer and the length differs by exactly the DST hour, because aligning the start moves one end of the one-day span across the transition. The new length is always consistent with the span the index actually covers (a 23-hour day gets 46 half-hour slots). That is a few windows per year, each under half a step wide.

## Tests

- Tie-second tests pin `pd.Timestamp.now` (a small module-attribute shim, no new dependencies) to :15 and :45 starts and assert the 48-stamp index stays unique. On the unfixed builder they fail with 24/25 unique stamps.
- An end-to-end test reproduces the exact CI ValueError through `get_load_forecast(method="typical")` on the unfixed code.
- DST tie cases: a spring-forward day (46 stamps) and a fall-back day (50 stamps).
- A no-op guard recomputes the old build-then-round pipeline inline at two non-tie seconds (one rounding down, one up) and asserts stamp-for-stamp equality for all three `method_ts_round` modes, pinning the aligned-start construction as byte-identical away from ties.
- An Australia/Adelaide (UTC+9:30) case at a 60 minute step pins the start alignment to the UTC grid, the same route the old index-wide round used, rather than the local wall-time grid.

## Why no issue first

The bug is fully characterized by the repro above, the fix is small and mechanical, and there is no design choice to discuss, so an issue would just restate this PR.

One out-of-scope observation while in here: `utils.get_forecast_dates` floors unconditionally regardless of `method_ts_round`, so the two date builders disagree about "nearest". Pre-existing, unchanged by this PR, happy to look at it separately if useful.

## Summary by Sourcery

Align forecast start timestamps in UTC to prevent duplicate forecast_dates and length mismatches, and simplify date_range construction to rely on the aligned start instead of rounding the full index.

Bug Fixes:
- Prevent intermittent ValueError length mismatches caused by duplicate forecast_dates when Forecast is constructed on half-interval tie seconds.
- Fix forecast date construction for timezones whose UTC offset is not a multiple of the optimization step, ensuring unique indices across DST transitions and non-integer offsets.

Enhancements:
- Unify forecast date construction across Forecast initialization, CSV export, and cached forecast data to use aligned starts without per-stamp rounding.
- Add tests covering tie-second behavior, DST transitions, non-tie equivalence with the previous pipeline, and non-integer offset timezones to pin the new behavior.

Tests:
- Introduce async and synchronous tests that pin pd.Timestamp.now to tie and non-tie instants to verify unique forecast_dates, end-to-end load forecast stability, DST behavior, and UTC-based rounding in offset timezones.