### PR TITLE
fix: build the csv/list forecast grid from the frozen start instead of re-reading the clock (#1076)

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -1546,27 +1546,13 @@ class Forecast:
         :rtype: pd.date_range
 
         """
-        start_forecast_csv = pd.Timestamp.now(tz=self.time_zone).replace(microsecond=0)
-        if self.method_ts_round == "nearest":
-            # Same start alignment as __init__: round once in UTC so the built
-            # range needs no stamp-by-stamp round (see the comment there).
-            start_forecast_csv = (
-                pd.Timestamp.now(tz=self.time_zone)
-                .replace(microsecond=0)
-                .tz_convert("utc")
-                .round(self.freq)
-                .tz_convert(self.time_zone)
-            )
-        elif self.method_ts_round == "first":
-            start_forecast_csv = (
-                pd.Timestamp.now(tz=self.time_zone).replace(microsecond=0).floor(freq=self.freq)
-            )
-        elif self.method_ts_round == "last":
-            start_forecast_csv = (
-                pd.Timestamp.now(tz=self.time_zone).replace(microsecond=0).ceil(freq=self.freq)
-            )
-        else:
-            self.logger.error("Wrong method_ts_round passed parameter")
+        # Reuse the start stamp frozen in __init__ rather than reading the clock
+        # again. Data prep between the two calls takes seconds, so a re-read that
+        # lands the other side of a rounding boundary builds a grid one step off
+        # from the one df_final is indexed on, and the strict lookup in
+        # _extract_daily_forecast then raises KeyError (issue #1076). The
+        # rounding itself still happens exactly once, in __init__.
+        start_forecast_csv = self.start_forecast
         end_forecast_csv = (
             start_forecast_csv + pd.DateOffset(days=self.optim_conf["delta_forecast_daily"].days)
         ).replace(microsecond=0)

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1490,11 +1490,10 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
         ``_pin_forecast_to_date``, so exact slot counts are asserted.
 
         ``get_load_cost_forecast`` and ``get_prod_price_forecast`` with
-        method="list" both internally call ``get_forecast_days_csv()`` which
-        uses wall-clock time rather than ``self.start_forecast``.  Pinning
-        those would require mocking ``pd.Timestamp.now`` throughout; instead
-        we just verify they do not raise and produce a DataFrame with the
-        expected columns.
+        method="list" internally call ``get_forecast_days_csv()``.  That used to
+        read the wall clock, so neither could be pinned here and both were left
+        out; since #1076 it builds from ``self.start_forecast``, which
+        ``_pin_forecast_to_date`` sets, so their slot counts are asserted too.
         """
         p_pv_forecast = await fcst.get_weather_forecast(method="list")
         self.assertIsInstance(p_pv_forecast, pd.DataFrame)
@@ -1515,11 +1514,25 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(p_load_forecast.values[0], 1)
         self.assertEqual(p_load_forecast.values[-1], expected_last)
 
-        # get_load_cost_forecast and get_prod_price_forecast with method="list"
-        # call get_forecast_days_csv() which always uses wall-clock time and
-        # therefore cannot be pinned to a fixed date without mocking
-        # pd.Timestamp.now globally.  Those code paths are not relevant to the
-        # DST list-trimming fix validated here, so they are omitted.
+        # The two list-priced paths, now that the pinned start reaches them.
+        df_input = pd.DataFrame(
+            {
+                "p_pv_forecast": p_pv_forecast.values[:, 0],
+                "p_load_forecast": p_load_forecast.values,
+            },
+            index=p_pv_forecast.index,
+        )
+        df_cost = fcst.get_load_cost_forecast(df_input, method="list")
+        self.assertEqual(len(df_cost), expected_last)
+        self.assertEqual(df_cost[fcst.var_load_cost].isna().sum(), 0)
+        self.assertEqual(df_cost[fcst.var_load_cost].values[0], 1)
+        self.assertEqual(df_cost[fcst.var_load_cost].values[-1], expected_last)
+
+        df_price = fcst.get_prod_price_forecast(df_cost, method="list")
+        self.assertEqual(len(df_price), expected_last)
+        self.assertEqual(df_price[fcst.var_prod_price].isna().sum(), 0)
+        self.assertEqual(df_price[fcst.var_prod_price].values[0], 1)
+        self.assertEqual(df_price[fcst.var_prod_price].values[-1], expected_last)
 
     async def test_get_forecasts_with_longer_lists_summer(self):
         """3-day list forecast in summer (no DST transition): exactly 3×48 slots."""
@@ -3194,6 +3207,154 @@ class TestForecastDatesTieAlignment(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(fcst.forecast_dates[0], expected_start)
         self.assertEqual(len(fcst.forecast_dates), 24)
         self.assertTrue(fcst.forecast_dates.is_unique)
+
+
+class TestForecastDaysCsvStartAlignment(unittest.IsolatedAsyncioTestCase):
+    """The csv/list forecast grid must match the one the input data is indexed on.
+
+    ``Forecast.__init__`` freezes ``self.start_forecast`` (and ``forecast_dates``)
+    from the clock at set-input-data time. ``get_forecast_days_csv`` used to read
+    the clock a second time and round it again, so a run whose data prep straddled
+    a rounding boundary built a grid one step off from ``df_final``. The strict
+    lookup in ``_extract_daily_forecast`` then raised
+    ``KeyError: [Timestamp(...)] not in index`` naming the stamp one step behind
+    (issue #1076, reported at 15 min/"first" and again at 30 min/"nearest").
+    """
+
+    TZ = "Europe/Brussels"
+    HORIZON = 10
+
+    async def asyncSetUp(self):
+        import pytz
+
+        self.params = await TestForecast.get_test_params()
+        self.params["passed_data"]["prediction_horizon"] = self.HORIZON
+        self.params["passed_data"]["load_cost_forecast"] = [0.25] * 200
+        self.params["passed_data"]["prod_price_forecast"] = [0.05] * 200
+        params_json = orjson.dumps(self.params).decode("utf-8")
+        retrieve_hass_conf, optim_conf, plant_conf = utils.get_yaml_parse(params_json, logger)
+        retrieve_hass_conf["optimization_time_step"] = pd.to_timedelta(15, "minutes")
+        retrieve_hass_conf["time_zone"] = pytz.timezone(self.TZ)
+        self.retrieve_hass_conf = retrieve_hass_conf
+        self.optim_conf = optim_conf
+        self.plant_conf = plant_conf
+        self.params_json = params_json
+
+    @staticmethod
+    def _pinned_now(now_local, tz_name):
+        """Patch only ``pd.Timestamp.now``, fixed to one instant.
+
+        ``Forecast`` has no injected clock seam to patch instead, so ``now``
+        itself is the narrowest available target; every other use of
+        ``Timestamp`` keeps its real behaviour. Unlike
+        ``TestForecastDatesTieAlignment._build_forecast``, which patches only
+        for the duration of construction, this returns the context manager so
+        a single test can pin two instants in turn: one for ``__init__``, one
+        for the later call that exposes the skew.
+        """
+        real_timestamp = pd.Timestamp
+        fixed_utc = real_timestamp(now_local, tz=tz_name).tz_convert("UTC")
+
+        def _now(tz=None):
+            return fixed_utc.tz_convert(tz) if tz is not None else fixed_utc.tz_localize(None)
+
+        return unittest.mock.patch.object(pd.Timestamp, "now", staticmethod(_now))
+
+    def _build(self, init_now, method_ts_round="first"):
+        conf = copy.deepcopy(self.retrieve_hass_conf)
+        conf["method_ts_round"] = method_ts_round
+        with self._pinned_now(init_now, self.TZ):
+            return Forecast(
+                conf,
+                self.optim_conf,
+                self.plant_conf,
+                self.params_json,
+                emhass_conf,
+                logger,
+                get_data_from_file=True,
+            )
+
+    def _dayahead_input(self, fcst):
+        """Mirrors df_input_data_dayahead: indexed on the frozen forecast dates."""
+        return pd.DataFrame(
+            {"p_pv_forecast": 0.0, "p_load_forecast": 500.0},
+            index=fcst.forecast_dates[: self.HORIZON],
+        )
+
+    def test_grid_start_is_the_frozen_start_not_the_clock(self):
+        """The returned grid starts at ``self.start_forecast`` however late it is called."""
+        fcst = self._build("2026-08-16 17:44:55")
+        # Call it a full step later than construction: the old builder rounded
+        # this second read to 17:45 and started the grid there instead.
+        with self._pinned_now("2026-08-16 17:45:09", self.TZ):
+            dates = fcst.get_forecast_days_csv(timedelta_days=0)
+        self.assertEqual(dates[0], fcst.start_forecast)
+        self.assertTrue(dates.equals(fcst.forecast_dates[: self.HORIZON]))
+
+    def test_boundary_straddle_does_not_raise(self):
+        """Init at 17:44:55 (floors to 17:30), load-cost call at 17:45:09 (floors to 17:45)."""
+        fcst = self._build("2026-08-16 17:44:55")
+        df = self._dayahead_input(fcst)
+        self.assertEqual(str(df.index[0]), "2026-08-16 17:30:00+02:00")
+        with self._pinned_now("2026-08-16 17:45:09", self.TZ):
+            out = fcst.get_load_cost_forecast(df, method="list")
+        self.assertEqual(len(out), self.HORIZON)
+        self.assertTrue(out.index.equals(df.index))
+        self.assertEqual(out[fcst.var_load_cost].isna().sum(), 0)
+        self.assertTrue((out[fcst.var_load_cost] == 0.25).all())
+
+    def test_boundary_straddle_does_not_raise_prod_price(self):
+        """The production-price list path shares the builder and the strict lookup."""
+        fcst = self._build("2026-08-16 17:44:55")
+        df = self._dayahead_input(fcst)
+        with self._pinned_now("2026-08-16 17:45:09", self.TZ):
+            out = fcst.get_prod_price_forecast(df, method="list")
+        self.assertEqual(len(out), self.HORIZON)
+        self.assertEqual(out[fcst.var_prod_price].isna().sum(), 0)
+
+    def test_nearest_half_hour_tie_boundary(self):
+        """The reporter's second config: 30 min steps, "nearest", crash only on the :15 run.
+
+        Round-half-to-even sends :15:00 down to the hour and :45:00 up, so only a
+        run firing at :15 has its two clock reads disagree.
+        """
+        self.retrieve_hass_conf["optimization_time_step"] = pd.to_timedelta(30, "minutes")
+        fcst = self._build("2026-08-17 08:15:00", method_ts_round="nearest")
+        df = self._dayahead_input(fcst)
+        with self._pinned_now("2026-08-17 08:15:44", self.TZ):
+            out = fcst.get_load_cost_forecast(df, method="list")
+        self.assertEqual(len(out), self.HORIZON)
+        self.assertTrue(out.index.equals(df.index))
+
+    def test_perfect_optim_list_path_prices_are_not_shifted(self):
+        """The silent case: ``list_and_perfect`` never raises, it just mis-prices.
+
+        The perfect-optim list path slices with ``between_time`` instead of the
+        strict ``.loc``, so a straddling run came back the right length with the
+        wrong values and nothing to notice: on master the tail repeats
+        (``[0.17, 0.18, 0.18]``) where it should read ``[0.17, 0.18, 0.19]``.
+        """
+        prices = [round(0.10 + 0.01 * i, 2) for i in range(200)]
+        self.params["passed_data"]["load_cost_forecast"] = prices
+        self.params_json = orjson.dumps(self.params).decode("utf-8")
+        fcst = self._build("2026-08-16 17:44:55")
+        df = self._dayahead_input(fcst)
+        with self._pinned_now("2026-08-16 17:45:09", self.TZ):
+            out = fcst.get_load_cost_forecast(df, method="list", list_and_perfect=True)
+        self.assertEqual(len(out), self.HORIZON)
+        # The frozen grid starts at slot 0 of the list, so the horizon is the
+        # first HORIZON prices in order, with no repeated tail value.
+        self.assertEqual(list(out[fcst.var_load_cost]), prices[: self.HORIZON])
+
+    def test_same_step_call_is_unchanged(self):
+        """Counterfactual: both reads inside one step behaved correctly before and after."""
+        fcst = self._build("2026-08-16 17:44:45")
+        df = self._dayahead_input(fcst)
+        with self._pinned_now("2026-08-16 17:44:58", self.TZ):
+            out = fcst.get_load_cost_forecast(df, method="list")
+        self.assertEqual(len(out), self.HORIZON)
+        self.assertTrue(out.index.equals(df.index))
+        self.assertTrue((out[fcst.var_load_cost] == 0.25).all())
 
 
 class _FakeRecorderRetrieveHass:


### PR DESCRIPTION
Fixes #1076.

## The bug

`Forecast.__init__` freezes `self.start_forecast` and `self.forecast_dates` from `pd.Timestamp.now()` when the input data dict is built. `get_forecast_days_csv` then read the clock a second time and re-applied the `method_ts_round` rounding to build its own grid. Data prep between those two reads (HA history retrieval, weather forecast) takes seconds, so a run that crosses a rounding boundary in that gap ends up with two grids one step apart. `_extract_daily_forecast` does a strict `df_csv.loc[fcst_index]` against the input frame, and the lookup raises

```
KeyError: "[Timestamp('2026-08-16 17:30:00+0200', tz='Europe/Brussels')] not in index"
```

naming the stamp one step behind the crash time. Two reporters hit it from different configs: @RikBast on 15 minute steps with `method_ts_round: "first"` (sporadic, boundary at the step edge), and @JoshC1994 on 30 minute steps with `nearest`, where round-half-to-even sends `:15:00` down and `:45:00` up so only the `:15` run has its two reads disagree. That gave him one crash an hour, always naming the top of the hour, 45 times in 45 hours.

It is not a 0.18.x regression. The same strict lookup and the same double clock read are in v0.17.0.

The crash is the visible half. The quieter half is that the same skew mis-prices the perfect-optim path without raising anything. See the disclosure list below.

## The fix

`get_forecast_days_csv` reuses the already-frozen `self.start_forecast` instead of reading the clock again. The rounding still happens, once, in `__init__`. Consistency with `df_final` is what the strict lookup actually needs, and this gives it by construction: if the frozen stamp were stale, the input frame would be equally stale, so the two cannot drift apart.

The removed block was a verbatim copy of the alignment that `__init__` already runs, so this deletes a duplicate rather than moving logic around.

## Behaviour changes, disclosed

- A run that straddles a boundary now returns a grid anchored one step earlier than the old builder produced, matching the frame it is being merged into. That is the fix, but it is a real change in what comes back rather than only the removal of an exception.
- Runs that do not straddle a boundary are unaffected. The two grids were already identical there.
- The deleted block carried its own `else: self.logger.error("Wrong method_ts_round passed parameter")`, which was unreachable. An invalid value leaves `self.start_forecast` unset in `__init__`, and the first use of it a few lines later raises `AttributeError`, so construction never gets far enough for this branch to run.
- The perfect-optim list path (`list_and_perfect=True`) slices with `between_time` rather than the strict `.loc`, so a straddling run never raised. It returned the right number of rows with the wrong values: on master the tail repeats, `[0.17, 0.18, 0.18]` where the list says `[0.17, 0.18, 0.19]`. That is silently mis-priced input to a perfect optimization, and it is fixed here too. CSV data with no usable timestamp column has the same exposure through a different branch of the same function, though nothing here tests that case.
- A CSV that carries its own timestamp column is unaffected either way: that path never consults the built grid.

## Alternative considered

Swapping the strict `.loc` for `.reindex(fcst_index)` was raised in the issue. It is worse than it looks: the NaN row survives the merge and reaches `self.param_load_cost.value` in `optimization.py`, where cvxpy rejects it with `ValueError: Parameter value must be real`. That trades a `KeyError` naming the forecast grid for a `ValueError` inside solver setup, so it relocates the failure rather than fixing it.

## Tests

New `TestForecastDaysCsvStartAlignment` in `tests/test_forecast.py`, pinning `pd.Timestamp.now` on either side of a boundary the same way the tie-second tests from #1064 do:

- `test_grid_start_is_the_frozen_start_not_the_clock` - the returned grid starts at `self.start_forecast` however late it is called.
- `test_boundary_straddle_does_not_raise` - RikBast's config and crash instant, asserting the full horizon comes back with no NaN. The constructor time is reconstructed: the KeyError pins it to somewhere in 17:30-17:45, his log does not record it.
- `test_boundary_straddle_does_not_raise_prod_price` - the production-price list path, which shares the builder and the strict lookup.
- `test_nearest_half_hour_tie_boundary` - JoshC1994's config, 30 minutes and `nearest` at `:15`. On master this raises naming the top of the hour, which is the signature from his logs.
- `test_perfect_optim_list_path_prices_are_not_shifted` - the silent case above, asserting the values rather than just that nothing raised.
- `test_same_step_call_is_unchanged` - counterfactual: both reads inside one step. Passes on master too, so the set cannot false-green.

On master three of those raise the reported `KeyError` and two fail on value assertions; the counterfactual passes on both.

The existing `_assert_longer_lists_forecast` helper also gains the two paths it had to leave out. Its comment said `get_forecast_days_csv` read wall-clock time and so could not be pinned, which was true and is the same root cause fixed here. With the frozen start it is pinned by `_pin_forecast_to_date` like everything else in that helper, so the four DST list tests now assert exact slot counts and no NaN for load cost and production price as well. All four fail on master.

Full suite on the branch: 995 passed, 32 xfailed.

## Summary by Sourcery

Use the initialization-time forecast start for all CSV and list forecast grids to keep derived forecasts aligned with their input data.

Bug Fixes:
- Prevent forecast CSV and list grids from drifting across clock-rounding boundaries by reusing the forecast start frozen during initialization.
- Correct silently shifted pricing values in perfect-optimization list forecasts.

Enhancements:
- Expand forecast coverage to validate load-cost and production-price list paths, boundary alignment, nearest-rounding behavior, and unchanged same-step calls.

Tests:
- Add regression tests covering boundary-straddling failures, forecast-grid alignment, production-price forecasts, and perfect-optimization pricing.
- Strengthen DST and longer-list forecast assertions to verify exact slot counts and absence of missing values for list-priced forecasts.