### PR TITLE
fix: tighten the battery identification RTE guardrail to reject near-lossless fits

### DIFF
--- a/src/emhass/battery_identification.py
+++ b/src/emhass/battery_identification.py
@@ -88,7 +88,9 @@ CAPACITY_SANITY_HIGH = 1.5
 ABS_CAPACITY_LOW_WH = 200.0
 ABS_CAPACITY_HIGH_WH = 500000.0
 SQRT_RTE_LOW = 0.80  # one-way efficiency = sqrt(RTE) plausible range
-SQRT_RTE_HIGH = 0.999
+# No real AC-coupled pack is near-lossless: a one-way efficiency above 0.995
+# (RTE > 0.99) is a sampling artifact, not physics (#1069).
+SQRT_RTE_HIGH = 0.995
 
 # Energy-balance cross-check is only meaningful over an approximately CLOSED
 # window: if the net SoC drift is large relative to the total SoC swung, the
@@ -595,7 +597,7 @@ class BatteryIdentification:
         if not (SQRT_RTE_LOW <= eta <= SQRT_RTE_HIGH):
             result.status = "rejected_sanity_check"
             result.messages.append(
-                f"One-way efficiency sqrt(RTE)={eta:.3f} outside "
+                f"One-way efficiency sqrt(RTE)={eta:.4f} outside "
                 f"[{SQRT_RTE_LOW}, {SQRT_RTE_HIGH}]; keeping configured values."
             )
             return result

--- a/tests/test_battery_identification.py
+++ b/tests/test_battery_identification.py
@@ -182,6 +182,27 @@ class TestBatteryIdentification(unittest.TestCase):
         self.assertEqual(res.status, "rejected_sanity_check")
         self.assertFalse(res.is_ok)
 
+    def test_near_lossless_rte_rejected(self):
+        # The #1069 case: change-only sampling produced a fit with RTE 0.991
+        # (one-way sqrt 0.9955) on a pack independently metered at 0.83
+        # round-trip efficiency. No real AC-coupled pack is that close to
+        # lossless, so the efficiency guardrail must reject it rather than
+        # publish. Asserting on the message pins the rejection to the
+        # efficiency band, not the separate RTE > 1 gate.
+        df = _make_history(10000.0, 0.991, n_cycles=6)
+        res = self._identify(df)
+        self.assertEqual(res.status, "rejected_sanity_check", msg=str(res.messages))
+        self.assertFalse(res.is_ok)
+        self.assertTrue(any("sqrt(RTE)" in m for m in res.messages), msg=str(res.messages))
+
+    def test_plausible_high_rte_still_passes(self):
+        # Counterfactual pin for the bound location: RTE 0.988 (one-way sqrt
+        # 0.994) sits just below SQRT_RTE_HIGH and must still publish.
+        df = _make_history(10000.0, 0.988, n_cycles=6)
+        res = self._identify(df)
+        self.assertEqual(res.status, "ok", msg=str(res.messages))
+        self.assertTrue(res.is_ok)
+
     # -- default-no-op sanity: to_dict is JSON-serialisable scalars -----------
     def test_result_to_dict_is_scalar_json(self):
         import json


### PR DESCRIPTION
Closes #1069. This is option 1 from that issue, the one greenlit as the first step.

## What changed

`SQRT_RTE_HIGH` goes from 0.999 to 0.995 in `battery_identification.py`. That's the upper bound on the one-way efficiency sqrt(RTE) a fit is allowed to publish with. No real AC-coupled pack sits above 0.995 one-way (RTE > 0.99), so anything up there is a sampling artifact, not physics.

The motivating case is @volschin's acceptance run on #1063: with the gap fix in place his 26-day fit passed every guardrail at RTE 0.991 (one-way 0.9955), against an independently metered cycle efficiency of 83.2% for the same pack. Under `trust_tier: suggest` that fit produces a recommendation to set both efficiency params to ~0.995, and an optimizer fed ~0.99 where the truth is ~0.83 will over-cycle the battery because cycling looks nearly free. With this change that fit lands `rejected_sanity_check` and the configured values stay in place.

One side tweak in the same block: the rejection message now prints the efficiency with 4 decimals instead of 3. At the new bound a rejected 0.9955 would otherwise print as "0.995 outside [0.8, 0.995]", which reads like a contradiction.

## Behaviour change, disclosed

Fits with one-way efficiency in (0.995, 0.999] flipped from publishable to rejected. That's the entire point of the issue, but it does mean a setup that was getting a (wrong) published RTE in that band will now keep its configured values and log the rejection. The only setup I could imagine legitimately living in that band is a DC-side power sensor on a genuinely high-RTE pack, and I couldn't construct a plausible example, same as in the issue discussion.

Everything else is untouched: the lower bound, the capacity sanity bands, the CI and divergence gates, and the energy-balance cross-check (still informational).

## Tests

- `test_near_lossless_rte_rejected`: volschin's exact numbers (RTE 0.991, one-way 0.9955) must land `rejected_sanity_check`, and the message assert pins the rejection to the efficiency band rather than the separate RTE > 1 gate. Fails on master, which publishes `ok` for that fit.
- `test_plausible_high_rte_still_passes`: RTE 0.988 (one-way 0.994), just below the new bound, must still publish. Pins the bound location from below.

Full suite green locally.

Option 2 from the issue (making suspiciously close slope-ratio vs energy-balance agreement count against the fit) stays open for a later step, per the discussion there.

## Summary by Sourcery

Tighten the battery identification efficiency guardrail to reject near-lossless round-trip efficiency fits and ensure unrealistic results do not get published.

Bug Fixes:
- Prevent publishing of battery fits with implausibly high one-way efficiency by lowering the upper sqrt(RTE) sanity bound.
- Clarify rejection logs by increasing the printed precision of the one-way efficiency value in sanity check messages.

Tests:
- Add regression tests ensuring near-lossless efficiency fits are rejected and plausible high-efficiency fits still pass under the new bound.