### PR TITLE
fix: missing await on rh.get_data() in export_influxdb_to_csv

### DIFF
--- a/src/emhass/command_line.py
+++ b/src/emhass/command_line.py
@@ -3461,7 +3461,7 @@ async def export_influxdb_to_csv(
     )
     logger.info(f"Sensors: {sensor_list}")
     # Retrieve data from InfluxDB
-    success = rh.get_data(days_list, sensor_list)
+    success = await rh.get_data(days_list, sensor_list)
     if not success or rh.df_final is None or rh.df_final.empty:
         logger.error("Failed to retrieve data from InfluxDB")
         return False

--- a/tests/test_command_line_utils.py
+++ b/tests/test_command_line_utils.py
@@ -1050,6 +1050,8 @@ class TestCommandLineAsyncUtils(unittest.IsolatedAsyncioTestCase):
 
     # Test export_influxdb_to_csv
     async def test_export_influxdb_to_csv(self):
+        from unittest.mock import AsyncMock, patch
+
         costfun = "profit"
         action = "export-influxdb-to-csv"
         # Test Success Case
@@ -1093,8 +1095,7 @@ class TestCommandLineAsyncUtils(unittest.IsolatedAsyncioTestCase):
         df_final_mock = pd.DataFrame(data, index=index)
         # Add some NaNs to test handle_nan
         df_final_mock.iloc[5:10, 0] = np.nan
-        # Mock rh.get_data
-        input_data_dict["rh"].get_data = Mock(return_value=True)
+        input_data_dict["rh"].get_data = AsyncMock(return_value=True)
         input_data_dict["rh"].df_final = df_final_mock
         # Mock the final to_csv call to avoid writing a file
         with patch("pandas.DataFrame.to_csv") as mock_to_csv:
@@ -1135,7 +1136,8 @@ class TestCommandLineAsyncUtils(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(success)
         # Test rh.get_data fails
         input_data_dict["rh"].use_influxdb = True  # Reset from test 2
-        input_data_dict["rh"].get_data = Mock(return_value=False)  # Mock get_data to fail
+        # FIX: Use AsyncMock here as well
+        input_data_dict["rh"].get_data = AsyncMock(return_value=False)  # Mock get_data to fail
         input_data_dict["rh"].df_final = None
         success = await export_influxdb_to_csv(input_data_dict, logger)
         self.assertFalse(success)


### PR DESCRIPTION
Fixes #1095

## Summary by Sourcery

Ensure InfluxDB data retrieval completes before exporting data to CSV.

Bug Fixes:
- Await InfluxDB data retrieval during CSV export so the operation correctly receives the asynchronous result and handles failures.

Tests:
- Update CSV export tests to use asynchronous mocks for InfluxDB data retrieval.