### PR TITLE
fix: derive the window warning from the sequence length for sequence deferrable loads (#1081)

### DIFF
--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -3692,20 +3692,25 @@ class Optimization:
 
             # Time Window Logic
             # Calculate Valid Window
-            if def_total_timestep and def_total_timestep[k] > 0:
-                def_start, def_end, warning = Optimization.validate_def_timewindow(
-                    def_start_timestep[k],
-                    def_end_timestep[k],
-                    ceil(def_total_timestep[k]),
-                    n,
-                )
+            if is_sequence_load:
+                # A sequence load is placed in one piece, so the window must fit the
+                # whole sequence. Operating hours/timesteps play no role for sequence
+                # loads (their energy constraint is skipped above), so they must not
+                # drive this check either. Clamped to the horizon: a sequence longer
+                # than the horizon is truncated to n steps (warned above), so n is
+                # all the window ever needs to fit.
+                min_steps = min(sequence_length, n)
+            elif def_total_timestep and def_total_timestep[k] > 0:
+                min_steps = ceil(def_total_timestep[k])
             else:
-                def_start, def_end, warning = Optimization.validate_def_timewindow(
-                    def_start_timestep[k],
-                    def_end_timestep[k],
-                    ceil(def_total_hours[k] / self.time_step),
-                    n,
-                )
+                min_steps = ceil(def_total_hours[k] / self.time_step)
+            def_start, def_end, warning = Optimization.validate_def_timewindow(
+                def_start_timestep[k],
+                def_end_timestep[k],
+                min_steps,
+                n,
+                is_sequence=is_sequence_load,
+            )
             if warning is not None:
                 self.logger.warning(f"Deferrable load {k} : {warning}")
 
@@ -5822,7 +5827,7 @@ class Optimization:
 
     @staticmethod
     def validate_def_timewindow(
-        start: int, end: int, min_steps: int, window: int
+        start: int, end: int, min_steps: int, window: int, is_sequence: bool = False
     ) -> tuple[int, int, str]:
         r"""
         Helper function to validate (and if necessary: correct) the defined optimization window of a deferrable load.
@@ -5831,10 +5836,16 @@ class Optimization:
         :type start: int
         :param end: End timestep of the optimization window of the deferrable load
         :type end: int
-        :param min_steps: Minimal timesteps during which the load should operate (at nominal power)
+        :param min_steps: Minimal number of usable timesteps the window must contain:
+            derived from the operating hours for regular loads, or from the
+            (horizon-clamped) sequence length for sequence loads
         :type min_steps: int
         :param window: Total number of timesteps in the optimization window
         :type window: int
+        :param is_sequence: True when min_steps was derived from a sequence load's
+            power-sequence length rather than from operating hours/timesteps. Selects
+            the wording of the short-timeframe warning.
+        :type is_sequence: bool
         :return: start_validated: Validated start timestep of the optimization window of the deferrable load
         :rtype: int
         :return: end_validated: Validated end timestep of the optimization window of the deferrable load
@@ -5852,9 +5863,16 @@ class Optimization:
             start_validated = max(0, min(window, start))
             end_validated = max(0, min(window, end))
             if end_validated > 0:
-                # If the available timeframe is shorter than the number of timesteps needed to meet the hours to operate (def_total_hours), issue a warning.
+                # If the available timeframe is shorter than the number of timesteps the load needs (min_steps: from the operating hours, or the sequence length for a sequence load), issue a warning.
                 if (end_validated - start_validated) < min_steps:
-                    warning = "Available timeframe is shorter than the specified number of hours to operate. Optimization will fail."
+                    if is_sequence:
+                        warning = (
+                            f"Available timeframe ({end_validated - start_validated} timesteps) is "
+                            f"shorter than the load's power sequence ({min_steps} timesteps). "
+                            "Optimization will fail."
+                        )
+                    else:
+                        warning = "Available timeframe is shorter than the specified number of hours to operate. Optimization will fail."
         else:
             warning = "Invalid timeframe for deferrable load (start timestep is not <= end timestep). Continuing optimization without timewindow constraint."
         return start_validated, end_validated, warning

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1636,6 +1636,123 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         # The 2-step, 1000 W sequence ran exactly once: total power 2000 W.
         self.assertAlmostEqual(res["P_deferrable0"].sum(), 2000.0, delta=1.0)
 
+    def test_sequence_load_short_window_warns_with_sequence_wording(self):
+        """Issue #1081: a sequence (list-valued power) deferrable load's window
+        check must be sized against the length of its own power sequence, not
+        against operating hours/timesteps (which are meaningless for it, since
+        the energy constraint already exempts sequence loads). When the
+        allowed window is shorter than the sequence, a warning naming both the
+        available window and the sequence length must fire.
+        """
+        df = self.prepare_forecast_data()
+        self.optim_conf.update(
+            {
+                "set_use_battery": False,
+                "number_of_deferrable_loads": 1,
+                "nominal_power_of_deferrable_loads": [[2200, 2200, 2200, 200, 200]],
+                "start_timesteps_of_each_deferrable_load": [0],
+                "end_timesteps_of_each_deferrable_load": [4],
+                "operating_hours_of_each_deferrable_load": [0],
+            }
+        )
+        self.opt = self.create_optimization()
+        with self.assertLogs(level="WARNING") as logs:
+            self.opt.perform_naive_mpc_optim(df, self.p_pv_forecast, self.p_load_forecast, 10)
+        joined = "\n".join(logs.output)
+        # 5-step sequence, only a 4-step window available: warning must name
+        # both the available window and the sequence length. The run is
+        # expected to be infeasible; that is not asserted here.
+        self.assertIn("power sequence", joined)
+        self.assertIn("(4 timesteps)", joined)
+        self.assertIn("(5 timesteps)", joined)
+
+    def test_sequence_load_exact_window_with_stale_operating_hours_no_warning(self):
+        """Issue #1081: previously, a sequence load's window check used
+        operating hours/timesteps even though they play no role in how a
+        sequence load is scheduled. That produced false-positive warnings
+        whenever a stale operating_hours value happened to be larger than the
+        sequence length, even though the configured window fits the sequence
+        exactly. With the window sized to the sequence length, a stale
+        operating_hours value must be inert and the load must still run.
+        """
+        df = self.prepare_forecast_data()
+        self.optim_conf.update(
+            {
+                "set_use_battery": False,
+                "number_of_deferrable_loads": 1,
+                "nominal_power_of_deferrable_loads": [[2200, 2200, 2200, 200, 200]],
+                "start_timesteps_of_each_deferrable_load": [0],
+                "end_timesteps_of_each_deferrable_load": [5],
+                "operating_hours_of_each_deferrable_load": [10],
+            }
+        )
+        self.opt = self.create_optimization()
+        with self.assertLogs(level="WARNING") as logs:
+            # Sentinel record so the context always has something to capture,
+            # regardless of whether the optimization itself logs anything.
+            logger.warning("sentinel: capture context armed")
+            res = self.opt.perform_naive_mpc_optim(df, self.p_pv_forecast, self.p_load_forecast, 10)
+        joined = "\n".join(logs.output)
+        self.assertNotIn("Available timeframe", joined)
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+        # The 5-step sequence ran exactly once: total power 2200+2200+2200+200+200 = 7000 W.
+        self.assertAlmostEqual(res["P_deferrable0"].sum(), 7000.0, delta=1.0)
+
+    def test_sequence_longer_than_horizon_window_check_clamped_to_horizon(self):
+        """Issue #1081: a sequence longer than the optimization horizon is
+        truncated to the horizon length (with its own warning), so the window
+        check must compare the window against the horizon-clamped length, not
+        the raw sequence length. A window covering the whole horizon fits
+        everything that can actually be placed, so no window warning must fire
+        next to the truncation warning, and the truncated sequence must run.
+        """
+        df = self.prepare_forecast_data()
+        self.optim_conf.update(
+            {
+                "set_use_battery": False,
+                "number_of_deferrable_loads": 1,
+                "nominal_power_of_deferrable_loads": [[1000] * 12],
+                "start_timesteps_of_each_deferrable_load": [0],
+                "end_timesteps_of_each_deferrable_load": [10],
+                "operating_hours_of_each_deferrable_load": [0],
+            }
+        )
+        self.opt = self.create_optimization()
+        with self.assertLogs(level="WARNING") as logs:
+            res = self.opt.perform_naive_mpc_optim(df, self.p_pv_forecast, self.p_load_forecast, 10)
+        joined = "\n".join(logs.output)
+        # The truncation warning fires; the window warning must not.
+        self.assertIn("longer than optimization horizon", joined)
+        self.assertNotIn("power sequence", joined)
+        self.assertIn(self.opt.optim_status, VALID_OPTIMAL_STATUSES)
+        # The 12-step sequence was truncated to the 10-step horizon: 10 x 1000 W.
+        self.assertAlmostEqual(res["P_deferrable0"].sum(), 10000.0, delta=1.0)
+
+    def test_nonsequence_load_short_window_warns_with_original_wording(self):
+        """Issue #1081: the window-check fix is scoped to sequence loads only.
+        A regular (scalar-power) deferrable load with a window shorter than
+        its operating-hours requirement must keep warning with the original,
+        unmodified wording.
+        """
+        df = self.prepare_forecast_data()
+        self.optim_conf.update(
+            {
+                "set_use_battery": False,
+                "number_of_deferrable_loads": 1,
+                "nominal_power_of_deferrable_loads": [1000],
+                "start_timesteps_of_each_deferrable_load": [0],
+                "end_timesteps_of_each_deferrable_load": [4],
+                "operating_hours_of_each_deferrable_load": [4],
+            }
+        )
+        self.opt = self.create_optimization()
+        with self.assertLogs(level="WARNING") as logs:
+            self.opt.perform_naive_mpc_optim(df, self.p_pv_forecast, self.p_load_forecast, 10)
+        joined = "\n".join(logs.output)
+        self.assertIn(
+            "Available timeframe is shorter than the specified number of hours to operate", joined
+        )
+
     def test_thermal_config_unknown_key_warns(self):
         """Issue #943: a thermal_config with an unrecognized key (e.g. the
         singular min_temperature instead of the list min_temperatures, or a


### PR DESCRIPTION
Fixes #1081, agreed there before building.

## The bug

A sequence deferrable load is placed in one piece, so it needs at least `len(sequence)` usable timesteps inside its `[start_timesteps, end_timesteps)` window. The pre-solve check in `_add_deferrable_load_constraints` instead derived `min_steps` from the operating hours or operating timesteps, which do nothing for sequence loads (their energy constraint is skipped). Two wrong outcomes, both shown in the issue against master:

- window genuinely shorter than the sequence, hours/timesteps left at 0: no warning, the whole optimization just dies Infeasible (this is what @RikBast hit on #1047)
- window fine, a stale `operating_hours` value lying around: a false "Available timeframe is shorter" warning

## The fix

Where `is_sequence_load` and `sequence_length` are already in scope, the check now uses the quantity that actually governs feasibility:

```python
if is_sequence_load:
    min_steps = min(sequence_length, n)
elif def_total_timestep and def_total_timestep[k] > 0:
    min_steps = ceil(def_total_timestep[k])
else:
    min_steps = ceil(def_total_hours[k] / self.time_step)
```

Not `max()` with the hours-derived value: that keeps the false positive (a 5-step window for a 5-step sequence solves Optimal but would still warn if `operating_hours = 10` is set). Covered in the issue.

One refinement over the snippet I posted there: the length is clamped to the horizon. A sequence longer than the horizon is already truncated to `n` steps with its own warning, so `n` is all the window ever needs to fit. Without the clamp, that corner logged "Optimization will fail" with the untruncated length right next to the truncation warning, and then solved fine. There is a test pinning the clamp.

`validate_def_timewindow` gets an `is_sequence` keyword (default False) so the sequence case warns with wording a user can act on, naming the sequence length and the usable window. The non-sequence message is byte-identical to before, the clamping outputs do not depend on `min_steps` at all, and the six other call sites (which all discard the warning) are left alone.

## Behaviour changes, disclosed

- New warning: a sequence load with a window shorter than its sequence now warns before the solve (previously silent unless an unrelated hours value happened to trip it).
- Removed warning: a sequence load with an adequate window no longer warns just because `operating_hours` or `operating_timesteps` hold a larger stale value.
- Incidental: the sequence branch no longer reads `operating_hours` at all, so a `None` entry there can no longer raise a `TypeError` for a sequence load. The unguarded read I flagged in the issue still exists for non-sequence loads; kept out of this PR since you did not weigh in on it, happy to do it separately.
- Non-sequence loads: unchanged, warning text unchanged. Still a warning, not an error: the failure behaviour itself is untouched, per the issue.
- Known limit, same as the old check: it compares window width only, so a sequence with padding zeros at its edges can technically fit a narrower window than its full length. The warning can overclaim there; it errs on the loud side for a degenerate config.

Also not included: the `end_timesteps` inclusive/exclusive doc wording, which the issue already scoped out.

## Tests

- `test_sequence_load_short_window_warns_with_sequence_wording`: the #1047 shape (5-step sequence, 4-step window, hours at 0) now warns naming both numbers. Fails on master.
- `test_sequence_load_exact_window_with_stale_operating_hours_no_warning`: a 5-step window for a 5-step sequence with `operating_hours = 10` set solves Optimal, runs the sequence, and does not warn. Fails on master (false positive).
- `test_sequence_longer_than_horizon_window_check_clamped_to_horizon`: 12-step sequence at a 10-step horizon with a full-horizon window keeps the truncation warning, gets no window warning, and runs the truncated sequence.
- `test_nonsequence_load_short_window_warns_with_original_wording`: the existing hours-based warning for a standard load, original text. Passes on master and here.

Full suite green locally on top of f380180b.

## Summary by Sourcery

Correct deferrable-load window validation so sequence loads are checked against the number of timesteps required by their power sequence.

Bug Fixes:
- Derive sequence deferrable-load window validation from the sequence length, preventing missed warnings for undersized windows and false warnings from stale operating-hour settings.
- Provide sequence-specific warning text that identifies the available window and required sequence length.

Enhancements:
- Clamp the sequence length used for window validation to the optimization horizon while preserving existing behavior for non-sequence loads.

Tests:
- Add coverage for undersized sequence windows, stale operating-hour values, horizon-truncated sequences, and unchanged non-sequence warning behavior.