### PR TITLE
fix: account Solcast quota per rooftop request

### DIFF
--- a/src/emhass/forecast.py
+++ b/src/emhass/forecast.py
@@ -2,6 +2,12 @@ import asyncio
 import bz2
 import copy
 
+# Exclusive advisory lock for the Solcast quota counter file, so concurrent
+# EMHASS processes reserve provider-call budget atomically. POSIX uses
+# fcntl.flock; Windows uses msvcrt.locking on a single deterministic byte at
+# offset 0 (seek there before both lock and unlock). If neither primitive is
+# available the acquire raises, so the caller fails the reservation closed
+# rather than proceeding without atomicity.
 try:
     import fcntl as _fcntl
 
@@ -10,13 +16,27 @@ try:
 
     def _flock_release(f):
         _fcntl.flock(f, _fcntl.LOCK_UN)
-except ImportError:  # Windows
+except ImportError:
+    try:
+        import msvcrt as _msvcrt
 
-    def _flock_acquire(f):
-        pass  # type: ignore[misc]
+        def _flock_acquire(f):
+            f.seek(0)
+            _msvcrt.locking(f.fileno(), _msvcrt.LK_LOCK, 1)
 
-    def _flock_release(f):
-        pass  # type: ignore[misc]
+        def _flock_release(f):
+            f.seek(0)
+            _msvcrt.locking(f.fileno(), _msvcrt.LK_UNLCK, 1)
+    except ImportError:  # no supported locking primitive: fail closed
+
+        def _flock_acquire(f):
+            raise OSError(
+                "No file-locking primitive available (neither fcntl nor msvcrt); "
+                "refusing a non-atomic Solcast quota reservation."
+            )
+
+        def _flock_release(f):
+            pass
 
 
 import logging
@@ -491,13 +511,16 @@ class Forecast:
                 return await self._get_weather_open_meteo(w_forecast_cache_path, use_legacy_pvlib)
         return data
 
-    def _solcast_rate_limit_ok(self, max_calls: int = 8) -> bool:
-        """Check and increment a daily Solcast API call counter.
+    def _solcast_rate_limit_ok(self, required_calls: int = 1, max_calls: int = 8) -> bool:
+        """Atomically reserve `required_calls` of Solcast provider-call budget.
 
-        Uses a file in temporary directory keyed by date. Returns True if under
-        the daily limit, False otherwise.
+        This is a reservation, not a count of calls actually transmitted: it
+        may exceed the real number sent if a later roof in the same refresh
+        fails first -- intentionally conservative to avoid a partial
+        aggregate. Keyed by UTC date, since Solcast's quota is UTC-day based.
+        Returns True (and reserves) if it fits under max_calls, else False.
         """
-        today = pd.Timestamp.now(tz=self.time_zone).strftime("%Y-%m-%d")
+        today = pd.Timestamp.now(tz="UTC").strftime("%Y-%m-%d")
         temp_dir = tempfile.gettempdir()
         counter_path = os.path.join(temp_dir, f"emhass_solcast_calls_{today}.count")
 
@@ -511,14 +534,14 @@ class Forecast:
                 content = f.read().strip()
                 count = int(content) if content else 0
 
-                if count >= max_calls:
+                if count + required_calls > max_calls:
                     _flock_release(f)
                     return False
 
                 # Write incremented count back
                 f.seek(0)
                 f.truncate()
-                f.write(str(count + 1))
+                f.write(str(count + required_calls))
                 f.flush()
                 # Explicit close/unlock occurs via context manager exit, but we unlock explicitly
                 _flock_release(f)
@@ -595,17 +618,34 @@ class Forecast:
                 "Bypassing 'weather_forecast_cache_only' flag to fetch and cache a fresh forecast."
             )
             # Do NOT return False. We'll let execution continue below to fetch normally.
-        if not self._solcast_rate_limit_ok():
-            self.logger.warning(
-                "Solcast daily API call limit reached (safety cap). "
-                "Skipping live API call to preserve quota."
-            )
-            return False
         if "solcast_api_key" not in self.retrieve_hass_conf:
             self.logger.error("The solcast_api_key parameter was not defined")
             return False
         if "solcast_rooftop_id" not in self.retrieve_hass_conf:
             self.logger.error("The solcast_rooftop_id parameter was not defined")
+            return False
+        # Determine the configured rooftop request count before any quota
+        # reservation. Drop empty tokens so an empty / whitespace / separator-
+        # only value does not reserve a bogus one-call budget or issue a
+        # request against an empty rooftop ID.
+        roof_ids = [
+            rid
+            for rid in re.split(r"[,\s]+", self.retrieve_hass_conf["solcast_rooftop_id"].strip())
+            if rid
+        ]
+        if not roof_ids:
+            self.logger.error(
+                "The solcast_rooftop_id parameter has no usable rooftop IDs "
+                "(empty or separators only)"
+            )
+            return False
+        # Reserve budget for all configured roofs before any HTTP request, so
+        # a reservation that doesn't fit never yields a partial aggregate.
+        if not self._solcast_rate_limit_ok(required_calls=len(roof_ids)):
+            self.logger.warning(
+                "Solcast daily API call limit reached (safety cap). "
+                "Skipping live API call to preserve quota."
+            )
             return False
         headers = {
             "User-Agent": "EMHASS",
@@ -613,7 +653,6 @@ class Forecast:
             "Accept": header_accept,
         }
         days_solcast = int(len(self.forecast_dates) * self.freq.seconds / 3600)
-        roof_ids = re.split(r"[,\s]+", self.retrieve_hass_conf["solcast_rooftop_id"].strip())
         total_data = pd.DataFrame()
 
         # Conservative-bias blend factor, read once before the roof loop.

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -3,10 +3,12 @@
 import _pickle as cPickle
 import bz2
 import copy
+import glob
 import os
 import pathlib
 import pickle
 import re
+import tempfile
 import unittest
 import unittest.mock
 
@@ -2248,6 +2250,198 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
             res = await self.fcst.get_weather_forecast(method="solcast")
             self.assertFalse(res)
 
+    # --- Multi-rooftop Solcast quota accounting + UTC quota day ---
+    #
+    # The daily counter reserves Solcast provider-call budget atomically for
+    # ALL configured rooftop IDs before any HTTP request is made, so a
+    # reservation that doesn't fit under the cap can never yield a partial
+    # multi-rooftop aggregate. Keyed by UTC calendar date, since Solcast's
+    # quota resets on the UTC day, not the site's local day.
+
+    def _isolate_solcast_counter_dir(self):
+        """Route the quota counter file into a private per-test temp dir so
+        these tests never touch a real developer/runtime quota counter."""
+        counter_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(counter_dir.cleanup)
+        patcher = unittest.mock.patch(
+            "emhass.forecast.tempfile.gettempdir", return_value=counter_dir.name
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self._counter_dir = counter_dir.name
+
+    def _read_solcast_counter(self):
+        paths = glob.glob(os.path.join(self._counter_dir, "emhass_solcast_calls_*.count"))
+        assert len(paths) == 1, f"expected exactly one counter file, found {paths}"
+        with open(paths[0]) as f:
+            return int(f.read().strip())
+
+    async def _fetch_solcast_quota_mock(self, roof_ids_csv):
+        """Configure the given comma-separated rooftop IDs and fetch, with a
+        mock registered for every possible roof (111111/222222) regardless of
+        how many are actually configured -- so a rejected reservation proves
+        zero requests even though a mock exists that would have succeeded.
+        Caller must isolate the counter dir first (needed before any
+        pre-loading reservation call, so it isn't done here)."""
+        self.fcst.params = {
+            "passed_data": {"weather_forecast_cache": False, "weather_forecast_cache_only": False}
+        }
+        self.fcst.retrieve_hass_conf["solcast_api_key"] = "k"
+        self.fcst.retrieve_hass_conf["solcast_rooftop_id"] = roof_ids_csv
+        if os.path.isfile(emhass_conf["data_path"] / "weather_forecast_data.pkl"):
+            os.remove(emhass_conf["data_path"] / "weather_forecast_data.pkl")
+        payload = {
+            "forecasts": [
+                {
+                    "period_end": "2026-08-22T10:00:00.0000000Z",
+                    "period": "PT30M",
+                    "pv_estimate": 0.5,
+                }
+            ]
+        }
+        with aioresponses() as mocked:
+            for rid in ("111111", "222222"):
+                mocked.get(
+                    f"https://api.solcast.com.au/rooftop_sites/{rid}/forecasts?hours=24",
+                    payload=payload,
+                )
+            res = await self.fcst.get_weather_forecast(method="solcast")
+            return res, len(mocked.requests)
+
+    # (initial reserved count, roof count) -> allowed?, final count, actual
+    # HTTP requests. Covers 1/2-roof reservation, the 6+2->8 boundary, 7+2
+    # rejection (no partial aggregate), and the 8-call cap for both roof
+    # counts.
+    async def test_solcast_quota_reservation_table(self):
+        cases = [
+            (0, 1, True, 1, 1),
+            (0, 2, True, 2, 2),
+            (6, 2, True, 8, 2),
+            (7, 2, False, 7, 0),
+            (8, 1, False, 8, 0),
+            (8, 2, False, 8, 0),
+        ]
+        for initial, n_roofs, allowed, final_count, n_requests in cases:
+            with self.subTest(initial=initial, n_roofs=n_roofs):
+                roof_ids_csv = ",".join(["111111", "222222"][:n_roofs])
+                self._isolate_solcast_counter_dir()
+                if initial:
+                    self.assertTrue(self.fcst._solcast_rate_limit_ok(required_calls=initial))
+                res, n_http = await self._fetch_solcast_quota_mock(roof_ids_csv)
+                self.assertEqual(res is not False, allowed)
+                if allowed:
+                    self.assertIsInstance(res, pd.DataFrame)
+                else:
+                    self.assertNotIsInstance(res, pd.DataFrame)
+                self.assertEqual(n_http, n_requests)
+                self.assertEqual(self._read_solcast_counter(), final_count)
+
+    async def test_solcast_quota_lock_error_path_preserved(self):
+        """The OSError/ValueError-safe fallback (return False, log an error)
+        must still work with the required_calls-aware signature."""
+        with unittest.mock.patch("builtins.open", side_effect=OSError("disk full")):
+            self.assertFalse(self.fcst._solcast_rate_limit_ok(required_calls=2))
+
+    async def test_solcast_quota_single_rooftop_default(self):
+        """Calling with no explicit required_calls (the pre-existing call
+        pattern used elsewhere) still reserves exactly 1."""
+        self._isolate_solcast_counter_dir()
+        self.assertTrue(self.fcst._solcast_rate_limit_ok())
+        self.assertEqual(self._read_solcast_counter(), 1)
+
+    async def test_solcast_quota_uses_utc_day(self):
+        """UTC quota-day semantics in one deterministic test (no wall clock):
+        local midnight does not reset the counter, but real UTC midnight
+        does start a fresh one."""
+        fixed = {"now": pd.Timestamp("2026-01-01 23:30:00", tz="UTC")}
+
+        def fake_now(tz=None):
+            return fixed["now"].tz_convert(tz) if tz is not None else fixed["now"]
+
+        patcher = unittest.mock.patch.object(pd.Timestamp, "now", side_effect=fake_now)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self._isolate_solcast_counter_dir()
+
+        # 23:30 UTC on Jan 1 == 00:30 CET Jan 2 (Europe/Paris in winter): local
+        # calendar date has already rolled over, UTC has not -- must still
+        # land on the Jan-1 UTC-day file.
+        self.assertTrue(self.fcst._solcast_rate_limit_ok(required_calls=5))
+        self.assertEqual(self._read_solcast_counter(), 5)
+        paths = glob.glob(os.path.join(self._counter_dir, "emhass_solcast_calls_*.count"))
+        self.assertIn("emhass_solcast_calls_2026-01-01.count", paths[0])
+
+        # Real UTC midnight rollover creates a fresh counter, not reused.
+        fixed["now"] = pd.Timestamp("2026-01-02 00:05:00", tz="UTC")
+        self.assertTrue(self.fcst._solcast_rate_limit_ok())
+        paths = sorted(glob.glob(os.path.join(self._counter_dir, "emhass_solcast_calls_*.count")))
+        self.assertEqual(len(paths), 2, "a new UTC-day counter file must be created, not reused")
+        with open(paths[1]) as f:
+            self.assertEqual(int(f.read().strip()), 1, "the new UTC day's counter starts fresh")
+
+    async def test_solcast_quota_reservation_fails_closed_without_lock(self):
+        """If the lock cannot be acquired the reservation fails closed
+        (returns False, reserves nothing) rather than proceeding without
+        atomicity -- this is also the observable behaviour of the "neither
+        fcntl nor msvcrt" fallback branch."""
+        self._isolate_solcast_counter_dir()
+        with unittest.mock.patch(
+            "emhass.forecast._flock_acquire", side_effect=OSError("no locking primitive")
+        ):
+            self.assertFalse(self.fcst._solcast_rate_limit_ok(required_calls=2))
+        # The failed attempt reserved nothing: the next real call starts at 1.
+        self.assertTrue(self.fcst._solcast_rate_limit_ok(required_calls=1))
+        self.assertEqual(self._read_solcast_counter(), 1)
+
+    @unittest.skipUnless(os.name == "nt", "Windows msvcrt locking branch")
+    def test_flock_windows_mutual_exclusion(self):
+        """On Windows, _flock_acquire takes an exclusive lock a second file
+        handle cannot take until _flock_release runs."""
+        import msvcrt
+
+        from emhass.forecast import _flock_acquire, _flock_release
+
+        counter_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(counter_dir.cleanup)
+        path = os.path.join(counter_dir.name, "lock.count")
+        with open(path, "a+") as f1, open(path, "a+") as f2:
+            _flock_acquire(f1)
+            try:
+                f2.seek(0)
+                with self.assertRaises(OSError):
+                    msvcrt.locking(f2.fileno(), msvcrt.LK_NBLCK, 1)
+            finally:
+                _flock_release(f1)
+            # The region is free again once released.
+            f2.seek(0)
+            msvcrt.locking(f2.fileno(), msvcrt.LK_NBLCK, 1)
+            msvcrt.locking(f2.fileno(), msvcrt.LK_UNLCK, 1)
+
+    async def test_solcast_empty_rooftop_id_rejected_before_reservation(self):
+        """An empty / whitespace / separator-only solcast_rooftop_id is
+        rejected before any quota reservation and before any HTTP request."""
+        for bad in ("", "   ", ",", " , "):
+            with self.subTest(value=repr(bad)):
+                self._isolate_solcast_counter_dir()
+                self.fcst.params = {
+                    "passed_data": {
+                        "weather_forecast_cache": False,
+                        "weather_forecast_cache_only": False,
+                    }
+                }
+                self.fcst.retrieve_hass_conf["solcast_api_key"] = "k"
+                self.fcst.retrieve_hass_conf["solcast_rooftop_id"] = bad
+                if os.path.isfile(emhass_conf["data_path"] / "weather_forecast_data.pkl"):
+                    os.remove(emhass_conf["data_path"] / "weather_forecast_data.pkl")
+                with aioresponses() as mocked:
+                    res = await self.fcst.get_weather_forecast(method="solcast")
+                self.assertFalse(res)
+                self.assertEqual(len(mocked.requests), 0)
+                self.assertFalse(
+                    glob.glob(os.path.join(self._counter_dir, "emhass_solcast_calls_*.count")),
+                    "no quota counter file must be created",
+                )
+
     async def test_get_cached_forecast_data_stale_open_meteo_deletes_cache(self):
         """Stale Open-Meteo cache must be deleted and return False (no zero-fill).
 
@@ -2695,7 +2889,7 @@ class TestForecast(unittest.IsolatedAsyncioTestCase):
         }
         self.fcst.retrieve_hass_conf["solcast_api_key"] = "test_key"
         self.fcst.retrieve_hass_conf["solcast_rooftop_id"] = "test_roof"
-        self.fcst._solcast_rate_limit_ok = lambda: True
+        self.fcst._solcast_rate_limit_ok = lambda *a, **kw: True
 
         cache_path = emhass_conf["data_path"] / "weather_forecast_data.pkl"
         temp_path = emhass_conf["data_path"] / "temp_bias_weather_forecast_data.pkl"


### PR DESCRIPTION
## Summary

Fixes #1090

The Solcast safety counter is a **provider-call budget**. A refresh may
issue one provider request per configured rooftop ID, but the counter
previously reserved only one call per refresh, and it keyed on the site's
local calendar date even though the Solcast quota resets on the UTC day.

This change:

* determines the configured rooftop request count **before** any quota
  reservation;
* atomically reserves the complete `len(roof_ids)` budget in one locked
  read/check/write **before any HTTP request**;
* rejects the whole refresh when the full reservation cannot fit under the
  cap — so quota exhaustion can never produce a partial multi-rooftop
  aggregate;
* keys the counter to the **UTC calendar day**;
* keeps the existing **8-call safety cap** unchanged;
* keeps `_solcast_rate_limit_ok()` backward compatible — the default
  reservation is one call, so the single-rooftop path is unchanged.

The counter is intentionally a **conservative reservation**, not a count of
calls actually transmitted: a later provider request failing does **not**
roll the reservation back (this avoids a partial aggregate at the cost of
occasionally reserving more than were sent).

### Cross-platform atomic locking

The counter lock was a no-op on Windows, so two concurrent Windows EMHASS
processes could both read the same count and both reserve against it
(raised in the previous Sourcery review). The lock is now actually mutually
exclusive on every platform:

* POSIX: `fcntl.flock` (unchanged);
* Windows: `msvcrt.locking` on a single deterministic byte at offset 0
  (`seek(0)` before both lock and unlock) — standard library only, **no new
  dependency**;
* neither primitive available: the acquire raises, so
  `_solcast_rate_limit_ok` fails the reservation **closed** rather than
  proceeding without atomicity.

Cross-platform file-locking is not otherwise redesigned.

### Empty rooftop-ID hardening

Because the reservation now depends on `len(roof_ids)`, an empty /
whitespace / separator-only `solcast_rooftop_id` (which
`re.split(r"[,\s]+", "")` turns into `[""]`) is now rejected: empty tokens
are dropped, and if nothing remains the refresh logs an error and returns
`False` **before** any reservation or HTTP request. No general
configuration-validation refactor is included.

### UTC-key migration note

No migration code is added for pre-existing local-date counter files. When
UTC keying first takes effect an existing local-date counter file may not
be reused (at worst one extra counter file is created for that day);
operation is then keyed consistently to the provider's UTC quota day.

## Tests

`tests/test_forecast.py`:

* reservation table — 1/2-roof reserve, the 6+2→8 boundary, 7+2 rejection
  with **zero** HTTP requests, the 8-call cap for one and two roofs;
* single-rooftop default still reserves exactly 1;
* UTC quota-day keying — local midnight does not reset the counter, real UTC
  midnight starts a fresh one;
* reservation **fails closed** when the lock cannot be acquired (the
  neither-`fcntl`-nor-`msvcrt` branch's observable behaviour);
* Windows `msvcrt` branch — `_flock_acquire` takes an exclusive lock a
  second handle cannot take until `_flock_release` (skipped off Windows,
  runs on the Windows CI job);
* empty / whitespace / separator-only rooftop ID rejected before any
  reservation or request;
* test counter files are isolated from any real runtime counter file.

### Local validation (clean CI-equivalent env: `uv sync --reinstall --upgrade --extra test`, `uv run pytest`, Python 3.12, Windows)

* Solcast + quota + lock tests: **18 passed, 10 subtests passed**
* Windows `msvcrt` lock test executed natively on Windows: **passed**;
  standalone Windows lock smoke check (empty-file lock beyond EOF,
  contention refused, owner truncate/write, release, persistence): **pass**
* `tests/test_forecast.py`: **89 passed, 0 failed**
* full suite (`uv run pytest`): **1053 passed, 0 failed, 32 xfailed**
  (unmodified `master` in the same env: 1046 passed, 0 failed, 32 xfailed —
  no baseline failures, the branch adds 7 tests)
* `uvx ruff check --output-format=github .`: pass
* `uvx ruff format --check --diff`: pass (117 files)
* `git diff --check`: clean
* combined locally with #1088: no conflict, all Solcast tests +
  `tests/test_forecast.py` pass

No live Solcast API call and no Home Assistant deployment were used for
validation.

## Summary by Sourcery

Reserve the complete Solcast rooftop request budget atomically before refreshing forecasts.

Bug Fixes:
- Account for every configured Solcast rooftop provider request when enforcing the daily quota, preventing partial multi-rooftop refreshes when the full reservation exceeds the cap.
- Use the Solcast UTC quota day and reject empty rooftop configurations before reservation or network requests.

Enhancements:
- Make quota reservations atomic and mutually exclusive across POSIX and Windows platforms, failing closed when file locking is unavailable.
- Preserve the existing eight-call safety cap and single-rooftop reservation behavior while adding comprehensive quota, locking, UTC rollover, and invalid-configuration coverage.

Tests:
- Add coverage for multi-rooftop quota boundaries, UTC-day counter behavior, lock failures and Windows mutual exclusion, backward-compatible single-rooftop reservations, and empty rooftop IDs.