### PR TITLE
fix: preserve nested configuration arrays (#1115)

### DIFF
--- a/src/emhass/static/configuration_script.js
+++ b/src/emhass/static/configuration_script.js
@@ -323,6 +323,7 @@ function buildParamContainers(
     let array_buttons = "";
     if (
       parameter_definition_object["input"].search("array.") > -1 &&
+      parameter_definition_object["input"] !== "array.array.float" &&
       section != "Deferrable Loads" &&
       !(section == "Battery" && BATTERY_ARRAY_PARAMS.includes(parameter_definition_name))
     ) {
@@ -509,6 +510,14 @@ function buildParamElement(
   //definitions default value is used if none is found in the configs, or an array element has been added in the ui (deferrable load number increase or plus button pressed)
   //check if a param value is saved in the config file (if so overwrite definition default)
   let value = checkConfigParam(placeholder, config, parameter_definition_name);
+
+  // Keep the complete nested value in one JSON input, including per-battery tables.
+  if (parameter_definition_object["input"] === "array.array.float") {
+    const json = typeof value === "string" ? value : JSON.stringify(value ?? []);
+    const escaped = json.replaceAll('&', '&amp;').replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+    return `<input class="param_input" type="text" placeholder="[]" value="${escaped}">`;
+  }
 
   //generate and return param input html,
   //check if param value is not an object, if so assume its a single value.
@@ -875,6 +884,25 @@ async function saveConfiguration(param_definitions) {
           );
 
           //build parameters using values extracted from param_inputs
+
+          // Nested numeric arrays must be saved as JSON, not flattened strings.
+          if (parameter_definition_object["input"] === "array.array.float") {
+            try {
+              const value = JSON.parse((param_values[0] ?? "").trim() || "[]");
+              const numericRow = (row) => Array.isArray(row) &&
+                row.every((item) => typeof item === "number" && Number.isFinite(item));
+              const numericTable = (table) => Array.isArray(table) && table.every(numericRow);
+              if (!numericTable(value) &&
+                  !(Array.isArray(value) && value.every(numericTable))) {
+                throw new Error("Expected nested numeric arrays");
+              }
+              config[parameter_definition_name] = value;
+            } catch (_) {
+              errorAlert(parameter_definition_name + ": enter a JSON array of numeric rows or tables, for example [[0.5, 1000]].");
+              return 0;
+            }
+            continue;
+          }
 
           // object-type: JSON.parse the text-box value; treat "" and "null" as JSON null
           if (parameter_definition_object["input"] === "object") {

--- a/src/emhass/static/configuration_script.js
+++ b/src/emhass/static/configuration_script.js
@@ -323,7 +323,7 @@ function buildParamContainers(
     let array_buttons = "";
     if (
       parameter_definition_object["input"].search("array.") > -1 &&
-      parameter_definition_object["input"] !== "array.array.float" &&
+      parameter_definition_name !== "battery_charge_power_derating" &&
       section != "Deferrable Loads" &&
       !(section == "Battery" && BATTERY_ARRAY_PARAMS.includes(parameter_definition_name))
     ) {
@@ -511,8 +511,10 @@ function buildParamElement(
   //check if a param value is saved in the config file (if so overwrite definition default)
   let value = checkConfigParam(placeholder, config, parameter_definition_name);
 
-  // Keep the complete nested value in one JSON input, including per-battery tables.
-  if (parameter_definition_object["input"] === "array.array.float") {
+  // Battery tables use one JSON field. Other nested-array parameters can allow
+  // null entries and follow their existing per-load rendering and save paths.
+  if (parameter_definition_name === "battery_charge_power_derating" &&
+      parameter_definition_object["input"] === "array.array.float") {
     const json = typeof value === "string" ? value : JSON.stringify(value ?? []);
     const escaped = json.replaceAll('&', '&amp;').replaceAll('<', '&lt;')
       .replaceAll('>', '&gt;').replaceAll('"', '&quot;');
@@ -886,7 +888,8 @@ async function saveConfiguration(param_definitions) {
           //build parameters using values extracted from param_inputs
 
           // Nested numeric arrays must be saved as JSON, not flattened strings.
-          if (parameter_definition_object["input"] === "array.array.float") {
+          if (parameter_definition_name === "battery_charge_power_derating" &&
+              parameter_definition_object["input"] === "array.array.float") {
             try {
               const value = JSON.parse((param_values[0] ?? "").trim() || "[]");
               const numericRow = (row) => Array.isArray(row) &&

--- a/tests/ui/nested-config.test.cjs
+++ b/tests/ui/nested-config.test.cjs
@@ -46,3 +46,44 @@ test('flat numeric arrays retain existing save behaviour', async () => {
   const ctx = setup('2'); await ctx.saveConfiguration({ Battery: { [name]: { input: 'array.string' } } });
   assert.deepEqual(ctx.sent[name], ['2']);
 });
+
+// Battery-only rules must not change another parameter using the same schema type.
+test('nullable per-load cost field keeps its original rendering', () => {
+  const ctx = setup('');
+  const other = 'cost_forecast_per_deferrable_load';
+  const html = ctx.buildParamElement({...definition,default_value:null},other,{[other]:null});
+  assert.match(html,/value=""/);
+  assert.doesNotMatch(html,/value="\[\]"/);
+});
+test('battery numeric-array validator does not intercept a per-load cost field', async () => {
+  const ctx = setup('');
+  const other = 'cost_forecast_per_deferrable_load';
+  ctx.document.getElementById = id => id === other ? {tagName:'DIV',getElementsByClassName:()=>[]} : null;
+  await ctx.saveConfiguration({Loads:{[other]:{...definition,default_value:null}}});
+  assert.deepEqual(ctx.sent, {});
+  assert.equal(ctx.error,undefined);
+});
+test('nullable or string elements cannot leak through battery validation', async () => {
+  for(const value of [[[null,0.5]],[[true,0.5]],[[[0.5,'0.8']]],[[[[0.5,0.8]]]]]) {
+    const ctx=setup(JSON.stringify(value));
+    assert.equal(await ctx.saveConfiguration({Battery:{[name]:definition}}),0);
+    assert.equal(ctx.sent,undefined);
+  }
+});
+test('battery fractional values survive three repeated render/save cycles',async()=>{
+  let value=[[[0.5,0.84],[0.7,0.42]],[[0.9,0.23]]];
+  const expected=JSON.stringify(value);
+  for(let i=0;i<3;i++) {
+    const ctx=setup('');const html=ctx.buildParamElement(definition,name,{[name]:value});
+    const save=setup(html.match(/value="([^"]*)"/)[1]);
+    await save.saveConfiguration({Battery:{[name]:definition}});value=save.sent[name];
+    assert.equal(JSON.stringify(value),expected);
+  }
+});
+test('existing empty per-load cost input is not rewritten by battery-specific parsing', async () => {
+  const ctx=setup(''); const other='cost_forecast_per_deferrable_load';
+  ctx.document.getElementById=id=>id===other?{tagName:'DIV',getElementsByClassName:()=>[{type:'text',value:''}]}:null;
+  await ctx.saveConfiguration({Loads:{[other]:{...definition,default_value:null}}});
+  // Preserve the pre-PR serialization; this is not a fix of the legacy cost editor.
+  assert.deepEqual(ctx.sent[other],['']);
+});

--- a/tests/ui/nested-config.test.cjs
+++ b/tests/ui/nested-config.test.cjs
@@ -1,0 +1,48 @@
+// Run from the repository root: node --test tests/ui/nested-config.test.cjs
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const source = fs.readFileSync('src/emhass/static/configuration_script.js', 'utf8');
+const name = 'battery_charge_power_derating';
+const definition = { input: 'array.array.float', default_value: [], friendly_name: 'Charge power derating', Description: 'Test' };
+function setup(raw) {
+  const input = { type: 'text', value: raw };
+  const ctx = { window: {}, console, document: {
+    getElementsByClassName: () => [{}],
+    getElementById: id => id === name ? { tagName: 'DIV', getElementsByClassName: () => [input] } : null,
+  }, fetch: async (url, options) => { ctx.sent = JSON.parse(options.body); return { status: 200, json: async () => [] }; } };
+  vm.createContext(ctx); vm.runInContext(source, ctx);
+  ctx.showChangeStatus = () => {}; ctx.errorAlert = msg => { ctx.error = msg; };
+  return ctx;
+}
+for (const value of [[], [[0.5,1000],[0.9,200]], [[[0.5,1000]],[[0.8,500]]]]) {
+  test(`render/save preserves ${JSON.stringify(value)}`, async () => {
+    const ctx = setup('');
+    const html = ctx.buildParamElement(definition, name, { [name]: value });
+    assert.equal((html.match(/<input /g)||[]).length, 1);
+    const raw = html.match(/value="([^"]*)"/)[1];
+    assert.deepEqual(JSON.parse(raw), value);
+    const save = setup(raw);
+    await save.saveConfiguration({ Battery: { [name]: definition } });
+    assert.deepEqual(save.sent[name], value);
+  });
+}
+test('blank clears table to []', async () => {
+  const ctx = setup('  '); await ctx.saveConfiguration({ Battery: { [name]: definition } });
+  assert.deepEqual(ctx.sent[name], []);
+});
+for (const raw of ['[','[0.5,1000]','["[0.5,1000]"]','[["0.5",1000]]','null','{}','[[0.5,1e999]]']) {
+  test(`invalid nested numeric JSON blocked: ${raw}`, async () => {
+    const ctx = setup(raw); assert.equal(await ctx.saveConfiguration({ Battery: { [name]: definition } }), 0);
+    assert.equal(ctx.sent, undefined); assert.match(ctx.error, /battery_charge_power_derating/);
+  });
+}
+test('HTML characters escaped in existing malformed data', () => {
+  const ctx = setup(''); const html = ctx.buildParamElement(definition, name, { [name]: '\"><img src=x>' });
+  assert.equal(html.includes('<img'), false); assert.match(html, /&quot;/);
+});
+test('flat numeric arrays retain existing save behaviour', async () => {
+  const ctx = setup('2'); await ctx.saveConfiguration({ Battery: { [name]: { input: 'array.string' } } });
+  assert.deepEqual(ctx.sent[name], ['2']);
+});


### PR DESCRIPTION
Fixes #1115.

The configuration list view flattens array.array.float values into text inputs and saves strings. This corrupts battery_charge_power_derating, so the backend rejects the table and falls back to the flat charging limit.

This change:
- Renders the complete nested value in one JSON input.
- Preserves empty arrays, shared 2-D tables and per-battery 3-D tables.
- Removes generic +/- controls for this input type.
- Escapes rendered values and blocks malformed JSON, flat arrays and nonnumeric values before submission.
- Saves an empty array when the field is blank.

Backend validation of thresholds, row sizes and battery counts remains authoritative. No backend, optimization or schema changes are included. The related OpenAPI representation gap is outside this UI fix.

Thanks to @anton4 for the report and @MMicieli for checking the supported shared and per-battery formats. This follows the maintainer's request in #1104. The results-page fixes are submitted separately in #1117.

Validation:
- JavaScript syntax check passed.
- 13 regression tests passed using Node's built-in test runner.
- With the original source, 12 tests failed and 1 passed.
- Tests cover rendering, serialization, clearing the field, invalid input, HTML escaping and unchanged flat string-array serialization.
- No new runtime dependencies.

Outstanding before marking ready for merge:
- [ ] Chrome and Firefox: list/JSON view round-trip and correct +/- controls.
- [ ] Actual configuration save/reload with shared and per-battery tables.
- [ ] Project CI checks.

Browser validation remains pending because browser engines were unavailable in the preparation environment and their download timed out. The full Python test suite was not rerun.

AI-assisted implementation and tests. Submitted as a draft pending browser validation.

## Summary by Sourcery

Preserve nested battery derating configuration tables through the UI without changing backend validation or schema behavior.

Bug Fixes:
- Preserve battery charge power derating tables as nested numeric arrays when configuration values are rendered and saved.
- Reject malformed, flat, nonnumeric, or non-finite battery derating values before submission while allowing blank fields to clear the table.

Enhancements:
- Render battery derating tables in a single escaped JSON input without generic array controls.
- Add regression coverage for shared and per-battery table round trips, clearing, validation, escaping, repeated serialization, and unaffected array parameters.

Tests:
- Add Node-based UI regression tests covering nested configuration array rendering and serialization.