### PR TITLE
fix: size the mlforecaster load forecast history retrieval from the trained model's lags (#1067)

### DIFF
--- a/docs/mlforecaster.md
+++ b/docs/mlforecaster.md
@@ -245,6 +245,11 @@ The hyperparameter tuning using Bayesian optimization improves the bare KNN regr
 The tuning routine can be computing intense. If you have problems with computation times, try to reduce the `historic_days_to_retrieve` parameter. In the example shown, for a 240-day train period, the optimization routine took almost 20 min to finish on an amd64 Linux architecture machine with an i5 processor and 8 GB of RAM. This is a task that should be performed once in a while, for example, every week.
 ```
 
+```{note}
+
+When the model is used inside an optimization run (`load_forecast_method: mlforecaster` with `dayahead-optim` or `naive-mpc-optim`), EMHASS automatically retrieves enough recent load history to fill the model's last window: at least as many past samples as the model has lags. For example, a tuned model with 144 lags at a 30 min time step needs 3 days of history. Make sure your Home Assistant recorder (`purge_keep_days`) retains at least that much history for the load sensor, otherwise the forecast will abort with an explicit error.
+```
+
 ## How does this work? 
 This machine learning forecast class is based on the `skforecast` module. 
 We use the recursive autoregressive forecaster with added features. 

--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -20,6 +20,7 @@ except ImportError:  # Windows
 
 
 import logging
+import math
 import os
 import pickle
 import pickle as cPickle
@@ -1986,27 +1987,79 @@ class Forecast:
         )
         return await self.get_weather_covariates(future_index, weather_features)
 
-    async def _get_load_forecast_ml(
-        self, df: pd.DataFrame, use_last_window: bool, mlf, debug: bool
-    ) -> pd.DataFrame | bool:
-        """Helper for ML forecast."""
+    async def _load_mlf_model(self, mlf, debug: bool) -> MLForecaster | bool:
+        """Resolve the MLForecaster instance to use for the load forecast.
+
+        In production (``debug=False``) the model is read from the saved pickle
+        file; in debug/unit-test mode the passed ``mlf`` object is used as-is.
+        Returns False when the pickle file is missing.
+        """
+        if debug:
+            return mlf
         model_type = self.params["passed_data"]["model_type"]
         filename = model_type + "_mlf.pkl"
         filename_path = self.emhass_conf["data_path"] / filename
-        if not debug:
-            if filename_path.is_file():
-                async with aiofiles.open(filename_path, "rb") as inp:
-                    content = await inp.read()
-                    mlf = pickle.loads(content)
-            else:
-                self.logger.error(
-                    "The ML forecaster file was not found, please run a model fit method before this predict method"
-                )
-                return False
+        if not filename_path.is_file():
+            self.logger.error(
+                "The ML forecaster file was not found, please run a model fit method before this predict method"
+            )
+            return False
+        async with aiofiles.open(filename_path, "rb") as inp:
+            content = await inp.read()
+            return pickle.loads(content)
+
+    @staticmethod
+    def _mlf_window_size(mlf) -> int:
+        """Return the number of observed samples the fitted model needs as its last window.
+
+        skforecast's ``forecaster.window_size`` is authoritative: it equals the
+        largest lag, which can exceed ``len(lags)`` when the lags are not
+        contiguous. Fall back to ``lags_opt``/``num_lags`` for model objects
+        without a fitted forecaster attached.
+        """
+        window_size = getattr(getattr(mlf, "forecaster", None), "window_size", None)
+        if window_size is None and getattr(mlf, "is_tuned", False):
+            window_size = getattr(mlf, "lags_opt", None)
+        if window_size is None:
+            window_size = mlf.num_lags
+        return int(window_size)
+
+    def _mlf_required_history_days(self, mlf, days_min_load_forecast: int) -> int:
+        """Days of history to retrieve so the model's last window can be filled.
+
+        Sized from the model's real lag requirement at the optimization time
+        step, never below ``days_min_load_forecast``. One extra day covers
+        DST-short days and minor recorder gaps.
+        """
+        window_size = self._mlf_window_size(mlf)
+        samples_per_day = max(1, int(pd.Timedelta(days=1) / self.freq))
+        needed_days = math.ceil(window_size / samples_per_day) + 1
+        return max(days_min_load_forecast, needed_days)
+
+    async def _get_load_forecast_ml(
+        self, df: pd.DataFrame, use_last_window: bool, mlf, debug: bool
+    ) -> pd.DataFrame | bool:
+        """Helper for ML forecast.
+
+        ``mlf`` is the already-loaded model: ``get_load_forecast`` reads the
+        pickle before the history retrieval (see ``_load_mlf_model``) so the
+        retrieval window can be sized from the model's lag requirement.
+        """
         data_last_window = None
         if use_last_window:
             data_last_window = copy.deepcopy(df)
             data_last_window = data_last_window.rename(columns={self.var_load_new: self.var_load})
+            window_size = self._mlf_window_size(mlf)
+            if len(data_last_window) < window_size:
+                self.logger.error(
+                    "Not enough load history to fill the ML forecaster's last window: "
+                    f"the model needs {window_size} samples at {self.freq} "
+                    f"but only {len(data_last_window)} were retrieved. Check that the "
+                    "Home Assistant recorder (or database) retains at least "
+                    f"{self._mlf_required_history_days(mlf, 0)} days of history for "
+                    f"{self.retrieve_hass_conf['sensor_power_load_no_var_loads']}."
+                )
+                return False
         # When the model was trained with weather covariates, supply the future weather over the
         # forecast horizon so the recursive predict has the exog columns it expects.
         weather_future = await self._build_weather_future(data_last_window, mlf)
@@ -2077,7 +2130,10 @@ class Forecast:
         Get and generate the load forecast data.
 
         :param days_min_load_forecast: The number of last days to retrieve that \
-            will be used to generate a naive forecast, defaults to 3
+            will be used to generate a naive forecast, defaults to 3. For the \
+            'mlforecaster' method this is a lower bound: the retrieval window is \
+            automatically enlarged to cover the trained model's last-window \
+            requirement (its lags) when needed.
         :type days_min_load_forecast: int, optional
         :param method: The method to be used to generate load forecast, the options \
             are 'typical' for a typical household load consumption curve, \
@@ -2111,6 +2167,19 @@ class Forecast:
         csv_path = self.emhass_conf["data_path"] / csv_path
         # Retrieve Data from Home Assistant if needed
         df = None
+        if method == "mlforecaster":
+            # Load the trained model BEFORE the history retrieval so the retrieval
+            # window can be sized from the model's real lag requirement (#1067):
+            # the optimization callers size days_min_load_forecast from
+            # delta_forecast_daily, which says nothing about how many past samples
+            # the (possibly tuned) auto-regressive model needs as its last window.
+            mlf = await self._load_mlf_model(mlf, debug)
+            if mlf is False:
+                return False
+            if use_last_window:
+                days_min_load_forecast = self._mlf_required_history_days(
+                    mlf, days_min_load_forecast
+                )
         if method in ["naive", "mlforecaster"]:
             df = await self._prepare_hass_load_data(days_min_load_forecast, method)
             if df is False:

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -3196,6 +3196,250 @@ class TestForecastDatesTieAlignment(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(fcst.forecast_dates.is_unique)
 
 
+class _FakeRecorderRetrieveHass:
+    """Stand-in for RetrieveHass simulating a recorder with a bounded history.
+
+    ``get_data`` synthesizes ``min(requested, available_days)`` full days of
+    30-min load samples (no partial "today", the conservative case), so the
+    number of samples the forecaster receives is a deterministic function of the
+    days the caller asked for -- which is exactly what the #1067 fix must size
+    correctly. The class records the last constructed instance and the requested
+    day count for assertions.
+    """
+
+    last_instance = None
+    available_days = None  # None = recorder has whatever is asked for
+
+    def __init__(self, hass_url, long_lived_token, freq, time_zone, params, emhass_conf, logger):
+        self.freq = freq
+        self.time_zone = time_zone
+        self.requested_days = None
+        self.df_final = None
+        type(self).last_instance = self
+
+    async def get_data(self, days_list, var_list, **kwargs):
+        # get_days_list(N) yields N prior days + today, i.e. N+1 stamps.
+        self.requested_days = len(days_list) - 1
+        self._var = var_list[0]
+        available = type(self).available_days
+        n_days = self.requested_days if available is None else min(self.requested_days, available)
+        samples_per_day = int(pd.Timedelta(days=1) / self.freq)
+        periods = max(1, n_days * samples_per_day)
+        end = pd.Timestamp.now(tz=self.time_zone).floor(self.freq)
+        index = pd.date_range(end=end, periods=periods, freq=self.freq)
+        values = 500.0 + 200.0 * np.sin(np.arange(periods) * 2 * np.pi / samples_per_day)
+        self.df_final = pd.DataFrame({self._var: values}, index=index)
+        return True
+
+    def prepare_data(self, var_load, **kwargs):
+        self.df_final = self.df_final.rename(columns={self._var: var_load + "_positive"})
+        return True
+
+
+class TestMlforecasterLastWindowSizing(unittest.IsolatedAsyncioTestCase):
+    """The mlforecaster load-forecast history retrieval is sized from the model (#1067).
+
+    The optimization callers (naive-mpc-optim, dayahead-optim) pass
+    ``days_min_load_forecast = delta_forecast_daily.days`` (default 1), which
+    says nothing about how many past samples the auto-regressive model needs as
+    its skforecast ``last_window``. A model with 144 lags at a 30-min step needs
+    3 days of history, so every optimization run used to die inside skforecast
+    with "`last_window` must have as many values as needed to generate the
+    predictors". The retrieval window must be sized from the loaded model, and a
+    still-too-short history must abort with a clear error instead of a raw
+    skforecast ValueError.
+    """
+
+    async def asyncSetUp(self):
+        params = await TestForecast.get_test_params()
+        params_json = orjson.dumps(params).decode("utf-8")
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+        self.retrieve_hass_conf = retrieve_hass_conf
+        self.optim_conf = optim_conf
+        self.plant_conf = plant_conf
+        self.params = params
+        self.var_load = retrieve_hass_conf["sensor_power_load_no_var_loads"]
+        self.time_zone = retrieve_hass_conf["time_zone"]
+        _FakeRecorderRetrieveHass.last_instance = None
+        _FakeRecorderRetrieveHass.available_days = None
+
+    def _build_forecast(self):
+        """A Forecast wired for a live (non-file) retrieval path."""
+        fcst = Forecast(
+            self.retrieve_hass_conf,
+            self.optim_conf,
+            self.plant_conf,
+            copy.deepcopy(self.params),
+            emhass_conf,
+            logger,
+            get_data_from_file=False,
+        )
+        # The ml path resolves the pickle filename from passed_data["model_type"]
+        # (and pre-fix code read it even in debug mode); the default test params
+        # do not carry one.
+        fcst.params["passed_data"]["model_type"] = "test_1067"
+        return fcst
+
+    async def _fit_mlf(self, num_lags, train_days=14):
+        """Fit a real KNN MLForecaster with ``num_lags`` on synthetic 30-min data."""
+        samples = train_days * 48
+        index = pd.date_range(
+            start=pd.Timestamp("2024-06-01", tz=self.time_zone),
+            periods=samples,
+            freq=pd.Timedelta("30min"),
+        )
+        rng = np.random.default_rng(1067)
+        values = (
+            500.0 + 200.0 * np.sin(np.arange(samples) * 2 * np.pi / 48) + rng.normal(0, 20, samples)
+        )
+        data = pd.DataFrame({self.var_load: values}, index=index)
+        mlf = MLForecaster(
+            data,
+            "test_1067",
+            self.var_load,
+            "KNeighborsRegressor",
+            num_lags,
+            emhass_conf,
+            logger,
+        )
+        await mlf.fit()
+        return mlf
+
+    async def _run_ml_forecast(self, fcst, mlf, days_min):
+        """Run the mlforecaster load forecast against the fake recorder.
+
+        RetrieveHass is patched at the module-class level because
+        _prepare_hass_load_data constructs its own instance internally --
+        there is no narrower seam to inject the fake through. Returns the
+        forecast result, or the raised ValueError (the base failure mode) so
+        assertions fail on behaviour rather than error out.
+        """
+        with unittest.mock.patch.object(forecast_module, "RetrieveHass", _FakeRecorderRetrieveHass):
+            try:
+                return await fcst.get_load_forecast(
+                    days_min_load_forecast=days_min,
+                    method="mlforecaster",
+                    use_last_window=True,
+                    debug=True,
+                    mlf=mlf,
+                )
+            except ValueError as e:
+                return e
+
+    async def test_history_retrieval_sized_from_model_lags(self):
+        """A 144-lag model with delta_forecast_daily=1 must still forecast.
+
+        On the unsized retrieval the recorder returns 1 day (48 samples), the
+        model needs 144, and skforecast raises -- the #1067 crash. The fix must
+        enlarge the fetch to ceil(144/48)+1 = 4 days and succeed.
+        """
+        fcst = self._build_forecast()
+        mlf = await self._fit_mlf(num_lags=144)
+
+        result = await self._run_ml_forecast(fcst, mlf, days_min=1)
+
+        self.assertIsInstance(
+            result,
+            pd.Series,
+            f"mlforecaster load forecast failed instead of succeeding: {result!r}",
+        )
+        self.assertEqual(len(result), len(fcst.forecast_dates))
+        self.assertFalse(result.isna().any())
+        # The retrieval was sized from the model, not from delta_forecast_daily.
+        self.assertEqual(_FakeRecorderRetrieveHass.last_instance.requested_days, 4)
+
+    async def test_short_recorder_aborts_cleanly_not_skforecast_error(self):
+        """Recorder retaining less than the model needs -> False, not a raw ValueError."""
+        _FakeRecorderRetrieveHass.available_days = 1  # recorder only has 1 day
+        fcst = self._build_forecast()
+        mlf = await self._fit_mlf(num_lags=144)
+
+        result = await self._run_ml_forecast(fcst, mlf, days_min=1)
+
+        self.assertIs(
+            result,
+            False,
+            f"expected a clean False abort on short history, got: {result!r}",
+        )
+
+    async def test_small_model_keeps_days_min_load_forecast(self):
+        """A model needing less than days_min_load_forecast must not shrink or grow the fetch."""
+        fcst = self._build_forecast()
+        # 52 lags (not 48) so the model can still fill the 50-step horizon of the
+        # 25-hour day before a fall-back DST transition; the sizing under test is
+        # unchanged: ceil(52/48)+1 = 3 days needed, below the days_min of 4.
+        mlf = await self._fit_mlf(num_lags=52)
+
+        result = await self._run_ml_forecast(fcst, mlf, days_min=4)
+
+        self.assertIsInstance(result, pd.Series)
+        self.assertEqual(len(result), len(fcst.forecast_dates))
+        # 3 days needed; days_min=4 is larger and must win.
+        self.assertEqual(_FakeRecorderRetrieveHass.last_instance.requested_days, 4)
+
+    async def test_missing_model_pickle_fails_before_any_retrieval(self):
+        """With no saved model the run must fail before the history fetch happens."""
+        fcst = self._build_forecast()
+        fcst.params["passed_data"]["model_type"] = "no_such_model_1067"
+
+        with unittest.mock.patch.object(forecast_module, "RetrieveHass", _FakeRecorderRetrieveHass):
+            result = await fcst.get_load_forecast(
+                days_min_load_forecast=1,
+                method="mlforecaster",
+                use_last_window=True,
+                debug=False,
+            )
+
+        self.assertIs(result, False)
+        self.assertIsNone(
+            _FakeRecorderRetrieveHass.last_instance,
+            "history retrieval ran despite the model pickle being missing",
+        )
+
+    def test_mlf_window_size_prefers_fitted_forecaster(self):
+        """forecaster.window_size wins over lags_opt/num_lags (non-contiguous lags)."""
+        mlf = unittest.mock.MagicMock()
+        mlf.forecaster.window_size = 144
+        mlf.is_tuned = True
+        mlf.lags_opt = 4  # len(lags) of a non-contiguous [1, 2, 3, 144]
+        mlf.num_lags = 48
+        self.assertEqual(Forecast._mlf_window_size(mlf), 144)
+
+    def test_mlf_window_size_fallbacks(self):
+        """Without a fitted forecaster: lags_opt when tuned, num_lags otherwise."""
+        tuned = unittest.mock.MagicMock()
+        tuned.forecaster = None
+        tuned.is_tuned = True
+        tuned.lags_opt = 96
+        tuned.num_lags = 48
+        self.assertEqual(Forecast._mlf_window_size(tuned), 96)
+
+        untuned = unittest.mock.MagicMock()
+        untuned.forecaster = None
+        untuned.is_tuned = False
+        untuned.num_lags = 48
+        self.assertEqual(Forecast._mlf_window_size(untuned), 48)
+
+    def test_mlf_required_history_days_math(self):
+        """needed_days = ceil(window_size / samples_per_day) + 1, floored at days_min."""
+        fcst = self._build_forecast()
+        mlf = unittest.mock.MagicMock()
+        mlf.forecaster.window_size = 144
+        # 30-min steps: 48/day -> ceil(144/48)+1 = 4
+        fcst.freq = pd.Timedelta("30min")
+        self.assertEqual(fcst._mlf_required_history_days(mlf, 1), 4)
+        # 1-h steps: 24/day -> ceil(144/24)+1 = 7
+        fcst.freq = pd.Timedelta("1h")
+        self.assertEqual(fcst._mlf_required_history_days(mlf, 1), 7)
+        # Non-divisible: 50 lags at 30-min -> ceil(50/48)+1 = 3
+        mlf.forecaster.window_size = 50
+        fcst.freq = pd.Timedelta("30min")
+        self.assertEqual(fcst._mlf_required_history_days(mlf, 1), 3)
+        # days_min larger than the model's need wins.
+        mlf.forecaster.window_size = 24
+        self.assertEqual(fcst._mlf_required_history_days(mlf, 5), 5)
+
+
 if __name__ == "__main__":
     unittest.main()
     ch.close()


### PR DESCRIPTION
Fixes #1067.

## The bug

When `load_forecast_method: mlforecaster` runs inside an optimization (`naive-mpc-optim` or `dayahead-optim`), the load forecast fetches its own history window in `Forecast._prepare_hass_load_data`, and both callers size that window as `delta_forecast_daily.days` (default 1). The trained model is only unpickled after the fetch, so the retrieval knows nothing about how many past samples the auto-regressive model actually needs for its skforecast `last_window`.

With a tuned model at `lags_opt: 144` and a 30 min time step, the model needs 144 samples (3 days) but the fetch returns one day plus part of today, so every optimization run dies inside skforecast:

```
ValueError: `last_window` must have as many values as needed to generate the predictors. For this forecaster it is 144.
```

No config knob can fix it from the outside: `historic_days_to_retrieve` is not used on this path, and tune is free to pick lags (up to 72h of history at the configured step) that the live path can never feed. This is not a 0.18.0 regression. The sizing has been that way for years.

## The fix

All inside `forecast.py`, no new config parameters:

- `get_load_forecast` now loads the mlf pickle before the history retrieval (new `_load_mlf_model` helper, same missing-file error as before) and, when `use_last_window` is set, enlarges the retrieval to `max(days_min_load_forecast, ceil(window_size / samples_per_day) + 1)`. The extra day covers DST-short days and small recorder gaps.
- The window size comes from `forecaster.window_size` (authoritative in skforecast: it equals the largest lag even for non-contiguous lags), falling back to `lags_opt` for tuned models and `num_lags` otherwise.
- `_get_load_forecast_ml` now checks the retrieved history against the model's window size before calling predict. If the recorder holds less than the model needs, the run aborts with a clear error naming the numbers and the sensor instead of a raw skforecast traceback.

Verified against skforecast 0.19.1 that a longer `last_window` produces predictions identical to an exact-size window (only the tail is used), so runs that already had enough history are unaffected.

## Behaviour changes

- The mlforecaster fetch can now retrieve more days than `delta_forecast_daily` (that is the fix). Recorder queries on this path get proportionally longer for large-lag models. This also applies to the default untuned config: `num_lags: 48` at 30 min with `delta_forecast_daily: 1` now fetches 2 days instead of 1, which is what makes runs just after midnight (almost no samples from today yet) reliable.
- A missing model pickle now fails before the history fetch instead of after it (same error message, cheaper failure).
- Insufficient recorder history now returns a logged error and aborts the optimization cleanly instead of raising the skforecast ValueError.

The `naive`, `typical`, `csv` and `list` methods are untouched, as is the `forecast-model-predict` endpoint (that path is sized by `historic_days_to_retrieve`, which the user controls).

## Tests

New `TestMlforecasterLastWindowSizing` in `tests/test_forecast.py`, running a real fitted `MLForecaster` against a fake recorder whose returned history is a deterministic function of the days requested:

- a 144-lag model with `delta_forecast_daily: 1` now forecasts (fails on master with the exact `last_window` ValueError above, proven red on base)
- a recorder retaining less than the model needs aborts with False, not a raw ValueError
- a small model keeps `days_min_load_forecast` as the floor (no fetch enlargement)
- a missing pickle fails before any retrieval happens
- unit coverage for the window-size source order and the sizing math at 30 min and 1 h steps

Full suite: 987 passed / 32 xfailed locally (980 baseline + 7 new).

Docs: added a note to `docs/mlforecaster.md` about the recorder retention this path needs.

@Lumme78 you mentioned you could test on your InfluxDB setup with the 450 days of history. That would be a great real-world check of this exact path if you're still up for it: check out this branch, keep your tuned `num_lags: 144` model, and run `naive-mpc-optim` with your normal `delta_forecast_daily`. It should now retrieve 4 days and produce a forecast.

## Summary by Sourcery

Align mlforecaster load forecast history retrieval with the trained model’s lag requirements to avoid skforecast last_window errors during optimizations.

New Features:
- Automatically size mlforecaster load history retrieval based on the model’s effective window size and the optimization time step when use_last_window is enabled.

Bug Fixes:
- Prevent mlforecaster-based optimizations from failing with skforecast last_window ValueError by ensuring sufficient historical samples are retrieved for large-lag models.
- Ensure missing ML forecaster pickle files cause an immediate, clean failure before any recorder access.
- Handle cases where the recorder retains too little history by aborting the forecast cleanly with a clear error message instead of propagating skforecast exceptions.

Enhancements:
- Introduce helpers to derive the ML forecaster’s required window size and corresponding history duration from the fitted model and configuration.
- Add validation that the retrieved history length meets the model’s last-window requirement before running predictions.
- Clarify in get_load_forecast docs that days_min_load_forecast is a lower bound for mlforecaster and may be increased automatically to satisfy model lag needs.

Documentation:
- Document recorder retention requirements for using mlforecaster within optimization runs, including guidance on necessary history duration for large-lag models.

Tests:
- Add TestMlforecasterLastWindowSizing suite to validate history sizing logic, model window-size derivation, clean failure modes, and edge cases across different lag counts and time steps.