### PR TITLE
feat: mask the demand/capacity charge to a tariff demand window (capacity_charge_window)

### DIFF
--- a/docs/cookbook/tariff_demand_charge.md
+++ b/docs/cookbook/tariff_demand_charge.md
@@ -76,6 +76,25 @@ Your orchestrator maintains the running peak: on each cycle, `current_period_pea
 
 Expected: with a non-zero `current_period_peak`, the plan stops shaving below that floor — deferrable loads relax up to (but not past) the incurred peak, recovering energy-cost savings the charge would otherwise forfeit.
 
+## Step 3b (MPC only): Mask the charge to your tariff's demand window
+
+<!-- source: src/emhass/optimization.py (param_capacity_window vector param, masked epigraph) -->
+
+Many tariffs assess demand only inside a **window** (e.g. 16:00-20:00, business days). Without a mask, the epigraph prices *every* timestep, so a deliberate off-window import — midday EV charging is the classic case — pins `peak_import` and the optimizer both pays a phantom charge on it and sees zero marginal value in shaving the actual window. Pass `capacity_charge_window`, a `prediction_horizon`-length list of `0`/`1` weights aligned to the horizon timesteps, and the epigraph becomes `peak_import ≥ mask[t] · p_grid_pos[t]`: only in-window import can set the priced peak.
+
+```json
+{
+  "prediction_horizon": 24,
+  "capacity_cost_per_kw": 8.0,
+  "current_period_peak": 6000,
+  "capacity_charge_window": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]
+}
+```
+
+Your orchestrator owns the calendar (business days, public holidays, seasons) and recomputes the mask each cycle; EMHASS stays tariff-agnostic. Omit the key for the previous full-horizon behaviour. An all-zero mask (horizon entirely outside the window) makes the demand term a constant — the plan is then identical to a run without the charge, which is exactly right when no window timestep is reachable. If your billing period is monthly, zero the slots that fall in the *next* month and reset `current_period_peak` at the boundary. See `passing_data.md` for an HA template that builds the mask.
+
+Expected: with the spike-owning timesteps masked out, off-window imports run unshaved at full power while in-window import is shaved toward the `current_period_peak` floor.
+
 ## Step 4: Verify the shave
 
 <!-- source: docs/plan_output_schema.md — `P_grid` (W, positive = import); P_grid = P_grid_pos + P_grid_neg at optimization.py:2299 -->
@@ -97,6 +116,7 @@ Expected: `peak_on ≤ peak_off`. The gap is your planned peak reduction; if it 
 - **`current_period_peak` is MPC-only.** It is read from runtime params on the `prediction_horizon` path (`utils.py:1637`) and defaults to `None` on the day-ahead path (`utils.py:1675`) — passing it to `dayahead-optim` has no effect.
 - **Opt-in, fail-open on bad input.** Default `0.0` skips the variable entirely (`optimization.py:1408`). A negative or non-finite `capacity_cost_per_kw` / `current_period_peak` is *ignored with a warning*, not an error (`optimization.py:1260-1270`, `3894-3906`) — so a bad value silently disables the charge; check your logs if a shave you expected does not appear.
 - **Units.** `capacity_cost_per_kw` is per **kW**; `current_period_peak` is in **Watts** (matches `P_grid`). Mixing them up (e.g. passing 6 instead of 6000) sets a 6 W floor, effectively no floor.
+- **`capacity_charge_window` is MPC-only and fail-open too.** Like `current_period_peak` it is read on the `prediction_horizon` path only. An invalid mask (non-numeric, NaN/inf, shorter than the horizon) is ignored with a warning — the full horizon gets priced again, which *overstates* the charge on off-window imports; check logs if the window seems to have no effect.
 
 ## Credits
 

--- a/docs/passing_data.md
+++ b/docs/passing_data.md
@@ -200,6 +200,32 @@ rest_command:
 `current_period_peak` is in **Watts**, not kilowatts: pass `7000`, not `7`, for a 7 kW peak (if your sensor is in kW, multiply by 1000 as shown above). It only has an effect when `capacity_cost_per_kw` is set above 0; on its own it does nothing. It is a floor, not a target: it never raises import or forces a new peak, it only stops the optimizer chasing a peak it cannot reduce. A negative, non-finite (NaN or infinity) or non-numeric value is ignored (treated as 0). Reset it at the start of each billing period (e.g. via a utility-meter cycle) so a stale high value does not suppress legitimate peak shaving in the new period.
 ```
 
+### Restricting the demand charge to a tariff demand window (naive-mpc-optim)
+
+Many demand tariffs do not charge the highest import of the whole day: they charge the highest import inside a **demand window** (e.g. 16:00-20:00 on business days only). Without a window, EMHASS prices the peak over every timestep of the horizon, so a deliberate off-window import (say, midday EV charging) pins `peak_import` and gets taxed for a cost that will never be billed - while shaving inside the actual window has zero marginal value (issues [#540](https://github.com/davidusb-geek/emhass/issues/540) / [#623](https://github.com/davidusb-geek/emhass/issues/623)).
+
+The optional runtime key `capacity_charge_window` masks the peak constraint to the window:
+
+- `capacity_charge_window`: a list of weights in `[0, 1]` of length `prediction_horizon`, aligned to the horizon timesteps like `load_cost_forecast`. The priced peak only "sees" timesteps where the mask is non-zero (`peak_import >= mask[t] * grid_import[t]`), so off-window import cannot inflate the demand charge. Only effective when `capacity_cost_per_kw > 0`; ignored otherwise.
+
+EMHASS stays tariff-agnostic: the **caller owns the calendar** (business days, public holidays, seasons) and simply sends the right mask each cycle. Combined with `current_period_peak` this models a windowed monthly demand tariff faithfully: the window mask says *where* a peak can be set, the floor says *how high* the bar already is.
+
+As an HA `rest_command` template fragment, marking 16:00-20:00 on weekdays for a 48-step / 30-minute horizon:
+
+```yaml
+      {% set nf = now().replace(minute=(now().minute // 30) * 30, second=0, microsecond=0) %}
+      {% set ns = namespace(mask=[]) %}
+      {% for i in range(48) %}
+        {% set dt = nf + timedelta(minutes=30 * i) %}
+        {% set ns.mask = ns.mask + [1 if (dt.weekday() < 5 and 16 <= dt.hour < 20) else 0] %}
+      {% endfor %}
+      "capacity_charge_window": {{ ns.mask | tojson }}
+```
+
+```{note}
+The mask defaults to *unset* (`None`) = every timestep priced, identical to behaviour without this key. An all-zero mask (no window in this horizon) makes the demand term a constant - the plan is then identical to running without a capacity charge. An invalid mask (non-numeric entries, NaN/infinity, or shorter than the horizon) is ignored with a warning and the full horizon is priced; a longer mask is truncated; weights outside `[0, 1]` are clipped. Fractional weights are allowed and scale how much of that timestep's import the priced peak sees. If your billing period resets monthly, also zero the mask entries that fall in the *next* month and reset `current_period_peak` on the boundary, so the new period starts from a clean floor.
+```
+
 ### Passing forecast data
 
 There is a complete dedicated section in the [Forecast](forecasts) section.

--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -2543,6 +2543,9 @@ async def naive_mpc_optim(
     soc_target = input_data_dict["params"]["passed_data"].get("soc_target", None)
     soc_target_timestep = input_data_dict["params"]["passed_data"].get("soc_target_timestep", None)
     current_period_peak = input_data_dict["params"]["passed_data"].get("current_period_peak", None)
+    capacity_charge_window = input_data_dict["params"]["passed_data"].get(
+        "capacity_charge_window", None
+    )
     def_total_hours = input_data_dict["params"]["optim_conf"].get(
         "operating_hours_of_each_deferrable_load", None
     )
@@ -2566,6 +2569,7 @@ async def naive_mpc_optim(
             soc_target=soc_target,
             soc_target_timestep=soc_target_timestep,
             current_period_peak=current_period_peak,
+            capacity_charge_window=capacity_charge_window,
             def_total_hours=def_total_hours,
             def_total_timestep=def_total_timestep,
             def_start_timestep=def_start_timestep,

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -314,6 +314,9 @@ class Optimization:
         # Peak grid import already incurred this billing period (issue #623, Phase 2)
         self._init_current_period_peak_param()
 
+        # Per-timestep demand-window mask for the capacity charge (issue #623, Phase 3)
+        self._init_capacity_window_param()
+
         # Initialize deferrable load parameters (window masks and energy constraints)
         self._init_deferrable_load_params()
 
@@ -399,6 +402,32 @@ class Optimization:
         """
         self.param_current_period_peak = cp.Parameter(nonneg=True, name="current_period_peak")
         self.param_current_period_peak.value = 0.0
+
+    def _init_capacity_window_param(self) -> None:
+        """Initialize the CVXPY parameter masking the capacity-charge epigraph to a
+        demand window (issue #623, Phase 3).
+
+        ``param_capacity_window`` is a per-horizon vector of weights in [0, 1]
+        applied to each grid-import timestep inside the ``peak_import`` epigraph:
+        ``peak_import >= mask[t] * p_grid_pos[t]``. Tariffs that charge demand
+        only inside a daily window (e.g. 16:00-20:00 business days) set 1 on
+        in-window timesteps and 0 elsewhere, so off-window import can no longer
+        inflate the priced peak. The mask is computed by the caller (Home
+        Assistant owns the business-day / holiday / season calendar) - EMHASS
+        stays tariff-agnostic.
+
+        ``cp.multiply(Parameter, Variable)`` is DPP, so per-call value updates
+        do not force recanonicalisation (warm-start safe). Default all-ones
+        reproduces the unmasked ``peak_import >= p_grid_pos`` epigraph exactly,
+        so behaviour is identical to Phase 2 unless a mask is explicitly passed.
+        Like ``param_soc_target_floor`` it is horizon-shaped, so it must be
+        re-created whenever the horizon length changes. Called from __init__
+        and from the resize block in ``perform_optimization``.
+        """
+        self.param_capacity_window = cp.Parameter(
+            self.num_timesteps, nonneg=True, name="capacity_window_mask"
+        )
+        self.param_capacity_window.value = np.ones(self.num_timesteps)
 
     def _init_deferrable_load_params(self) -> None:
         """
@@ -1708,7 +1737,16 @@ class Optimization:
         # part of the OptimizationCache key (a change rebuilds the problem).
         if self._get_capacity_cost_per_kw() > 0:
             vars_dict["peak_import"] = cp.Variable(nonneg=True, name="peak_import")
-            constraints.append(vars_dict["peak_import"] >= vars_dict["p_grid_pos"])
+            # Epigraph masked to the tariff's demand window (issue #623, Phase 3):
+            # param_capacity_window is all-ones by default, reproducing the plain
+            # peak_import >= p_grid_pos epigraph; a 0/1 window mask passed at
+            # runtime zeroes out-of-window timesteps so only in-window import can
+            # raise the priced peak. cp.multiply(Parameter, Variable) is DPP, so
+            # mask updates do not rebuild the problem.
+            constraints.append(
+                vars_dict["peak_import"]
+                >= cp.multiply(self.param_capacity_window, vars_dict["p_grid_pos"])
+            )
             # Floor peak_import at any demand already incurred this billing period
             # (issue #623, Phase 2). With the floor binding, shaving below it has
             # zero marginal value, so the solver does not waste battery /
@@ -4228,6 +4266,7 @@ class Optimization:
         soc_target: float | None = None,
         soc_target_timestep: int | None = None,
         current_period_peak: float | None = None,
+        capacity_charge_window: list | None = None,
         def_total_hours: list | None = None,
         def_total_timestep: list | None = None,
         def_start_timestep: list | None = None,
@@ -4281,6 +4320,11 @@ class Optimization:
 
             # Re-initialize the intermediate SOC target mask with the new horizon (#553)
             self._init_soc_target_params()
+
+            # Re-initialize the capacity-charge window mask with the new horizon
+            # (issue #623, Phase 3) - it is a vector param, so unlike the scalar
+            # current_period_peak below it MUST be re-created on resize.
+            self._init_capacity_window_param()
 
             # NOTE: param_current_period_peak (issue #623, Phase 2) is a SCALAR
             # cp.Parameter, horizon-independent, so it is intentionally NOT
@@ -4418,6 +4462,54 @@ class Optimization:
                 )
         else:
             self.param_current_period_peak.value = 0.0
+
+        # Demand-window mask for the capacity charge (issue #623, Phase 3).
+        # Reset to all-ones on EVERY call so a mask from a previous MPC tick
+        # does not leak; a valid runtime mask then overwrites it. Any invalid
+        # mask (non-numeric, NaN/inf, too short) falls back to all-ones - the
+        # unmasked Phase 2 epigraph - with a warning rather than crashing.
+        # Weights are clipped into [0, 1]; fractional weights pass through so a
+        # tariff could in principle weight timesteps, though 0/1 is the
+        # expected shape. A too-long mask is truncated to the horizon.
+        window_mask = np.ones(self.num_timesteps)
+        if self._get_capacity_cost_per_kw() > 0 and capacity_charge_window is not None:
+            try:
+                mask_arr = np.asarray(capacity_charge_window, dtype=float).ravel()
+            except (TypeError, ValueError):
+                self.logger.warning(
+                    f"Invalid capacity_charge_window (non-numeric entries): "
+                    f"{capacity_charge_window!r}; ignoring it (full-horizon peak pricing)."
+                )
+                mask_arr = None
+            if mask_arr is not None and not np.all(np.isfinite(mask_arr)):
+                self.logger.warning(
+                    "capacity_charge_window contains NaN/inf entries; "
+                    "ignoring it (full-horizon peak pricing)."
+                )
+                mask_arr = None
+            if mask_arr is not None and len(mask_arr) < self.num_timesteps:
+                self.logger.warning(
+                    f"capacity_charge_window has {len(mask_arr)} entries but the "
+                    f"horizon is {self.num_timesteps}; ignoring it "
+                    "(full-horizon peak pricing)."
+                )
+                mask_arr = None
+            if mask_arr is not None:
+                if len(mask_arr) > self.num_timesteps:
+                    self.logger.debug(
+                        f"capacity_charge_window has {len(mask_arr)} entries; "
+                        f"truncating to the {self.num_timesteps}-step horizon."
+                    )
+                    mask_arr = mask_arr[: self.num_timesteps]
+                if np.any(mask_arr < 0) or np.any(mask_arr > 1):
+                    self.logger.warning("capacity_charge_window entries outside [0, 1]; clipping.")
+                    mask_arr = np.clip(mask_arr, 0.0, 1.0)
+                window_mask = mask_arr
+                self.logger.debug(
+                    f"Capacity charge: demand-window mask active on "
+                    f"{int(np.count_nonzero(window_mask))}/{self.num_timesteps} timesteps."
+                )
+        self.param_capacity_window.value = window_mask
 
         # Pad deferrable load lists
         if def_total_timestep is not None:
@@ -5536,6 +5628,7 @@ class Optimization:
         soc_target: float | None = None,
         soc_target_timestep: int | None = None,
         current_period_peak: float | None = None,
+        capacity_charge_window: list | None = None,
         def_total_hours: list | None = None,
         def_total_timestep: list | None = None,
         def_start_timestep: list | None = None,
@@ -5590,6 +5683,18 @@ class Optimization:
             identical to omitting it. Ignored when ``capacity_cost_per_kw`` is 0. \
             Runtime-only; only used by naive-mpc-optim. See issue #623.
         :type current_period_peak: float
+        :param capacity_charge_window: Optional per-timestep demand-window mask for \
+            the capacity charge: a list of weights in [0, 1] of length \
+            ``prediction_horizon``, aligned like ``load_cost_forecast``. When the \
+            capacity charge (``capacity_cost_per_kw`` > 0) is active, the \
+            ``peak_import`` epigraph only prices timesteps where the mask is \
+            non-zero, so import outside the tariff's demand window (e.g. \
+            16:00-20:00 business days) cannot inflate the priced peak. The \
+            caller owns the business-day / holiday / season calendar. ``None`` \
+            (the default) prices every timestep, identical to omitting it. \
+            Ignored when ``capacity_cost_per_kw`` is 0. Runtime-only; only \
+            used by naive-mpc-optim. See issue #623.
+        :type capacity_charge_window: list
         :param def_total_timestep: The functioning timesteps for this iteration for each deferrable load. \
             (For continuous deferrable loads: functioning timesteps at nominal power)
         :type def_total_timestep: list
@@ -5642,6 +5747,7 @@ class Optimization:
             soc_target=soc_target,
             soc_target_timestep=soc_target_timestep,
             current_period_peak=current_period_peak,
+            capacity_charge_window=capacity_charge_window,
             def_total_hours=def_total_hours,
             def_total_timestep=def_total_timestep,
             def_start_timestep=def_start_timestep,

--- a/src/emhass/static/data/runtime_params.json
+++ b/src/emhass/static/data/runtime_params.json
@@ -42,6 +42,13 @@
       "default_value": null,
       "unit": "W"
     },
+    "capacity_charge_window": {
+      "friendly_name": "Capacity charge demand-window mask",
+      "Description": "Optional per-timestep mask restricting the demand/capacity charge to a tariff's demand window: a list of weights in [0, 1] of length prediction_horizon, aligned like load_cost_forecast. The peak_import epigraph only prices timesteps where the mask is non-zero, so import outside the window (e.g. outside 16:00-20:00 on business days) cannot inflate the priced peak. The caller owns the business-day / holiday / season calendar - EMHASS stays tariff-agnostic. Only effective when capacity_cost_per_kw > 0; ignored otherwise. Defaults to unset (None -> all timesteps priced), identical to behaviour without this key. An invalid mask (non-numeric, NaN/inf, shorter than the horizon) is ignored with a warning; a longer mask is truncated; values outside [0, 1] are clipped. Only used by naive-mpc-optim. See issues #540 / #623 and passing_data.md.",
+      "input": "array.float",
+      "default_value": null,
+      "unit": "none"
+    },
     "operating_timesteps_of_each_deferrable_load": {
       "friendly_name": "Operating timesteps of each deferrable load",
       "Description": "Per-deferrable-load total number of operating timesteps over the horizon (the timestep-based alternative to operating_hours_of_each_deferrable_load, preferred for sub-hour steps). One int per deferrable load. Only used by naive-mpc-optim. See passing_data.md.",

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -1771,6 +1771,15 @@ async def treat_runtimeparams(
             params["passed_data"]["current_period_peak"] = runtimeparams.get(
                 "current_period_peak", None
             )
+            # Demand-window mask for the capacity charge (issue #623, Phase 3).
+            # Runtime-only list of [0, 1] weights, length = prediction_horizon;
+            # defaults to None (all timesteps priced). Validation happens in
+            # Optimization.perform_optimization. Deliberately NOT mirrored into
+            # optim_conf / associations.csv: it changes every call, so putting
+            # it in the structural config would defeat the OptimizationCache.
+            params["passed_data"]["capacity_charge_window"] = runtimeparams.get(
+                "capacity_charge_window", None
+            )
             if "operating_timesteps_of_each_deferrable_load" in runtimeparams.keys():
                 params["passed_data"]["operating_timesteps_of_each_deferrable_load"] = (
                     runtimeparams["operating_timesteps_of_each_deferrable_load"]
@@ -1818,6 +1827,9 @@ async def treat_runtimeparams(
                 else None
             )
             params["passed_data"]["current_period_peak"] = None
+            # Like current_period_peak, the demand-window mask is naive-mpc-only:
+            # dayahead/perfect optimizations price the full horizon peak.
+            params["passed_data"]["capacity_charge_window"] = None
 
         # Parsing the thermal model parameters
         # Load the default config
@@ -3487,6 +3499,7 @@ async def build_params(
         "soc_target": None,
         "soc_target_timestep": None,
         "current_period_peak": None,
+        "capacity_charge_window": None,
         "operating_hours_of_each_deferrable_load": None,
         "start_timesteps_of_each_deferrable_load": None,
         "end_timesteps_of_each_deferrable_load": None,

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1038,6 +1038,127 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
             msg="current_period_peak ignored: high baseline still shaved like peak=0",
         )
 
+    def test_capacity_charge_window_mask(self):
+        """Issue #623 Phase 3 (see also #540): capacity_charge_window (runtime-only)
+        masks the peak_import epigraph to a tariff's demand window, so only
+        in-window import can raise the priced peak:
+          - no mask (None)      -> every timestep priced (== Phase 2).
+          - mask excluding the spike -> spike NOT shaved (== no-capacity baseline
+            off-window), flexibility saved for the window.
+          - all-zero mask       -> peak collapses to the current_period_peak floor,
+            a constant: plan == the no-capacity baseline.
+          - invalid masks (short / non-numeric) -> warning + all-ones fallback
+            (== the unmasked shaving plan), never a crash.
+        Discriminator: capacity_cost_per_kw > 0 is FIXED across the masked runs,
+        so only the mask changes. A build ignoring the mask would shave the
+        off-window spike in every run and fail the masked check.
+        """
+        df = self.prepare_forecast_data()
+        n = len(df)
+        prediction_horizon = 6
+        df["p_pv_forecast"] = 0.0
+        load = np.full(n, 1000.0)
+        load[2] = 5000.0  # spike at timestep 2, OUTSIDE the window below
+        df["p_load_forecast"] = load
+        pv = df["p_pv_forecast"].copy()
+        load_s = df["p_load_forecast"].copy()
+        df["unit_load_cost"] = 0.20
+        df["unit_prod_price"] = 0.20
+        self.optim_conf.update(
+            {
+                "set_use_battery": True,
+                "number_of_deferrable_loads": 0,
+                "set_battery_dynamic": False,
+                "set_nodischarge_to_grid": True,
+                "weight_battery_discharge": 0.1,
+                "weight_battery_charge": 0.1,
+            }
+        )
+        self.plant_conf.update(
+            {
+                "battery_nominal_energy_capacity": 10000,
+                "battery_discharge_power_max": 20000,
+                "battery_charge_power_max": 20000,
+                "battery_minimum_state_of_charge": 0.0,
+                "battery_maximum_state_of_charge": 1.0,
+                "battery_discharge_efficiency": 1.0,
+                "battery_charge_efficiency": 1.0,
+            }
+        )
+        window_mask = [0, 0, 0, 0, 1, 1]  # window = timesteps 4-5 only
+
+        def run(cap_cost, capacity_charge_window, current_period_peak=0.0):
+            self.optim_conf["capacity_cost_per_kw"] = cap_cost
+            self.opt = self.create_optimization()
+            res = self.opt.perform_naive_mpc_optim(
+                df,
+                pv,
+                load_s,
+                prediction_horizon,
+                soc_init=0.5,
+                soc_final=0.5,
+                current_period_peak=current_period_peak,
+                capacity_charge_window=capacity_charge_window,
+            )
+            self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+            return res["P_grid_pos"].iloc[:prediction_horizon].to_numpy()
+
+        # RUN 1 - no capacity charge: true baseline, full spike imported.
+        grid_baseline = run(cap_cost=0.0, capacity_charge_window=None)
+        self.assertGreater(
+            grid_baseline.max(),
+            4000.0,
+            msg="baseline did not import the full spike; scenario no longer discriminates",
+        )
+
+        # RUN 2 - capacity charge ON, no mask: every timestep priced (Phase 2),
+        # the spike is shaved.
+        grid_unmasked = run(cap_cost=2.0, capacity_charge_window=None)
+        self.assertTrue(self.opt.prob.is_dpp())  # DPP preserved (warm-start)
+        self.assertLess(
+            grid_unmasked.max(),
+            grid_baseline.max() - 1000.0,
+            msg="no mask must reproduce Phase 2 full-horizon shaving",
+        )
+
+        # RUN 3 - SAME cost, mask excludes the spike: off-window import is free
+        # of demand pricing, so the spike must NOT be shaved.
+        grid_masked = run(cap_cost=2.0, capacity_charge_window=window_mask)
+        self.assertTrue(self.opt.prob.is_dpp())
+        self.assertGreater(
+            grid_masked[2],
+            grid_baseline[2] - 1e-3,
+            msg="capacity_charge_window ignored: off-window spike was still shaved",
+        )
+
+        # RUN 4 - all-zero mask + an incurred-peak floor: peak_import collapses to
+        # the constant floor -> no decision bias, plan == the no-capacity baseline.
+        grid_zero = run(
+            cap_cost=2.0,
+            capacity_charge_window=[0] * prediction_horizon,
+            current_period_peak=3000.0,
+        )
+        np.testing.assert_allclose(grid_zero, grid_baseline, atol=1e-3)
+
+        # RUN 5 - invalid masks fail safe to all-ones (the unmasked plan), with a
+        # warning, never a crash. Short mask:
+        with self.assertLogs(level="WARNING") as logs:
+            grid_short = run(cap_cost=2.0, capacity_charge_window=[1, 0, 1])
+        self.assertTrue(
+            any("capacity_charge_window" in line for line in logs.output),
+            msg=f"expected a short-mask warning, got: {logs.output}",
+        )
+        np.testing.assert_allclose(grid_short, grid_unmasked, atol=1e-3)
+
+        # Non-numeric mask:
+        with self.assertLogs(level="WARNING") as logs:
+            grid_nonnum = run(cap_cost=2.0, capacity_charge_window=["a", "b"])
+        self.assertTrue(
+            any("capacity_charge_window" in line for line in logs.output),
+            msg=f"expected a non-numeric warning, got: {logs.output}",
+        )
+        np.testing.assert_allclose(grid_nonnum, grid_unmasked, atol=1e-3)
+
     def test_current_period_peak_noop_and_coercion(self):
         """Issue #623 Phase 2: current_period_peak with the feature OFF is a no-op;
         with the feature ON, 0/unset reproduces the Phase-1 plan, a numeric string is

--- a/tests/test_runtime_params.py
+++ b/tests/test_runtime_params.py
@@ -52,6 +52,7 @@ EXPECTED_KEYS = {
     "soc_target",
     "soc_target_timestep",
     "current_period_peak",
+    "capacity_charge_window",
     "operating_timesteps_of_each_deferrable_load",
     "alpha",
     "beta",


### PR DESCRIPTION
## What

Adds an optional runtime parameter **`capacity_charge_window`** for `naive-mpc-optim`: a `prediction_horizon`-length list of `[0, 1]` weights that masks the demand/capacity-charge epigraph to a tariff's **demand window**:

```
peak_import >= mask[t] * p_grid_pos[t]
```

Related: #623 (capacity charge + `current_period_peak` floor), #540 (demand-window tariffs).

## Why

Many demand tariffs bill the highest 30-min import **inside a window only** (e.g. 16:00-20:00 business days — Endeavour Energy N73 in NSW, and similar windowed tariffs elsewhere). The current epigraph prices *every* timestep, so a household whose largest import is deliberate off-window EV charging gets the peak pinned by that import: the optimizer levies a phantom charge on the EV schedule while seeing zero marginal value in shaving the actual window. With the mask, off-window import cannot set the priced peak and window shaving regains its true marginal value.

EMHASS stays tariff-agnostic: the caller owns the business-day / holiday / season calendar and just sends the mask each cycle (HA template example in the docs).

## Design notes

- **Backward compatible**: omitted/`None` mask = all-ones = exactly current behaviour. Not added to `associations.csv`/`optim_conf` (it changes every call and would defeat the OptimizationCache structural hash).
- **DPP-safe**: the mask is a horizon-shaped `cp.Parameter` and `cp.multiply(Parameter, Variable)` is DPP, so mask changes update values only — no problem rebuild, warm start preserved (asserted in the test). Re-created on horizon resize like the other vector params.
- **Fail-open validation** mirroring `current_period_peak`: non-numeric/NaN/inf/short masks warn and fall back to all-ones; longer masks truncate; weights clip into [0, 1]; fractional weights pass through.
- **All-zero mask** (horizon entirely outside the window) collapses `peak_import` to the `current_period_peak` floor — a constant term, so the plan equals a no-charge run, which is the correct economics.
- Composes with `current_period_peak` (#623 Phase 2): the mask says *where* a peak can be set, the floor says *how high* the bar already is.

## Testing

- New `test_capacity_charge_window_mask` (mirrors the Phase 2 test): unmasked == full-horizon shaving; masked off-window spike NOT shaved (counterfactual defeats a mask-ignoring build); all-zero mask + floor == no-charge baseline (allclose); short/non-numeric masks warn + fall back; `prob.is_dpp()` asserted after masked solves.
- `capacity_charge_window` registered in `runtime_params.json` + `test_runtime_params.py` EXPECTED_KEYS.
- Full `test_optimization.py` + `test_multi_battery_optimization.py` (179 passed) and `test_command_line_utils.py` (87 passed) green on 0.18.0.
- Field-tested on a live HA + EMHASS 0.18.0 install against the N73 tariff (mask from an HA trigger template, seasonal monthly rate, monthly peak floor): off-window EV import unshaved, window import shaved toward the floor, cached problem reused across mask changes (no rebuild logs, no DPP warnings).

## Docs

- `passing_data.md`: new section with semantics, HA mask-building template, validation note.
- `cookbook/tariff_demand_charge.md`: new Step 3b + caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqqC5gRNkKZbFPLE3Jfrmg

## Summary by Sourcery

Add a runtime demand-window mask to capacity charge pricing in naive MPC optimization and document its usage for windowed demand tariffs.

New Features:
- Introduce the capacity_charge_window runtime parameter to restrict capacity charge peak pricing to specified demand-window timesteps in naive-mpc-optim.

Enhancements:
- Integrate a CVXPY vector parameter to apply the demand-window mask in the peak_import epigraph while preserving DPP and warm-start behavior.
- Wire capacity_charge_window through runtime parameter handling, CLI, and optimization entry points as an MPC-only, tariff-agnostic input.
- Implement fail-open validation and clipping for capacity_charge_window values so invalid or out-of-range masks revert to full-horizon pricing with logging.

Documentation:
- Document capacity_charge_window semantics, Home Assistant mask construction, and interaction with current_period_peak in passing_data.md.
- Update the demand-charge cookbook to include demand-window masking examples and operational caveats.

Tests:
- Add a dedicated test validating masked vs unmasked capacity-charge behavior, all-zero masks, and warning/fallback handling for invalid capacity_charge_window inputs.
- Extend runtime parameter tests to include capacity_charge_window.