### PR TITLE
fix: scale thermal loss by timestep duration (#1074)

### DIFF
--- a/docs/thermal_battery.md
+++ b/docs/thermal_battery.md
@@ -243,10 +243,19 @@ The temperature dynamics in hot water tank mode:
 
 ```
 conversion = 3600 / (density * heat_capacity * volume)
+thermal_loss_energy = thermal_loss * dt   # kW rate -> kWh removed this timestep
 
 predicted_temp[t+1] = predicted_temp[t]
-    + conversion * (cop[t] * p_deferrable[t] / 1000 * dt - draw_off_demand[t] - thermal_loss)
+    + conversion * (cop[t] * p_deferrable[t] / 1000 * dt - draw_off_demand[t] - thermal_loss_energy)
 ```
+
+`thermal_loss` is configured and documented as a constant **kW** rate. `draw_off_demand[t]`
+and the heater term are already **kWh** for that timestep, so EMHASS multiplies
+`thermal_loss` by the timestep duration `dt` (in hours) internally before it enters the
+balance. You always supply `thermal_loss` in kW regardless of your configured timestep —
+do not pre-scale it. A 5-minute timestep then removes 1/12th of the standby-loss energy
+that a 60-minute timestep removes; at exactly 60 minutes the result is numerically
+identical to earlier EMHASS versions (`kW × 1 h = kWh`).
 
 ### Weather-compensated minimum temperature (radiator emission floor)
 
@@ -892,6 +901,12 @@ Loss = thermal_loss  (constant, not dependent on outdoor temperature)
 ```
 
 This is appropriate because a tank sits indoors at roughly constant ambient temperature.
+
+In both modes `Loss` above is a **kW** magnitude. EMHASS converts it to the energy removed
+over one timestep (`thermal_loss_energy = Loss × dt`, `dt` in hours) before subtracting it in
+the temperature balance, exactly as shown in the hot-water-tank dynamics equation earlier.
+This keeps the inferred continuous standby-loss *rate* equal to the configured kW value at
+any timestep length; `draw_off_demand` stays in kWh per timestep and needs no conversion.
 
 ### 3. Heating demand / draw-off demand
 

--- a/src/emhass/optimization.py
+++ b/src/emhass/optimization.py
@@ -1398,18 +1398,25 @@ class Optimization:
                 draw_off_profile = hc.get("draw_off_demand", None)
 
                 if draw_off_profile is not None and len(draw_off_profile) > 0:
-                    # Hot water tank mode: constant standby loss + tiled draw-off
-                    params["thermal_losses"].value = np.full(n, base_loss)
+                    # Hot water tank mode: constant standby loss + tiled draw-off.
+                    # thermal_loss is a public kW rate; convert to kWh/timestep.
+                    params["thermal_losses"].value = self._loss_kw_to_timestep_energy(
+                        np.full(n, base_loss)
+                    )
                     draw_off_arr = self._tile_profile(draw_off_profile, n)
                     params["heating_demand"].value = draw_off_arr
                 else:
-                    # Building heating mode: outdoor-temp-dependent losses
+                    # Building heating mode: outdoor-temp-dependent losses.
+                    # calculate_thermal_loss_signed returns a signed kW magnitude;
+                    # convert to kWh/timestep before the temperature balance.
                     thermal_losses = utils.calculate_thermal_loss_signed(
                         outdoor_temperature_forecast=outdoor_temp.tolist(),
                         indoor_temperature=new_start_temp,
                         base_loss=base_loss,
                     )
-                    params["thermal_losses"].value = np.array(thermal_losses[:n])
+                    params["thermal_losses"].value = self._loss_kw_to_timestep_energy(
+                        np.array(thermal_losses[:n])
+                    )
 
                     # Heating demand
                     if all(
@@ -2968,12 +2975,27 @@ class Optimization:
             arr = np.tile(arr, repeats)
         return arr[:required_len]
 
+    def _loss_kw_to_timestep_energy(self, loss_kw):
+        """Convert a ``thermal_loss`` value from its public contract (a constant
+        standby-loss RATE in kW) to the energy removed over one optimisation
+        timestep (kWh/timestep).
+
+        The temperature balance adds ``thermal_losses`` to the other, already
+        timestep-scaled energy terms (heater input ``P/1000 * dt`` and the
+        kWh/timestep ``heating_demand``/``draw_off_demand``), so the kW rate must
+        be multiplied by the timestep duration here. This is the single
+        authoritative conversion point; the public ``thermal_loss`` unit (kW) is
+        unchanged. Accepts a scalar or a NumPy array.
+        """
+        return loss_kw * self.time_step
+
     def _resolve_draw_off_demand(self, hc, base_loss, required_len):
         """Return (demand_arr, loss_arr) if hot-water-tank mode (draw_off_demand present), else None."""
         draw_off_profile = hc.get("draw_off_demand", None)
         if draw_off_profile is not None and len(draw_off_profile) > 0:
             demand_arr = self._tile_profile(draw_off_profile, required_len)
-            loss_arr = np.full(required_len, base_loss)
+            # thermal_loss is a public kW rate; convert to kWh/timestep.
+            loss_arr = np.full(required_len, self._loss_kw_to_timestep_energy(base_loss))
             return demand_arr, loss_arr
         return None
 
@@ -3073,7 +3095,10 @@ class Optimization:
                     indoor_temperature=start_temp_float,
                     base_loss=base_loss,
                 )
-                params["thermal_losses"].value = np.array(losses[:required_len])
+                # Signed kW magnitude -> kWh/timestep (see _loss_kw_to_timestep_energy).
+                params["thermal_losses"].value = self._loss_kw_to_timestep_energy(
+                    np.array(losses[:required_len])
+                )
 
                 # Compute heating demand
                 if all(
@@ -3186,12 +3211,15 @@ class Optimization:
             if hot_water is not None:
                 heating_demand, thermal_losses = hot_water
             else:
-                thermal_losses = np.array(
-                    utils.calculate_thermal_loss_signed(
-                        outdoor_temperature_forecast=outdoor_temp_arr.tolist(),
-                        indoor_temperature=start_temp_float,
-                        base_loss=base_loss,
-                    )[:required_len]
+                # Signed kW magnitude -> kWh/timestep (see _loss_kw_to_timestep_energy).
+                thermal_losses = self._loss_kw_to_timestep_energy(
+                    np.array(
+                        utils.calculate_thermal_loss_signed(
+                            outdoor_temperature_forecast=outdoor_temp_arr.tolist(),
+                            indoor_temperature=start_temp_float,
+                            base_loss=base_loss,
+                        )[:required_len]
+                    )
                 )
 
                 # Compute heating demand (simplified fallback)
@@ -3504,12 +3532,15 @@ class Optimization:
         if hot_water is not None:
             heating_demand, thermal_losses = hot_water
         else:
-            thermal_losses = np.array(
-                utils.calculate_thermal_loss_signed(
-                    outdoor_temperature_forecast=outdoor_temp_arr.tolist(),
-                    indoor_temperature=start_temperature,
-                    base_loss=base_loss,
-                )[:required_len]
+            # Signed kW magnitude -> kWh/timestep (see _loss_kw_to_timestep_energy).
+            thermal_losses = self._loss_kw_to_timestep_energy(
+                np.array(
+                    utils.calculate_thermal_loss_signed(
+                        outdoor_temperature_forecast=outdoor_temp_arr.tolist(),
+                        indoor_temperature=start_temperature,
+                        base_loss=base_loss,
+                    )[:required_len]
+                )
             )
             if all(
                 key in tank

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -6236,6 +6236,201 @@ class TestOptimization(unittest.IsolatedAsyncioTestCase):
         # Heating energy should be at least the draw-off demand (COP amplifies electrical input)
         self.assertGreater(total_heating, 0, "Heat pump must run to compensate draw-off demand")
 
+    def test_thermal_loss_kw_rate_scaled_by_timestep(self):
+        """Regression for issue #1074.
+
+        ``thermal_loss`` is a public standby-loss RATE in kW. It must be
+        converted to kWh for the current timestep (``thermal_loss * dt_hours``)
+        before it enters the temperature balance, alongside the already
+        timestep-scaled heater energy and the kWh/timestep ``draw_off_demand``.
+
+        Before the fix the raw kW value was subtracted directly, so the energy
+        removed per timestep - and therefore the implied continuous loss power -
+        depended on the optimisation timestep length (only 60 min matched the
+        configured value).
+
+        This exercises the real ``_resolve_draw_off_demand`` helper, which is the
+        single hot-water-tank standby-loss source shared by the fresh-build,
+        cache-hit and shared-tank paths.
+        """
+        base_loss_kw = 0.035
+        hc = {"thermal_loss": base_loss_kw, "draw_off_demand": [0.0] * 6}
+
+        for timestep_min in (5, 30, 60):
+            with self.subTest(timestep_min=timestep_min):
+                rhc = dict(self.retrieve_hass_conf)
+                rhc["optimization_time_step"] = pd.Timedelta(minutes=timestep_min)
+                opt = self.create_optimization(retrieve_hass_conf=rhc)
+                dt_hours = timestep_min / 60.0
+                self.assertAlmostEqual(opt.time_step, dt_hours, places=12)
+
+                _, loss_arr = opt._resolve_draw_off_demand(hc, base_loss_kw, 6)
+
+                # Energy removed per timestep scales with dt.
+                np.testing.assert_allclose(
+                    loss_arr, np.full(6, base_loss_kw * dt_hours), atol=1e-12
+                )
+                # The inferred continuous standby-loss RATE stays at 0.035 kW.
+                self.assertAlmostEqual(loss_arr[0] / dt_hours, base_loss_kw, places=12)
+
+        # 60-minute numerical compatibility: kW * 1 h == the historical raw value.
+        rhc = dict(self.retrieve_hass_conf)
+        rhc["optimization_time_step"] = pd.Timedelta(minutes=60)
+        opt60 = self.create_optimization(retrieve_hass_conf=rhc)
+        _, loss60 = opt60._resolve_draw_off_demand(hc, base_loss_kw, 6)
+        np.testing.assert_allclose(loss60, np.full(6, base_loss_kw), atol=1e-12)
+
+        # Zero loss stays an exact zero-loss path.
+        _, loss_zero = opt60._resolve_draw_off_demand(
+            {"thermal_loss": 0.0, "draw_off_demand": [0.0] * 6}, 0.0, 6
+        )
+        np.testing.assert_array_equal(loss_zero, np.zeros(6))
+
+    def test_thermal_loss_signed_building_loss_scaled_and_sign_preserved(self):
+        """Issue #1074: the building/space-heating thermal-battery path
+        (``draw_off_demand`` absent) feeds ``calculate_thermal_loss_signed`` -
+        a signed kW magnitude - into ``param_thermal[k]["thermal_losses"]``.
+
+        That parameter must receive kWh/timestep (``kW * dt``), keeping the
+        +loss (outdoor below the start/indoor temperature) / -gain (outdoor at
+        or above it) sign convention, with no abs(), clipping or double scaling.
+        Inspects the real parameter value produced by a normal optimisation run
+        rather than calling the conversion helper directly.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        # start_temperature (20 C) is the threshold used by
+        # calculate_thermal_loss_signed: first half cold -> heat loss (+),
+        # second half warm -> passive gain (-).
+        self.df_input_data_dayahead["outdoor_temperature_forecast"] = [5.0] * 24 + [25.0] * 24
+
+        base_loss_kw = 0.035
+        self.optim_conf["def_load_config"] = [
+            {
+                "thermal_battery": {
+                    "start_temperature": 20.0,
+                    "supply_temperature": 35.0,
+                    "volume": 50.0,
+                    "thermal_loss": base_loss_kw,
+                    "specific_heating_demand": 0.0,
+                    "area": 1.0,
+                    "min_temperatures": [5.0] * 48,
+                    "max_temperatures": [90.0] * 48,
+                }
+            }
+        ]
+        opt = self.create_optimization()
+        ulc = self.df_input_data_dayahead[opt.var_load_cost].values
+        upp = self.df_input_data_dayahead[opt.var_prod_price].values
+        opt.perform_optimization(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast.values.ravel(),
+            self.p_load_forecast.values.ravel(),
+            ulc,
+            upp,
+        )
+
+        losses = np.asarray(opt.param_thermal[0]["thermal_losses"].value)
+        dt_hours = opt.time_step  # 0.5 h
+        np.testing.assert_allclose(losses[:24], np.full(24, base_loss_kw * dt_hours), atol=1e-12)
+        np.testing.assert_allclose(losses[24:], np.full(24, -base_loss_kw * dt_hours), atol=1e-12)
+        # Sign convention preserved (not abs()/clipped).
+        self.assertTrue(np.all(losses[:24] > 0))
+        self.assertTrue(np.all(losses[24:] < 0))
+
+    def test_thermal_loss_timestep_scaling_survives_cache_hit(self):
+        """Issue #1074: ``update_thermal_params`` (the cache-hit / rolling-MPC
+        runtime refresh) must re-apply the kW -> kWh/timestep conversion, not
+        leave a stale unscaled kW vector in the cached parameter.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        base_loss_kw = 0.035
+        config = {
+            "start_temperature": 50.0,
+            "volume": 0.259,
+            "density": 1000,
+            "heat_capacity": 4.186,
+            "efficiency": 1.0,
+            "thermal_loss": base_loss_kw,
+            "draw_off_demand": [0.0] * 48,
+            "min_temperatures": [0.0] * 48,
+            "max_temperatures": [100.0] * 48,
+        }
+        self.optim_conf["def_load_config"] = [{"thermal_battery": config}]
+        opt = self.create_optimization()
+
+        unit_load_cost = self.df_input_data_dayahead[opt.var_load_cost].values
+        unit_prod_price = self.df_input_data_dayahead[opt.var_prod_price].values
+        opt.perform_optimization(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast.values.ravel(),
+            self.p_load_forecast.values.ravel(),
+            unit_load_cost,
+            unit_prod_price,
+        )
+        self.assertIn(0, opt.param_thermal)
+
+        # Force the OLD buggy (unscaled) vector, then simulate a cache-hit refresh.
+        opt.param_thermal[0]["thermal_losses"].value = np.full(48, base_loss_kw)
+        opt.update_thermal_params(
+            self.optim_conf, self.df_input_data_dayahead, self.p_load_forecast.values.ravel()
+        )
+
+        np.testing.assert_allclose(
+            opt.param_thermal[0]["thermal_losses"].value,
+            np.full(48, base_loss_kw * opt.time_step),
+            atol=1e-12,
+            err_msg="cache-hit path did not scale thermal_loss to kWh/timestep",
+        )
+
+    def test_shared_thermal_tank_thermal_loss_timestep_scaled(self):
+        """Issue #1074: a shared thermal tank built end-to-end through
+        ``_add_shared_thermal_tank_constraints`` must decay an idle tank by the
+        timestep-scaled standby loss (``thermal_loss * dt``), not the raw kW
+        value.
+        """
+        self.df_input_data_dayahead = self.prepare_forecast_data()
+        base_loss_kw = 0.035
+        volume, density, heat_capacity = 0.1, 1000, 4.186
+        conversion = 3600 / (density * heat_capacity * volume)
+
+        self.optim_conf["number_of_deferrable_loads"] = 1
+        self.optim_conf["def_load_config"] = [
+            {"thermal_source": {"supply_temperature": 55.0, "carnot_efficiency": 0.40}}
+        ]
+        self.optim_conf["shared_thermal_tanks"] = [
+            {
+                "id": "buf",
+                "load_ids": [0],
+                "start_temperature": 60.0,
+                "volume": volume,
+                "density": density,
+                "heat_capacity": heat_capacity,
+                "thermal_loss": base_loss_kw,
+                "draw_off_demand": [0.0] * 48,
+                "min_temperatures": [0.0] * 48,
+                "max_temperatures": [100.0] * 48,
+            }
+        ]
+        opt = self.create_optimization()
+        ulc = self.df_input_data_dayahead[opt.var_load_cost].values
+        upp = self.df_input_data_dayahead[opt.var_prod_price].values
+        res = opt.perform_optimization(
+            self.df_input_data_dayahead,
+            self.p_pv_forecast.values.ravel(),
+            self.p_load_forecast.values.ravel(),
+            ulc,
+            upp,
+        )
+        self.assertEqual(res["optim_status"].unique()[0], "Optimal")
+        # Profit cost function never runs the pump when min temp is 0 -> pure decay.
+        self.assertAlmostEqual(res["P_deferrable0"].iloc[0], 0.0, places=3)
+
+        actual_drop = res["predicted_temp_heater0"].iloc[0] - res["predicted_temp_heater0"].iloc[1]
+        expected_drop = conversion * base_loss_kw * opt.time_step  # ~0.150 degC at 30 min
+        buggy_drop = conversion * base_loss_kw  # ~0.301 degC (raw kW, unscaled)
+        self.assertAlmostEqual(actual_drop, expected_drop, places=2)
+        self.assertLess(actual_drop, (expected_drop + buggy_drop) / 2)
+
     def test_inverter_stress_cost_discharge_spread(self):
         """Test that inverter stress cost encourages spreading discharge over time."""
         # Setup plant configuration for hybrid inverter with battery


### PR DESCRIPTION
## Summary

Fixes #1074

`thermal_loss` is documented and configured as a standby heat-loss **rate in
kW**, but the thermal temperature balance currently consumes it directly
alongside timestep-energy quantities in kWh.

That makes the effective standby-loss power depend on
`optimization_time_step`: shorter timesteps overstate the loss, while a
60-minute timestep happens to be numerically correct.

The maintainer confirmed in #1074 that `thermal_loss` should remain a kW rate
and should be converted internally to timestep energy.

This change applies:

```text
thermal_loss_energy = thermal_loss * timestep_hours
```

before the loss enters the thermal balance.

## Dimensional contract

The public units remain unchanged:

* `thermal_loss`: kW;
* heater input: `P / 1000 * dt` = kWh/timestep;
* `draw_off_demand`: kWh/timestep.

`thermal_losses` inside the temperature balance therefore becomes
kWh/timestep consistently.

No user-side pre-scaling is required.

## Affected paths

The conversion is applied consistently to the current thermal-loss paths:

* hot-water / `draw_off_demand` mode;
* cache-hit/runtime thermal parameter refresh;
* building/space-heating signed thermal loss;
* parameterised thermal-battery construction;
* fallback thermal-battery construction;
* shared thermal tanks.

A small private `_loss_kw_to_timestep_energy()` helper provides the single
kW -> kWh/timestep conversion.

Existing signed building semantics are preserved:

* positive = heat loss;
* negative = passive heat gain.

No clipping or absolute-value conversion is introduced.

## Behaviour

For `thermal_loss = 0.035 kW`:

| optimisation timestep | previous loss energy per step |     corrected |
| --------------------- | ----------------------------: | ------------: |
| 5 min                 |                     0.035 kWh | 0.0029167 kWh |
| 30 min                |                     0.035 kWh |    0.0175 kWh |
| 60 min                |                     0.035 kWh |     0.035 kWh |

The inferred continuous standby-loss rate is therefore 0.035 kW at every
timestep after the fix.

The 60-minute numerical result is unchanged because `kW x 1 h` has the same
numeric value in kWh.

## Regression evidence

The new regression suite was first run against untouched
`upstream/master` (`511072ac`).

For the real building/space-heating path at a 30-minute timestep, master
produced:

```text
cold slots:  +0.035
warm slots:  -0.035
```

while the correct timestep-energy values are:

```text
cold slots:  +0.0175 kWh/timestep
warm slots:  -0.0175 kWh/timestep
```

The regression therefore fails numerically on master and passes after the
fix.

Coverage includes:

* 5 / 30 / 60-minute timestep scaling;
* continuous kW-rate invariance;
* 60-minute numerical compatibility;
* zero-loss behaviour;
* real building-path signed loss/gain behaviour;
* cache-hit thermal parameter refresh;
* end-to-end shared-tank standby-loss decay.

## Documentation

`docs/thermal_battery.md` now makes the dimensional conversion explicit:

```text
thermal_loss_energy = thermal_loss * dt
```

Users should continue configuring `thermal_loss` in kW regardless of their
optimisation timestep.

## Validation

Clean Python 3.12 development environment:

* focused #1074 regressions: **4 passed**, 3 subtests passed;
* full suite: **1050 passed, 32 xfailed, 0 failed**;
* `uvx ruff check --output-format=github .`: pass;
* `uvx ruff format --check --diff`: pass;
* `git diff --check`: clean.

## Scope

This is a dimensional bug fix only.

There are no changes to:

* public configuration parameters or units;
* configuration schema / OpenAPI;
* `OptimizationCacheKey`;
* capacity/demand-charge behaviour;
* battery electrical modelling;
* Home Assistant integration/control logic;
* optimisation-result DataFrame schema;
* external dependencies.

No production Home Assistant deployment or live device/API interaction was
used for validation.

## Summary by Sourcery

Correct thermal-loss handling so configured kW standby-loss rates produce timestep-consistent thermal energy losses.

Bug Fixes:
- Scale configured thermal-loss rates by the optimization timestep before applying them to thermal-balance energy calculations, preserving signed building heat-loss behavior and 60-minute compatibility.

Enhancements:
- Apply the corrected thermal-loss conversion consistently across hot-water, building-heating, cached-parameter, fallback, parameterized, and shared-tank paths.

Documentation:
- Document that thermal_loss remains configured in kW and is internally converted to kWh per timestep.

Tests:
- Add regression coverage for timestep scaling, signed losses and gains, cache refreshes, zero loss, and shared-tank standby-loss decay.